### PR TITLE
Remove organization secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,11 @@ jobs:
           # Action-scoped GitHub token used for downloading code, etc.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Cross-repo GitHub token for publishing to timescale/homebrew-tap
-          TAP_GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_CLOUD }}
+          # NOTE: this token will need to be rotated once per year.
+          TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           # AWS credentials for pushing to tiger-cli-releases S3 bucket
-          AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TIGER_CLI_RELEASES_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TIGER_CLI_RELEASES_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
           # PackageCloud credentials for publishing Linux packages
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}


### PR DESCRIPTION
See [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1758728658672599) for background.

This removes the organization secrets from the release pipeline and replaces them with newly created repository secrets that have a much more limited scope:

- `HOMEBREW_TAP_GITHUB_TOKEN` - A new fine-grained GitHub access token that has permission to write to the https://github.com/timescale/homebrew-tap repo, but nothing else.
- `TIGER_CLI_RELEASES_AWS_ACCESS_KEY_ID`/`TIGER_CLI_RELEASES_AWS_SECRET_ACCESS_KEY` - A new [bot-github-actions-tiger-cli-release](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/bot-github-actions-tiger-cli-release?section=permissions) AWS user that has permission to write to the `tiger-cli-releases` S3 bucket, but nothing else.

This is in preparation for making this repo public, since the old organization secrets are not accessible to public repos.

I don't think there's any threat vector for abusing these repository secrets, since our workflow is only triggered on tag pushes (i.e. not via pull requests from forks), and external users can't push tags.

I verified that these new secrets work by triggering a new [v0.1.1 release](https://github.com/timescale/tiger-cli/actions/runs/17984329817/job/51158484602), which completed successfully.