### PR TITLE
Fix install script kill bug

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -442,7 +442,10 @@ main() {
     binary_path="$(extract_archive "${archive_name}" "${tmp_dir}" "${platform}")"
 
     # Copy binary to install directory
+    # Remove existing binary first to prevent errors related
+    # to swapping out a currently executing binary
     log_info "Installing to ${install_dir}..."
+    rm -f "${install_dir}/${BINARY_NAME}"
     cp "${binary_path}" "${install_dir}/${BINARY_NAME}"
 
     # Verify installation


### PR DESCRIPTION
See [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1759949745523629?thread_ts=1759946030.408509&cid=C099S47CSRX) for background.

There was a bug in the `install.sh` script, where if you were currently running the `tiger` binary (most commonly when running the MCP server via an AI tool like Claude Code), then when the script swapped it out for the new binary, the operating system would immediately kill future invocations of the command until all of the existing invocations of the old binary were finished running. This PR fixes it by first removing the old binary with `rm -f` before swapping the new binary into place (fwiw, I don't fully understand what the underlying issue is or why this fixes it, but it does, based on my testing).

Closes [AGE-209](https://linear.app/tigerdata/issue/AGE-209/tiger-cli-fix-install-script-bug)

### How to Test

1. Install the CLI via the `install.sh` script if you haven't already: `sh ./scripts/install.sh`
   - Make sure the first `tiger` command in your `$PATH` is the one installed via the script: `which tiger` (should print `~/.local/bin/tiger` or `~/bin/tiger`). If it's not, uninstall the other binaries or update your `$PATH`.
1. Install the MCP server into Claude Code: `tiger mcp install claude-code`
1. Open Claude Code in a separate terminal and leave it running: `claude`.
1. Run the install script to install a new version of the binary: `sh ./scripts/install.sh`
1. Run `tiger version`

Previously, the last step (running `tiger version`) would fail immediately with an error saying it had been killed (you could fix it either by closing the Claude Code session, or manually removing the binary and re-installing). After this PR, the command should execute like normal.