### PR TITLE
Upgrade hint should include brew update

### DIFF
--- a/internal/tiger/version/check.go
+++ b/internal/tiger/version/check.go
@@ -175,7 +175,7 @@ func detectInstallMethod(binaryPath string) InstallMethod {
 func getUpdateCommand(method InstallMethod, cfg *config.Config) string {
 	switch method {
 	case InstallMethodHomebrew:
-		return "brew upgrade tiger-cli"
+		return "brew update && brew upgrade tiger-cli"
 	case InstallMethodDeb:
 		return "sudo apt update && sudo apt install tiger-cli"
 	case InstallMethodRPM:

--- a/internal/tiger/version/check_test.go
+++ b/internal/tiger/version/check_test.go
@@ -180,7 +180,7 @@ func TestGetUpdateCommand(t *testing.T) {
 		{
 			name:   "homebrew",
 			method: InstallMethodHomebrew,
-			want:   "brew upgrade tiger-cli",
+			want:   "brew update && brew upgrade tiger-cli",
 		},
 		{
 			name:   "deb",


### PR DESCRIPTION
We've found that just a `brew upgrade tiger-cli` doesn't reliably fetch the latest version, as brew caches some version metadata locally and only updates it after some TTL implicitly. Adding an explicit `brew update` to the update hint should result in more success.
