### PR TITLE
Always log the oauth url

### DIFF
--- a/internal/tiger/cmd/oauth.go
+++ b/internal/tiger/cmd/oauth.go
@@ -83,10 +83,10 @@ func (l *oauthLogin) getAccessToken() (string, error) {
 
 	// Open browser
 	authURL := server.oauthCfg.AuthCodeURL(state, oauth2.S256ChallengeOption(codeVerifier))
+	fmt.Fprintf(l.out, "Auth URL is: %s\n", authURL)
 	fmt.Fprintln(l.out, "Opening browser for authentication...")
-	fmt.Fprintf(l.out, "Auth URL: %s\n", authURL)
 	if err := openBrowser(authURL); err != nil {
-		fmt.Fprintf(l.out, "Failed to open browser: %s\nPlease manually navigate to: %s\n", err, authURL)
+		fmt.Fprintf(l.out, "Failed to open browser: %s\nPlease manually navigate to the Auth URL.", err)
 	}
 
 	// Wait for callback with timeout


### PR DESCRIPTION
The `tiger auth login` command automatically opens the system's default browser for OAuth authentication, but this creates issues for users with multiple browser profiles:

- Users cannot control which browser profile/Google account is used for authentication
- If the wrong profile opens, OAuth parameters are stripped from the URL, making manual copy/paste impossible
- No fallback mechanism exists for users to manually navigate to the correct authentication context

So I prefer to always log the complete OAuth URL to the terminal before attempting to open the browser:

```
  Opening browser for authentication...
  Auth URL: https://console.dev.timescale.com/oauth/authorize?client_id=...&code_challenge=...
```

This at least allows me to manually copy the URL to the correct browser window if something goes wrong.