### PR TITLE
Shorten install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tiger CLI is the command-line interface for Tiger Cloud. It provides commands fo
 ### Install Script
 
 ```bash
-curl -fsSL https://cli.tigerdata.com/install.sh | sh
+curl -fsSL https://cli.tigerdata.com | sh
 ```
 
 ### Homebrew (macOS/Linux)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,7 @@
 # and downloads the appropriate binary for your system.
 #
 # Usage:
-#   curl -fsSL https://cli.tigerdata.com/install.sh | sh
+#   curl -fsSL https://cli.tigerdata.com | sh
 #
 # Environment Variables (all optional):
 #   VERSION           - Specific version to install (e.g., "v1.2.3")


### PR DESCRIPTION
Shortens the install URL from `https://cli.tigerdata.com/install.sh` to `https://cli.tigerdata.com`, now that `install.sh` has been made the default root object in the CloudFront distribution (see [Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1760596986846779?thread_ts=1759939195.393139&cid=C099S47CSRX)).

CC @billy-the-fish for sake of docs update.