### PR TITLE
Fix OAuth test failures by improving Auth URL output

### DIFF
--- a/internal/tiger/cmd/integration_test.go
+++ b/internal/tiger/cmd/integration_test.go
@@ -98,7 +98,6 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 	tmpDir := setupIntegrationTest(t)
 	t.Logf("Using temporary config directory: %s", tmpDir)
 
-
 	// Generate unique service name to avoid conflicts
 	serviceName := fmt.Sprintf("integration-test-%d", time.Now().Unix())
 	var serviceID string

--- a/internal/tiger/cmd/oauth.go
+++ b/internal/tiger/cmd/oauth.go
@@ -83,10 +83,9 @@ func (l *oauthLogin) getAccessToken() (string, error) {
 
 	// Open browser
 	authURL := server.oauthCfg.AuthCodeURL(state, oauth2.S256ChallengeOption(codeVerifier))
-	fmt.Fprintf(l.out, "Auth URL is: %s\n", authURL)
 	fmt.Fprintln(l.out, "Opening browser for authentication...")
 	if err := openBrowser(authURL); err != nil {
-		fmt.Fprintf(l.out, "Failed to open browser: %s\nPlease manually navigate to the Auth URL.", err)
+		fmt.Fprintf(l.out, "Failed to open browser: %s\nAuth URL: %s\nPlease manually navigate to the Auth URL.", err, authURL)
 	}
 
 	// Wait for callback with timeout


### PR DESCRIPTION
## Summary

Fixes failing OAuth tests that were broken due to unexpected output format.

The `TestAuthLogin_OAuth_SingleProject` and `TestAuthLogin_OAuth_MultipleProjects` tests were failing because they expected specific output but were getting an extra "Auth URL is: ..." line that was printed unconditionally during OAuth flows.

## Changes

- ✅ Only show Auth URL when browser fails to open (when user actually needs it)
- ✅ Remove redundant Auth URL output from successful OAuth flows  
- ✅ Improve error message to include Auth URL when browser opening fails

## Result

- OAuth tests now pass consistently
- Better UX: Users only see the Auth URL when they need it (browser fails to open)
- Cleaner output during successful OAuth flows
- All authentication functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)