### PR TITLE
Add service start/stop commands

### DIFF
--- a/internal/tiger/api/client.go
+++ b/internal/tiger/api/client.go
@@ -166,6 +166,12 @@ type ClientInterface interface {
 
 	PostProjectsProjectIdServicesServiceIdSetHA(ctx context.Context, projectId ProjectId, serviceId ServiceId, body PostProjectsProjectIdServicesServiceIdSetHAJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostProjectsProjectIdServicesServiceIdStart request
+	PostProjectsProjectIdServicesServiceIdStart(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostProjectsProjectIdServicesServiceIdStop request
+	PostProjectsProjectIdServicesServiceIdStop(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostProjectsProjectIdServicesServiceIdUpdatePasswordWithBody request with any body
 	PostProjectsProjectIdServicesServiceIdUpdatePasswordWithBody(ctx context.Context, projectId ProjectId, serviceId ServiceId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -543,6 +549,30 @@ func (c *Client) PostProjectsProjectIdServicesServiceIdSetHAWithBody(ctx context
 
 func (c *Client) PostProjectsProjectIdServicesServiceIdSetHA(ctx context.Context, projectId ProjectId, serviceId ServiceId, body PostProjectsProjectIdServicesServiceIdSetHAJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostProjectsProjectIdServicesServiceIdSetHARequest(c.Server, projectId, serviceId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostProjectsProjectIdServicesServiceIdStart(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostProjectsProjectIdServicesServiceIdStartRequest(c.Server, projectId, serviceId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostProjectsProjectIdServicesServiceIdStop(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostProjectsProjectIdServicesServiceIdStopRequest(c.Server, projectId, serviceId)
 	if err != nil {
 		return nil, err
 	}
@@ -1651,6 +1681,88 @@ func NewPostProjectsProjectIdServicesServiceIdSetHARequestWithBody(server string
 	return req, nil
 }
 
+// NewPostProjectsProjectIdServicesServiceIdStartRequest generates requests for PostProjectsProjectIdServicesServiceIdStart
+func NewPostProjectsProjectIdServicesServiceIdStartRequest(server string, projectId ProjectId, serviceId ServiceId) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "project_id", runtime.ParamLocationPath, projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "service_id", runtime.ParamLocationPath, serviceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/services/%s/start", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostProjectsProjectIdServicesServiceIdStopRequest generates requests for PostProjectsProjectIdServicesServiceIdStop
+func NewPostProjectsProjectIdServicesServiceIdStopRequest(server string, projectId ProjectId, serviceId ServiceId) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "project_id", runtime.ParamLocationPath, projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "service_id", runtime.ParamLocationPath, serviceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/services/%s/stop", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewPostProjectsProjectIdServicesServiceIdUpdatePasswordRequest calls the generic PostProjectsProjectIdServicesServiceIdUpdatePassword builder with application/json body
 func NewPostProjectsProjectIdServicesServiceIdUpdatePasswordRequest(server string, projectId ProjectId, serviceId ServiceId, body PostProjectsProjectIdServicesServiceIdUpdatePasswordJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -2233,6 +2345,12 @@ type ClientWithResponsesInterface interface {
 
 	PostProjectsProjectIdServicesServiceIdSetHAWithResponse(ctx context.Context, projectId ProjectId, serviceId ServiceId, body PostProjectsProjectIdServicesServiceIdSetHAJSONRequestBody, reqEditors ...RequestEditorFn) (*PostProjectsProjectIdServicesServiceIdSetHAResponse, error)
 
+	// PostProjectsProjectIdServicesServiceIdStartWithResponse request
+	PostProjectsProjectIdServicesServiceIdStartWithResponse(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*PostProjectsProjectIdServicesServiceIdStartResponse, error)
+
+	// PostProjectsProjectIdServicesServiceIdStopWithResponse request
+	PostProjectsProjectIdServicesServiceIdStopWithResponse(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*PostProjectsProjectIdServicesServiceIdStopResponse, error)
+
 	// PostProjectsProjectIdServicesServiceIdUpdatePasswordWithBodyWithResponse request with any body
 	PostProjectsProjectIdServicesServiceIdUpdatePasswordWithBodyWithResponse(ctx context.Context, projectId ProjectId, serviceId ServiceId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostProjectsProjectIdServicesServiceIdUpdatePasswordResponse, error)
 
@@ -2717,6 +2835,54 @@ func (r PostProjectsProjectIdServicesServiceIdSetHAResponse) StatusCode() int {
 	return 0
 }
 
+type PostProjectsProjectIdServicesServiceIdStartResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *Service
+	JSON400      *BadRequest
+	JSON404      *NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r PostProjectsProjectIdServicesServiceIdStartResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostProjectsProjectIdServicesServiceIdStartResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostProjectsProjectIdServicesServiceIdStopResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *Service
+	JSON400      *BadRequest
+	JSON404      *NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r PostProjectsProjectIdServicesServiceIdStopResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostProjectsProjectIdServicesServiceIdStopResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type PostProjectsProjectIdServicesServiceIdUpdatePasswordResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3195,6 +3361,24 @@ func (c *ClientWithResponses) PostProjectsProjectIdServicesServiceIdSetHAWithRes
 		return nil, err
 	}
 	return ParsePostProjectsProjectIdServicesServiceIdSetHAResponse(rsp)
+}
+
+// PostProjectsProjectIdServicesServiceIdStartWithResponse request returning *PostProjectsProjectIdServicesServiceIdStartResponse
+func (c *ClientWithResponses) PostProjectsProjectIdServicesServiceIdStartWithResponse(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*PostProjectsProjectIdServicesServiceIdStartResponse, error) {
+	rsp, err := c.PostProjectsProjectIdServicesServiceIdStart(ctx, projectId, serviceId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostProjectsProjectIdServicesServiceIdStartResponse(rsp)
+}
+
+// PostProjectsProjectIdServicesServiceIdStopWithResponse request returning *PostProjectsProjectIdServicesServiceIdStopResponse
+func (c *ClientWithResponses) PostProjectsProjectIdServicesServiceIdStopWithResponse(ctx context.Context, projectId ProjectId, serviceId ServiceId, reqEditors ...RequestEditorFn) (*PostProjectsProjectIdServicesServiceIdStopResponse, error) {
+	rsp, err := c.PostProjectsProjectIdServicesServiceIdStop(ctx, projectId, serviceId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostProjectsProjectIdServicesServiceIdStopResponse(rsp)
 }
 
 // PostProjectsProjectIdServicesServiceIdUpdatePasswordWithBodyWithResponse request with arbitrary body returning *PostProjectsProjectIdServicesServiceIdUpdatePasswordResponse
@@ -3971,6 +4155,86 @@ func ParsePostProjectsProjectIdServicesServiceIdSetHAResponse(rsp *http.Response
 	}
 
 	response := &PostProjectsProjectIdServicesServiceIdSetHAResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest Service
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostProjectsProjectIdServicesServiceIdStartResponse parses an HTTP response from a PostProjectsProjectIdServicesServiceIdStartWithResponse call
+func ParsePostProjectsProjectIdServicesServiceIdStartResponse(rsp *http.Response) (*PostProjectsProjectIdServicesServiceIdStartResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostProjectsProjectIdServicesServiceIdStartResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest Service
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostProjectsProjectIdServicesServiceIdStopResponse parses an HTTP response from a PostProjectsProjectIdServicesServiceIdStopWithResponse call
+func ParsePostProjectsProjectIdServicesServiceIdStopResponse(rsp *http.Response) (*PostProjectsProjectIdServicesServiceIdStopResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostProjectsProjectIdServicesServiceIdStopResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/tiger/api/mocks/mock_client.go
+++ b/internal/tiger/api/mocks/mock_client.go
@@ -762,6 +762,46 @@ func (mr *MockClientInterfaceMockRecorder) PostProjectsProjectIdServicesServiceI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostProjectsProjectIdServicesServiceIdSetHAWithBody", reflect.TypeOf((*MockClientInterface)(nil).PostProjectsProjectIdServicesServiceIdSetHAWithBody), varargs...)
 }
 
+// PostProjectsProjectIdServicesServiceIdStart mocks base method.
+func (m *MockClientInterface) PostProjectsProjectIdServicesServiceIdStart(ctx context.Context, projectId api.ProjectId, serviceId api.ServiceId, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectId, serviceId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PostProjectsProjectIdServicesServiceIdStart", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostProjectsProjectIdServicesServiceIdStart indicates an expected call of PostProjectsProjectIdServicesServiceIdStart.
+func (mr *MockClientInterfaceMockRecorder) PostProjectsProjectIdServicesServiceIdStart(ctx, projectId, serviceId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectId, serviceId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostProjectsProjectIdServicesServiceIdStart", reflect.TypeOf((*MockClientInterface)(nil).PostProjectsProjectIdServicesServiceIdStart), varargs...)
+}
+
+// PostProjectsProjectIdServicesServiceIdStop mocks base method.
+func (m *MockClientInterface) PostProjectsProjectIdServicesServiceIdStop(ctx context.Context, projectId api.ProjectId, serviceId api.ServiceId, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectId, serviceId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PostProjectsProjectIdServicesServiceIdStop", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostProjectsProjectIdServicesServiceIdStop indicates an expected call of PostProjectsProjectIdServicesServiceIdStop.
+func (mr *MockClientInterfaceMockRecorder) PostProjectsProjectIdServicesServiceIdStop(ctx, projectId, serviceId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectId, serviceId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostProjectsProjectIdServicesServiceIdStop", reflect.TypeOf((*MockClientInterface)(nil).PostProjectsProjectIdServicesServiceIdStop), varargs...)
+}
+
 // PostProjectsProjectIdServicesServiceIdUpdatePassword mocks base method.
 func (m *MockClientInterface) PostProjectsProjectIdServicesServiceIdUpdatePassword(ctx context.Context, projectId api.ProjectId, serviceId api.ServiceId, body api.PostProjectsProjectIdServicesServiceIdUpdatePasswordJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1624,6 +1664,46 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) PostProjectsProjectIdSer
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, projectId, serviceId, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostProjectsProjectIdServicesServiceIdSetHAWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PostProjectsProjectIdServicesServiceIdSetHAWithResponse), varargs...)
+}
+
+// PostProjectsProjectIdServicesServiceIdStartWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) PostProjectsProjectIdServicesServiceIdStartWithResponse(ctx context.Context, projectId api.ProjectId, serviceId api.ServiceId, reqEditors ...api.RequestEditorFn) (*api.PostProjectsProjectIdServicesServiceIdStartResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectId, serviceId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PostProjectsProjectIdServicesServiceIdStartWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.PostProjectsProjectIdServicesServiceIdStartResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostProjectsProjectIdServicesServiceIdStartWithResponse indicates an expected call of PostProjectsProjectIdServicesServiceIdStartWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) PostProjectsProjectIdServicesServiceIdStartWithResponse(ctx, projectId, serviceId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectId, serviceId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostProjectsProjectIdServicesServiceIdStartWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PostProjectsProjectIdServicesServiceIdStartWithResponse), varargs...)
+}
+
+// PostProjectsProjectIdServicesServiceIdStopWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) PostProjectsProjectIdServicesServiceIdStopWithResponse(ctx context.Context, projectId api.ProjectId, serviceId api.ServiceId, reqEditors ...api.RequestEditorFn) (*api.PostProjectsProjectIdServicesServiceIdStopResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectId, serviceId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PostProjectsProjectIdServicesServiceIdStopWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.PostProjectsProjectIdServicesServiceIdStopResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostProjectsProjectIdServicesServiceIdStopWithResponse indicates an expected call of PostProjectsProjectIdServicesServiceIdStopWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) PostProjectsProjectIdServicesServiceIdStopWithResponse(ctx, projectId, serviceId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectId, serviceId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostProjectsProjectIdServicesServiceIdStopWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).PostProjectsProjectIdServicesServiceIdStopWithResponse), varargs...)
 }
 
 // PostProjectsProjectIdServicesServiceIdUpdatePasswordWithBodyWithResponse mocks base method.

--- a/internal/tiger/cmd/errors.go
+++ b/internal/tiger/cmd/errors.go
@@ -9,6 +9,7 @@ const (
 	ExitAuthenticationError = 4 // Authentication error
 	ExitPermissionDenied    = 5 // Permission denied
 	ExitServiceNotFound     = 6 // Service not found
+	ExitConflict            = 7 // Resource conflict (e.g., service cannot be modified in current state)
 )
 
 // exitCodeError creates an error that will cause the program to exit with the specified code

--- a/internal/tiger/cmd/integration_test.go
+++ b/internal/tiger/cmd/integration_test.go
@@ -358,6 +358,130 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		t.Logf("✅ psql command with updated password succeeded")
 	})
 
+	t.Run("StopService", func(t *testing.T) {
+		if serviceID == "" {
+			t.Skip("No service ID available from create test")
+		}
+
+		t.Logf("Stopping service: %s", serviceID)
+
+		output, err := executeIntegrationCommand(
+			"service", "stop", serviceID,
+			"--wait-timeout", "10m", // Longer timeout for integration tests
+		)
+
+		if err != nil {
+			// Check if it's a conflict error (service already stopped)
+			if exitErr, ok := err.(interface{ ExitCode() int }); ok && exitErr.ExitCode() == ExitConflict {
+				t.Logf("Service is already stopped (conflict error): %v", err)
+			} else {
+				t.Fatalf("Service stop failed: %v\nOutput: %s", err, output)
+			}
+		} else {
+			// Verify stop success message
+			if !strings.Contains(output, "Stop request accepted") &&
+			   !strings.Contains(output, "stopped successfully") {
+				t.Errorf("Expected stop success message, got: %s", output)
+			}
+			t.Logf("Service stop completed successfully")
+		}
+	})
+
+	t.Run("VerifyServiceStopped", func(t *testing.T) {
+		if serviceID == "" {
+			t.Skip("No service ID available from create test")
+		}
+
+		t.Logf("Verifying service is stopped")
+
+		output, err := executeIntegrationCommand("service", "describe", serviceID, "--output", "json")
+		if err != nil {
+			t.Fatalf("Failed to describe service after stop: %v\nOutput: %s", err, output)
+		}
+
+		// Parse JSON to check status
+		var service api.Service
+		if err := json.Unmarshal([]byte(output), &service); err != nil {
+			t.Fatalf("Failed to parse service JSON: %v", err)
+		}
+
+		var status string
+		if service.Status != nil {
+			status = string(*service.Status)
+		}
+
+		t.Logf("Service status after stop: %s", status)
+
+		// The status should be PAUSED for stopped services
+		if status != "PAUSED" {
+			t.Logf("Warning: Expected service status to be PAUSED, got %s. This might be expected depending on timing or service state.", status)
+		} else {
+			t.Logf("✅ Service is correctly in PAUSED state")
+		}
+	})
+
+	t.Run("StartService", func(t *testing.T) {
+		if serviceID == "" {
+			t.Skip("No service ID available from create test")
+		}
+
+		t.Logf("Starting service: %s", serviceID)
+
+		output, err := executeIntegrationCommand(
+			"service", "start", serviceID,
+			"--wait-timeout", "10m", // Longer timeout for integration tests
+		)
+
+		if err != nil {
+			// Check if it's a conflict error (service already started)
+			if exitErr, ok := err.(interface{ ExitCode() int }); ok && exitErr.ExitCode() == ExitConflict {
+				t.Logf("Service is already started (conflict error): %v", err)
+			} else {
+				t.Fatalf("Service start failed: %v\nOutput: %s", err, output)
+			}
+		} else {
+			// Verify start success message
+			if !strings.Contains(output, "Start request accepted") &&
+			   !strings.Contains(output, "ready and running") {
+				t.Errorf("Expected start success message, got: %s", output)
+			}
+			t.Logf("Service start completed successfully")
+		}
+	})
+
+	t.Run("VerifyServiceStarted", func(t *testing.T) {
+		if serviceID == "" {
+			t.Skip("No service ID available from create test")
+		}
+
+		t.Logf("Verifying service is started")
+
+		output, err := executeIntegrationCommand("service", "describe", serviceID, "--output", "json")
+		if err != nil {
+			t.Fatalf("Failed to describe service after start: %v\nOutput: %s", err, output)
+		}
+
+		// Parse JSON to check status
+		var service api.Service
+		if err := json.Unmarshal([]byte(output), &service); err != nil {
+			t.Fatalf("Failed to parse service JSON: %v", err)
+		}
+
+		var status string
+		if service.Status != nil {
+			status = string(*service.Status)
+		}
+
+		t.Logf("Service status after start: %s", status)
+
+		// The status should be READY for started services
+		if status != "READY" {
+			t.Logf("Warning: Expected service status to be READY, got %s. This might be expected depending on timing or service state.", status)
+		} else {
+			t.Logf("✅ Service is correctly in READY state")
+		}
+	})
+
 	t.Run("DeleteService", func(t *testing.T) {
 		if serviceID == "" {
 			t.Skip("No service ID available for deletion")
@@ -550,6 +674,16 @@ func TestServiceNotFound(t *testing.T) {
 			expectedExitCode: ExitServiceNotFound,
 		},
 		{
+			name:             "service start",
+			args:             []string{"service", "start", nonExistentServiceID},
+			expectedExitCode: ExitServiceNotFound,
+		},
+		{
+			name:             "service stop",
+			args:             []string{"service", "stop", nonExistentServiceID},
+			expectedExitCode: ExitServiceNotFound,
+		},
+		{
 			name:             "db connection-string",
 			args:             []string{"db", "connection-string", nonExistentServiceID},
 			expectedExitCode: ExitServiceNotFound,
@@ -709,6 +843,14 @@ func TestAuthenticationErrorsIntegration(t *testing.T) {
 		{
 			name: "service delete",
 			args: []string{"service", "delete", "non-existent-service", "--confirm", "--api-key", invalidAPIKey, "--project-id", projectID, "--no-wait"},
+		},
+		{
+			name: "service start",
+			args: []string{"service", "start", "non-existent-service", "--api-key", invalidAPIKey, "--project-id", projectID, "--no-wait"},
+		},
+		{
+			name: "service stop",
+			args: []string{"service", "stop", "non-existent-service", "--api-key", invalidAPIKey, "--project-id", projectID, "--no-wait"},
 		},
 	}
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -276,6 +276,48 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /projects/{project_id}/services/{service_id}/start:
+    post:
+      tags:
+        - Services
+      summary: Start a Service
+      description: Starts a stopped service within a project. This is an asynchronous operation.
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '202':
+          description: Service start request has been accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /projects/{project_id}/services/{service_id}/stop:
+    post:
+      tags:
+        - Services
+      summary: Stop a Service
+      description: Stops a running service within a project. This is an asynchronous operation.
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '202':
+          description: Service stop request has been accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /projects/{project_id}/services/{service_id}/attachToVPC:
     post:
       tags:


### PR DESCRIPTION
  Adds tiger service start and tiger service stop commands to manage database service lifecycle.

  New Commands

  - tiger service start [service-id] - Start a stopped service
  - tiger service stop [service-id] - Stop a running service

  Both commands support --no-wait and --wait-timeout flags for async operation control.

  Features

  - Status monitoring: Real-time progress with completion indicators
  - Proper error handling: New ExitConflict exit code for state conflicts (409 responses)
  - Complete error mapping: 401/403/404/409 responses map to appropriate exit codes
  - Integration testing: Enhanced lifecycle and error scenario test coverage

  Usage

  // Start/stop with completion wait (default)
  tiger service start svc-12345
  tiger service stop svc-12345

  // Return immediately after request accepted
  tiger service start svc-12345 --no-wait

  Technical Changes

  - Updated OpenAPI spec and regenerated API client
  - Added waitForServicePaused() function following existing patterns
  - Enhanced integration tests with start/stop validation
  - Added ExitConflict = 7 exit code for HTTP 409 responses

  Compatibility

  Fully backward compatible. No breaking changes to existing functionality.

  ---
  Co-Authored-By: Claude noreply@anthropic.com