### PR TITLE
New install script URL

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,7 +90,7 @@ blobs:
   - provider: s3
     bucket: tiger-cli-releases
     region: us-east-1
-    directory: "install"
+    directory: ""
     extra_files_only: true
     disable: '{{ ne .Prerelease "" }}' # Skip this step for prereleases
     extra_files:
@@ -115,7 +115,7 @@ homebrew_casks:
     license: Apache-2.0
     skip_upload: auto # Skips prerelease builds
     url:
-      template: "https://tiger-cli-releases.s3.us-east-1.amazonaws.com/releases/{{ .Tag }}/{{ .ArtifactName }}"
+      template: "https://cli.tigerdata.com/releases/{{ .Tag }}/{{ .ArtifactName }}"
     hooks:
       # TODO: Sign and notarize instead of removing quarantine bit
       # See: https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,7 +797,7 @@ VERSION=1.2.3 && git tag -a v${VERSION} -m "${VERSION}" && git push origin v${VE
 **Publishing Targets:**
 1. **GitHub Releases** - Creates release with binaries for multiple platforms (macOS, Linux, Windows)
 2. **Homebrew Tap** - Updates `timescale/homebrew-tap` with new formula
-3. **S3 Bucket** - Uploads binaries to `tiger-cli-releases.s3.amazonaws.com` for install script
+3. **S3 Bucket** - Uploads binaries to `tiger-cli-releases` S3 bucket (behind `https://cli.tigerdata.com` CloudFront CDN) for install script and Homebrew downloads
 4. **PackageCloud** - Publishes Debian (.deb) and RPM packages to `timescale/tiger-cli` repository
 
 **Build Tool:** Uses [GoReleaser](https://goreleaser.com) to build and publish across all platforms. Configuration is in `.goreleaser.yml`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tiger CLI is the command-line interface for Tiger Cloud. It provides commands fo
 ### Install Script
 
 ```bash
-curl -fsSL https://tiger-cli-releases.s3.amazonaws.com/install/install.sh | sh
+curl -fsSL https://cli.tigerdata.com/install.sh | sh
 ```
 
 ### Homebrew (macOS/Linux)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,12 +4,12 @@
 #
 # Tiger CLI Installation Script
 #
-# This script automatically downloads and installs the latest version of Tiger CLI
-# from S3 releases. It detects your platform (OS and architecture) and downloads
-# the appropriate binary for your system.
+# This script automatically downloads and installs the latest version of Tiger
+# CLI from the release server. It detects your platform (OS and architecture)
+# and downloads the appropriate binary for your system.
 #
 # Usage:
-#   curl -fsSL https://tiger-cli-releases.s3.amazonaws.com/install/install.sh | sh
+#   curl -fsSL https://cli.tigerdata.com/install.sh | sh
 #
 # Environment Variables (all optional):
 #   VERSION           - Specific version to install (e.g., "v1.2.3")
@@ -34,9 +34,8 @@ set -eu
 REPO_NAME="tiger-cli"
 BINARY_NAME="tiger"
 
-# S3 Configuration (primary download source)
-S3_BUCKET="tiger-cli-releases"
-S3_BASE_URL="https://${S3_BUCKET}.s3.amazonaws.com"
+# Download URL
+DOWNLOAD_BASE_URL="https://cli.tigerdata.com"
 
 # Colors for output
 RED='\033[0;31m'
@@ -175,7 +174,7 @@ download_with_retry() {
     done
 }
 
-# Get version (from VERSION env var or latest from S3)
+# Get version (from VERSION env var or latest from CloudFront)
 get_version() {
     # Use VERSION env var if provided
     if [ -n "${VERSION:-}" ]; then
@@ -184,9 +183,9 @@ get_version() {
         return
     fi
 
-    local url="${S3_BASE_URL}/install/latest.txt"
+    local url="${DOWNLOAD_BASE_URL}/latest.txt"
 
-    # Try to get version from S3 latest.txt file at bucket root
+    # Try to get version from latest.txt file
     local version
     version=$(fetch_with_retry "${url}" "latest version")
 
@@ -286,7 +285,7 @@ verify_checksum() {
     local tmp_dir="$3"
 
     # Construct individual checksum file URL
-    local checksum_url="${S3_BASE_URL}/releases/${version}/${filename}.sha256"
+    local checksum_url="${DOWNLOAD_BASE_URL}/releases/${version}/${filename}.sha256"
     local checksum_file="${tmp_dir}/${filename}.sha256"
 
     # Download checksum file with retry logic
@@ -327,8 +326,8 @@ download_archive() {
     local tmp_dir="$3"
     local platform="$4"
 
-    # Construct S3 download URL
-    local download_url="${S3_BASE_URL}/releases/${version}/${archive_name}"
+    # Construct download URL
+    local download_url="${DOWNLOAD_BASE_URL}/releases/${version}/${archive_name}"
 
     # Download archive with retry logic
     download_with_retry "${download_url}" "${tmp_dir}/${archive_name}" "Tiger CLI ${version} for ${platform}"


### PR DESCRIPTION
See [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1759939195393139) for background.

Replaces the public S3 bucket URL (https://tiger-cli-releases.s3.amazonaws.com) with the new CloudFront URL (https://cli.tigerdata.com).

Additionally, moves the `install.sh` script and `latest.txt` files to the root of the S3 bucket, instead of nesting them in an `install` directory. As a result, the new URL for the install script (after this is merged and I trigger a real release) will be: https://cli.tigerdata.com/install.sh ✨

CC @nickstamat 

Closes [AGE-215](https://linear.app/tigerdata/issue/AGE-215/tiger-cli-update-install-script-s3-url-to-cloudfront-url)