### PR TITLE
Render console URL in service describe output

### DIFF
--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -605,6 +605,7 @@ type OutputService struct {
 	api.Service
 	password.ConnectionDetails
 	ConnectionString string `json:"connection_string,omitempty" yaml:"connection_string,omitempty"`
+	ConsoleURL       string `json:"console_url,omitempty" yaml:"console_url,omitempty"`
 }
 
 // Convert to JSON to respect omitempty tags, then unmarshal
@@ -769,6 +770,9 @@ func outputServiceTable(service OutputService, output io.Writer) error {
 	if service.ConnectionString != "" {
 		table.Append("Connection String", service.ConnectionString)
 	}
+	if service.ConsoleURL != "" {
+		table.Append("Console URL", service.ConsoleURL)
+	}
 
 	return table.Render()
 }
@@ -819,6 +823,13 @@ func prepareServiceForOutput(service api.Service, withPassword bool, output io.W
 	} else {
 		outputSvc.ConnectionDetails = *connectionDetails
 		outputSvc.ConnectionString = connectionDetails.String()
+	}
+
+	// Build console URL
+	cfg, err := config.Load()
+	if err == nil {
+		url := fmt.Sprintf("%s/dashboard/services/%s", cfg.ConsoleURL, *service.ServiceId)
+		outputSvc.ConsoleURL = url
 	}
 
 	return outputSvc


### PR DESCRIPTION
This generates the web console URL for a given service, includes it in the output shown by describe, list, create, etc.

<img width="854" height="229" alt="image" src="https://github.com/user-attachments/assets/35e6d4af-4f9a-4693-8ed8-e5e95f33372a" />

I intentionally excluded this from `tiger svc list -o table`, as it will be too wide for many displays, and looks horrible when wrapped. This is an area that needs more improvement in general.