### PR TITLE
Fix S3 directory bug

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,7 +90,7 @@ blobs:
   - provider: s3
     bucket: tiger-cli-releases
     region: us-east-1
-    directory: "{{ \"\" }}"
+    directory: "{{ \"\" }}" # Can't use an empty string directly or GoReleaser defaults to "{{ .ProjectName }}/{{ .Tag }}"
     extra_files_only: true
     disable: '{{ ne .Prerelease "" }}' # Skip this step for prereleases
     extra_files:


### PR DESCRIPTION
Fixes a bug in #56.

GoReleaser is treating `directory: ""` in the S3 blob config the same as an omitted `directory` config, which is causing it to use its built-in default of `{{ .ProjectName }}/{{ .Tag }}` instead of the bucket root 🙄.

This fixes it by instead using a Go template that outputs an empty string (`{{ "" }}`), since the field supports templates, and this gets around the defaulting behavior while maintaining the same end result. There might be other ways to fix it too, but there's nothing about it in the [docs](https://goreleaser.com/customization/blob/), and this seems to work (I went ahead and released `v0.9.2` from this branch to verify - probably should have just done that in the first place 😅 ).