### PR TITLE
Add explicit warning to with_password schema description

### DIFF
--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -80,7 +80,7 @@ func setServiceIDSchemaProperties(schema *jsonschema.Schema) {
 
 // setWithPasswordSchemaProperties sets common with_password schema properties
 func setWithPasswordSchemaProperties(schema *jsonschema.Schema) {
-	schema.Properties["with_password"].Description = "Whether to include the password in the response and connection string."
+	schema.Properties["with_password"].Description = "Whether to include the password in the response and connection string. NEVER set to true unless the user explicitly asks for the password."
 	schema.Properties["with_password"].Default = util.Must(json.Marshal(false))
 	schema.Properties["with_password"].Examples = []any{false, true}
 }


### PR DESCRIPTION
## Summary

- Adds an explicit warning to the `with_password` parameter schema description in MCP tools
- Warning states: "NEVER set to true unless the user explicitly asks for the password"
- Helps prevent AI assistants from accidentally including passwords in responses or connection strings

## Changes

- Updated `setWithPasswordSchemaProperties()` in `internal/tiger/mcp/service_tools.go` to include the warning in the schema description

🤖 Generated with [Claude Code](https://claude.com/claude-code)