### PR TITLE
Fix sha256sum logic in install.sh script on Mac

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -301,13 +301,13 @@ verify_checksum() {
     formatted_checksum=$(printf "%s  %s\n" "$(cat "${checksum_file}" | tr -d '[:space:]')" "${filename}")
 
     if command -v sha256sum >/dev/null 2>&1; then
-        if ! echo "${formatted_checksum}" | sha256sum -c >/dev/null 2>&1; then
+        if ! echo "${formatted_checksum}" | sha256sum -c - >/dev/null 2>&1; then
             log_error "Checksum validation failed using sha256sum"
             log_error "For security reasons, installation has been aborted"
             exit 1
         fi
     elif command -v shasum >/dev/null 2>&1; then
-        if ! echo "${formatted_checksum}" | shasum -a 256 -c >/dev/null 2>&1; then
+        if ! echo "${formatted_checksum}" | shasum -a 256 -c - >/dev/null 2>&1; then
             log_error "Checksum validation failed using shasum"
             log_error "For security reasons, installation has been aborted"
             exit 1


### PR DESCRIPTION
See [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1759348881281829) for background.

This fixes the checksum validation logic on Mac. The problem seems to be that the default version of `sha256sum` installed on Macs works differently than the Linux/GNU version 🙄.

In particular, when the `-c` option is given but no input files are listed, the GNU version happily reads the digest file from stdin, whereas the Mac version fails with a usage error: `usage: sha256sum [-bctwz] [files ...]`. This is despite the docs for the Mac version clearly saying:

> If no files are listed on the command line, or a file name is given as -, input is taken from stdin instead.

For whatever reason, it seems the "If no files are listed on the command line" part only applies if the `-c` option is _not_ given. If the `-c` option is given, you apparently need to specify `-` as the file name for it to read from stdin 🤷‍♂️.

Note that I made the same change for the `shasum` invocation, just to be consistent. It's man page documents the same behavior with respect to stdin:

> With no FILE, or when FILE is -, read standard input.

I tested the updated script with `sh ./scripts/install.sh` on my Mac (both with and without the GNU coreutils bin in my PATH 😅), as well as in an Ubuntu docker container. I also commented out the `sha256sum` part and tried with `shasum` (which only exists on Mac) to verify that fallback works correctly too.