### PR TITLE
Rename module path in all files

### DIFF
--- a/cmd/tiger/main.go
+++ b/cmd/tiger/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/tigerdata/tiger-cli/internal/tiger/cmd"
+import "github.com/timescale/tiger-cli/internal/tiger/cmd"
 
 func main() {
 	cmd.Execute()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tigerdata/tiger-cli
+module github.com/timescale/tiger-cli
 
 go 1.23.0
 

--- a/internal/tiger/api/client_util.go
+++ b/internal/tiger/api/client_util.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 // Shared HTTP client with resource limits to prevent resource exhaustion under load

--- a/internal/tiger/api/client_util_test.go
+++ b/internal/tiger/api/client_util_test.go
@@ -7,8 +7,8 @@ import (
 
 	"go.uber.org/mock/gomock"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/api/mocks"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/api/mocks"
 )
 
 func TestValidateAPIKeyWithClient(t *testing.T) {

--- a/internal/tiger/api/mocks/mock_client.go
+++ b/internal/tiger/api/mocks/mock_client.go
@@ -15,7 +15,7 @@ import (
 	http "net/http"
 	reflect "reflect"
 
-	api "github.com/tigerdata/tiger-cli/internal/tiger/api"
+	api "github.com/timescale/tiger-cli/internal/tiger/api"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/tiger/cmd/auth.go
+++ b/internal/tiger/cmd/auth.go
@@ -13,8 +13,8 @@ import (
 	"github.com/zalando/go-keyring"
 	"golang.org/x/term"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 // Keyring parameters

--- a/internal/tiger/cmd/auth_test.go
+++ b/internal/tiger/cmd/auth_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 	"github.com/zalando/go-keyring"
 )
 

--- a/internal/tiger/cmd/config.go
+++ b/internal/tiger/cmd/config.go
@@ -8,8 +8,8 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
-	"github.com/tigerdata/tiger-cli/internal/tiger/logging"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/logging"
 )
 
 func buildConfigShowCmd() *cobra.Command {

--- a/internal/tiger/cmd/config_test.go
+++ b/internal/tiger/cmd/config_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 func setupConfigTest(t *testing.T) (string, func()) {

--- a/internal/tiger/cmd/db.go
+++ b/internal/tiger/cmd/db.go
@@ -12,8 +12,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/spf13/cobra"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 var (

--- a/internal/tiger/cmd/db_test.go
+++ b/internal/tiger/cmd/db_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 func setupDBTest(t *testing.T) string {

--- a/internal/tiger/cmd/integration_test.go
+++ b/internal/tiger/cmd/integration_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 // setupIntegrationTest sets up isolated test environment with temporary config directory

--- a/internal/tiger/cmd/password_storage.go
+++ b/internal/tiger/cmd/password_storage.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
 	"github.com/zalando/go-keyring"
 )
 

--- a/internal/tiger/cmd/password_storage_test.go
+++ b/internal/tiger/cmd/password_storage_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
 )
 
 // Helper function to create a test service

--- a/internal/tiger/cmd/root.go
+++ b/internal/tiger/cmd/root.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
-	"github.com/tigerdata/tiger-cli/internal/tiger/logging"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/logging"
 )
 
 func buildRootCmd() *cobra.Command {

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 var (

--- a/internal/tiger/cmd/service_test.go
+++ b/internal/tiger/cmd/service_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
-	"github.com/tigerdata/tiger-cli/internal/tiger/api"
-	"github.com/tigerdata/tiger-cli/internal/tiger/config"
+	"github.com/timescale/tiger-cli/internal/tiger/api"
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
 
 func setupServiceTest(t *testing.T) string {


### PR DESCRIPTION
The module path was previously set to `github.com/tigerdata/tiger-cli`, but the repo URL is actually `https://github.com/timescale/tiger-cli`. We don't currently own https://github.com/tigerdata, as far as I can tell.

This updates the module path to `github.com/timescale/tiger-cli` to match the actual GitHub URL. This is standard practice for Go module naming, and is less likely to cause confusion for both users and tools.

See the [Go module docs](https://go.dev/ref/mod#module-path), which say (emphasis mine):

> Typically, a module path consists of a repository root path, a directory within the repository (usually empty), and a major version suffix (only for major version 2 or higher).
>
>    - The repository root path is the portion of the module path that **corresponds to the root directory of the version control repository where the module is developed**. Most modules are defined in their repository’s root directory, so this is usually the entire path.