### PR TITLE
Rename whoami to status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Tiger CLI is a Go-based command-line interface for managing Tiger, the modern da
 - **Entry Point**: `cmd/tiger/main.go` - Simple main that delegates to cmd.Execute()
 - **Command Structure**: `internal/tiger/cmd/` - Cobra-based command definitions
   - `root.go` - Root command with global flags and configuration initialization
-  - `auth.go` - Authentication commands (login, logout, whoami)
+  - `auth.go` - Authentication commands (login, logout, status)
   - `service.go` - Service management commands (list, create, get, fork, delete, update-password)
   - `db.go` - Database operation commands (connection-string, connect, test-connection)
   - `config.go` - Configuration management commands (show, set, unset, reset)
@@ -377,7 +377,7 @@ buildRootCmd() → Complete CLI with all commands and flags
 ├── buildAuthCmd()
 │   ├── buildLoginCmd()
 │   ├── buildLogoutCmd()
-│   └── buildWhoamiCmd()
+│   └── buildStatusCmd()
 ├── buildServiceCmd()
 │   ├── buildServiceListCmd()
 │   ├── buildServiceGetCmd()

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Tiger CLI provides the following commands:
 - `tiger auth` - Authentication management
   - `login` - Log in to your Tiger account
   - `logout` - Log out from your Tiger account
-  - `whoami` - Show current authentication status
+  - `status` - Show current authentication status
 - `tiger service` - Service lifecycle management
   - `list` - List all services
   - `create` - Create a new service

--- a/internal/tiger/cmd/auth.go
+++ b/internal/tiger/cmd/auth.go
@@ -171,11 +171,11 @@ func buildLogoutCmd() *cobra.Command {
 	}
 }
 
-func buildWhoamiCmd() *cobra.Command {
+func buildStatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "whoami",
-		Short: "Show current user information",
-		Long:  `Show information about the currently authenticated user.`,
+		Use:   "status",
+		Short: "Show current auth information",
+		Long:  `Show information about the currently authenticated token.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
@@ -183,7 +183,7 @@ func buildWhoamiCmd() *cobra.Command {
 				return err
 			}
 
-			// TODO: Make API call to get user information
+			// TODO: Make API call to get token information
 			fmt.Fprintln(cmd.OutOrStdout(), "Logged in (API key stored)")
 
 			return nil
@@ -200,7 +200,7 @@ func buildAuthCmd() *cobra.Command {
 
 	cmd.AddCommand(buildLoginCmd())
 	cmd.AddCommand(buildLogoutCmd())
-	cmd.AddCommand(buildWhoamiCmd())
+	cmd.AddCommand(buildStatusCmd())
 
 	return cmd
 }

--- a/internal/tiger/cmd/auth_test.go
+++ b/internal/tiger/cmd/auth_test.go
@@ -583,13 +583,13 @@ func TestAuthLogin_KeyringFallback(t *testing.T) {
 		t.Errorf("Expected API key '%s', got '%s'", expectedAPIKey, storedKey)
 	}
 
-	// Test whoami with file-only storage
-	output, err = executeAuthCommand("auth", "whoami")
+	// Test status with file-only storage
+	output, err = executeAuthCommand("auth", "status")
 	if err != nil {
-		t.Fatalf("Whoami failed with file storage: %v", err)
+		t.Fatalf("Status failed with file storage: %v", err)
 	}
 	if output != "Logged in (API key stored)\n" {
-		t.Errorf("Unexpected whoami output: '%s'", output)
+		t.Errorf("Unexpected status output: '%s'", output)
 	}
 
 	// Test logout with file-only storage
@@ -666,7 +666,7 @@ func TestAuthLogin_EnvironmentVariable_FileOnly(t *testing.T) {
 	}
 }
 
-func TestAuthWhoami_LoggedIn(t *testing.T) {
+func TestAuthStatus_LoggedIn(t *testing.T) {
 	setupAuthTest(t)
 
 	// Store API key first
@@ -675,10 +675,10 @@ func TestAuthWhoami_LoggedIn(t *testing.T) {
 		t.Fatalf("Failed to store API key: %v", err)
 	}
 
-	// Execute whoami command
-	output, err := executeAuthCommand("auth", "whoami")
+	// Execute status command
+	output, err := executeAuthCommand("auth", "status")
 	if err != nil {
-		t.Fatalf("Whoami failed: %v", err)
+		t.Fatalf("Status failed: %v", err)
 	}
 
 	if output != "Logged in (API key stored)\n" {
@@ -686,13 +686,13 @@ func TestAuthWhoami_LoggedIn(t *testing.T) {
 	}
 }
 
-func TestAuthWhoami_NotLoggedIn(t *testing.T) {
+func TestAuthStatus_NotLoggedIn(t *testing.T) {
 	setupAuthTest(t)
 
-	// Execute whoami command without being logged in
-	_, err := executeAuthCommand("auth", "whoami")
+	// Execute status command without being logged in
+	_, err := executeAuthCommand("auth", "status")
 	if err == nil {
-		t.Fatal("Expected whoami to fail when not logged in")
+		t.Fatal("Expected status to fail when not logged in")
 	}
 
 	// Error should indicate not logged in

--- a/internal/tiger/cmd/integration_test.go
+++ b/internal/tiger/cmd/integration_test.go
@@ -81,7 +81,7 @@ func executeIntegrationCommand(args ...string) (string, error) {
 }
 
 // TestServiceLifecycleIntegration tests the complete authentication and service lifecycle:
-// login -> whoami -> create -> get -> update-password -> delete -> logout
+// login -> status -> create -> get -> update-password -> delete -> logout
 func TestServiceLifecycleIntegration(t *testing.T) {
 	config.SetTestServiceName(t)
 	// Check for required environment variables
@@ -148,12 +148,12 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		t.Logf("Login successful")
 	})
 
-	t.Run("WhoAmI", func(t *testing.T) {
+	t.Run("Status", func(t *testing.T) {
 		t.Logf("Verifying authentication status")
 
-		output, err := executeIntegrationCommand("auth", "whoami")
+		output, err := executeIntegrationCommand("auth", "status")
 		if err != nil {
-			t.Fatalf("WhoAmI failed: %v\nOutput: %s", err, output)
+			t.Fatalf("Status failed: %v\nOutput: %s", err, output)
 		}
 
 		// Should not say "Not logged in"
@@ -433,10 +433,10 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 	t.Run("VerifyLoggedOut", func(t *testing.T) {
 		t.Logf("Verifying we're logged out")
 
-		output, err := executeIntegrationCommand("auth", "whoami")
+		output, err := executeIntegrationCommand("auth", "status")
 		// This should either fail or say "Not logged in"
 		if err == nil && !strings.Contains(output, "Not logged in") {
-			t.Errorf("Expected to be logged out, but whoami succeeded: %s", output)
+			t.Errorf("Expected to be logged out, but status succeeded: %s", output)
 		}
 
 		t.Logf("Verified logged out status")

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -68,7 +68,7 @@ For the initial v0 release, implement these essential commands first:
 **Authentication:**
 - `tiger auth login` - Token-based authentication
 - `tiger auth logout` - Remove stored credentials
-- `tiger auth whoami` - Show current user
+- `tiger auth status` - Show current user
 
 **Core Service Management:**
 - `tiger service list` - List all services
@@ -105,7 +105,7 @@ Manage authentication and credentials (token-based only).
 **Subcommands:**
 - `login`: Authenticate with API token
 - `logout`: Remove stored credentials
-- `whoami`: Show current user information
+- `status`: Show current user information
 
 **Examples:**
 ```bash
@@ -125,7 +125,7 @@ tiger auth login
 tiger auth login
 
 # Show current user
-tiger auth whoami
+tiger auth status
 
 # Logout
 tiger auth logout

--- a/specs/spec_after_oauth.md
+++ b/specs/spec_after_oauth.md
@@ -10,7 +10,7 @@ Manage authentication and credentials with OAuth support.
 **Subcommands:**
 - `login`: Authenticate with TigerData Cloud (OAuth flow)
 - `logout`: Remove stored credentials
-- `whoami`: Show current user information
+- `status`: Show current user information
 - `token`: Manage API tokens
 
 **Examples:**
@@ -21,8 +21,8 @@ tiger auth login
 # Web-based OAuth authentication
 tiger auth login --web
 
-# Show current user
-tiger auth whoami
+# Show current token status
+tiger auth status
 
 # Logout and clear credentials
 tiger auth logout


### PR DESCRIPTION
This renames the `tiger auth whoami` command to `tiger auth status`. There is not yet any change in behavior, we can add more information to the output later. Doing this before launch avoids any dependence on `whoami`, and any deprecation period for such a breaking change.
