### PR TITLE
Fix Linux package install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ go install github.com/timescale/tiger-cli/cmd/tiger@latest
 ### Debian/Ubuntu
 ```bash
 # Add repository
-curl -s https://packagecloud.io/install/repositories/timescale/tiger-cli/script.deb.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/timescale/tiger-cli/script.deb.sh | sudo os=any dist=any bash
 
 # Install tiger-cli
 sudo apt-get install tiger-cli
@@ -60,7 +60,7 @@ For manual repository installation instructions, see [here](https://packagecloud
 ### Red Hat/CentOS/Fedora
 ```bash
 # Add repository
-curl -s https://packagecloud.io/install/repositories/timescale/tiger-cli/script.rpm.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/timescale/tiger-cli/script.rpm.sh | sudo os=rpm_any dist=rpm_any bash
 
 # Install tiger-cli
 sudo yum install tiger-cli


### PR DESCRIPTION
This PR fixes the Linux package installation instructions. See [AGE-136](https://linear.app/tigerdata/issue/AGE-136/tiger-cli-verify-installation-on-all-oses-mac-debian) and [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1758829079787879) for more info.