### PR TITLE
Update 'tiger service fork' to output service info like 'tiger servic…

### DIFF
--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1104,6 +1104,7 @@ func buildServiceForkCmd() *cobra.Command {
 	var forkToTimestamp string
 	var forkCPU int
 	var forkMemory int
+	var forkWithPassword bool
 
 	cmd := &cobra.Command{
 		Use:   "fork [service-id]",
@@ -1320,20 +1321,26 @@ Examples:
 				}
 
 				// Handle wait behavior
+				var result error
 				if forkNoWait {
 					fmt.Fprintf(statusOutput, "⏳ Service is being forked. Use 'tiger service list' to check status.\n")
-					return nil
+				} else {
+					// Wait for service to be ready
+					fmt.Fprintf(statusOutput, "⏳ Waiting for fork to complete (timeout: %v)...\n", forkWaitTimeout)
+					forkedService.Status, result = waitForServiceReady(client, projectID, forkedServiceID, forkWaitTimeout, statusOutput)
+					if result != nil {
+						fmt.Fprintf(statusOutput, "❌ %v\n", result)
+					} else {
+						fmt.Fprintf(statusOutput, "🎉 Service fork completed successfully!\n")
+						printConnectMessage(statusOutput, passwordSaved, forkNoSetDefault, forkedServiceID)
+					}
 				}
 
-				// Wait for service to be ready with custom timeout
-				fmt.Fprintf(statusOutput, "⏳ Waiting for fork to complete (timeout: %v)...\n", forkWaitTimeout)
-				if _, err := waitForServiceReady(client, projectID, forkedServiceID, forkWaitTimeout, statusOutput); err != nil {
-					return err
+				if err := outputService(cmd, forkedService, cfg.Output, forkWithPassword); err != nil {
+					fmt.Fprintf(statusOutput, "⚠️  Warning: Failed to output service details: %v\n", err)
 				}
-				fmt.Fprintf(statusOutput, "🎉 Service fork completed successfully!\n")
-				printConnectMessage(statusOutput, passwordSaved, forkNoSetDefault, serviceID)
-				return nil
 
+				return result
 			case 401:
 				return exitWithCode(ExitAuthenticationError, fmt.Errorf("authentication failed: invalid API key"))
 			case 403:
@@ -1364,6 +1371,7 @@ Examples:
 	// Resource customization flags
 	cmd.Flags().IntVar(&forkCPU, "cpu", 0, "CPU allocation in millicores (inherits from source if not specified)")
 	cmd.Flags().IntVar(&forkMemory, "memory", 0, "Memory allocation in gigabytes (inherits from source if not specified)")
+	cmd.Flags().BoolVar(&forkWithPassword, "with-password", false, "Include initial password in output")
 
 	return cmd
 }


### PR DESCRIPTION
Updates `tiger service fork` to output the service info in the same way that `tiger service create` was updated to return it in #32.

Note that there is currently some information missing from the output. I believe it's ultimately because the [GraphQL query for making a fork](https://github.com/timescale/timescale-graphql-client/blob/08d3a3a6a3572a171c125cad75b675b6344d345d/client/queries/create_fork.graphql#L1-L87) is requesting different fields in the response than the [GraphQL query for creating a service](https://github.com/timescale/timescale-graphql-client/blob/08d3a3a6a3572a171c125cad75b675b6344d345d/client/queries/create_service.graphql#L1-L82). I mentioned this before [here](https://iobeam.slack.com/archives/C0914KFV927/p1759248678004249?thread_ts=1759243297.088159&cid=C0914KFV927), and it sounds like we will probably just update the create service and fork service REST API endpoints to use the same GraphQL query under the hood (they're both technically using the same `createService` mutation, and both already take a `forkConfig`). I plan to tackle that next week. **UPDATE:** fixed [here](https://github.com/timescale/savannah-public/pull/47).