### PR TITLE
Fix homebrew install instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -fsSL https://tiger-cli-releases.s3.amazonaws.com/install/install.sh | sh
 
 ### Homebrew (macOS/Linux)
 ```bash
-brew install timescale/tap/tiger-cli
+brew install --cask timescale/tap/tiger-cli
 ```
 
 ### Go install


### PR DESCRIPTION
Fixes the homebrew instructions for Linux. See [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1758829321163119?thread_ts=1758829079.787879&cid=C099S47CSRX).