### PR TITLE
Add support for `svc get <name>` (match by name instead of id)

### DIFF
--- a/internal/tiger/cmd/errors.go
+++ b/internal/tiger/cmd/errors.go
@@ -12,6 +12,7 @@ const (
 	ExitPermissionDenied    = 5 // Permission denied
 	ExitServiceNotFound     = 6 // Service not found
 	ExitUpdateAvailable     = 7 // Update available
+	ExitMultipleMatches     = 8 // Multiple resources match
 )
 
 // exitCodeError creates an error that will cause the program to exit with the specified code

--- a/internal/tiger/cmd/service_test.go
+++ b/internal/tiger/cmd/service_test.go
@@ -1675,3 +1675,440 @@ func TestServiceList_OutputFlagAffectsCommandOnly(t *testing.T) {
 			string(originalConfigBytes), string(newConfigBytes))
 	}
 }
+
+func TestServiceFind_NoAuth(t *testing.T) {
+	tmpDir := setupServiceTest(t)
+
+	// Set up config with project ID and API URL
+	_, err := config.UseTestConfig(tmpDir, map[string]any{
+		"api_url":    "https://api.tigerdata.com/public/v1",
+		"project_id": "test-project-123",
+	})
+	if err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+
+	// Mock authentication failure
+	originalGetAPIKey := getAPIKeyForService
+	getAPIKeyForService = func() (string, error) {
+		return "", fmt.Errorf("not logged in")
+	}
+	defer func() { getAPIKeyForService = originalGetAPIKey }()
+
+	// Execute service find command
+	_, err, _ = executeServiceCommand("service", "find", "test-service")
+	if err == nil {
+		t.Fatal("Expected error when not authenticated")
+	}
+
+	if !strings.Contains(err.Error(), "authentication required") {
+		t.Errorf("Expected authentication error, got: %v", err)
+	}
+}
+
+func TestServiceFind_NoProjectID(t *testing.T) {
+	tmpDir := setupServiceTest(t)
+
+	// Set up config without project ID
+	_, err := config.UseTestConfig(tmpDir, map[string]any{
+		"api_url": "https://api.tigerdata.com/public/v1",
+	})
+	if err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+
+	// Mock authentication
+	originalGetAPIKey := getAPIKeyForService
+	getAPIKeyForService = func() (string, error) {
+		return "test-api-key", nil
+	}
+	defer func() { getAPIKeyForService = originalGetAPIKey }()
+
+	// Execute service find command
+	_, err, _ = executeServiceCommand("service", "find", "test-service")
+	if err == nil {
+		t.Fatal("Expected error when no project ID is configured")
+	}
+
+	if !strings.Contains(err.Error(), "project ID is required") {
+		t.Errorf("Expected project ID error, got: %v", err)
+	}
+}
+
+func TestServiceFind_NoServiceName(t *testing.T) {
+	tmpDir := setupServiceTest(t)
+
+	// Set up config with project ID
+	_, err := config.UseTestConfig(tmpDir, map[string]any{
+		"api_url":    "https://api.tigerdata.com/public/v1",
+		"project_id": "test-project-123",
+	})
+	if err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
+	}
+
+	// Execute service find command without service name
+	_, err, _ = executeServiceCommand("service", "find")
+	if err == nil {
+		t.Fatal("Expected error when no service name is provided")
+	}
+
+	// Should have an argument error
+	if !strings.Contains(err.Error(), "accepts 1 arg(s)") {
+		t.Errorf("Expected argument error, got: %v", err)
+	}
+}
+
+func TestServiceFind_HelpOutput(t *testing.T) {
+	// Test that the help output contains expected information
+	output, err, _ := executeServiceCommand("service", "find", "--help")
+	if err != nil {
+		t.Fatalf("Help command should not fail: %v", err)
+	}
+
+	expectedStrings := []string{
+		"Find database services",
+		"exact name match",
+		"tiger service get",
+		"tiger service list",
+		"--output",
+		"tiger service find my-production-db",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Expected help output to contain '%s', but it didn't. Output: %s", expected, output)
+		}
+	}
+}
+
+func TestServiceFind_SingleMatch_OutputsLikeGet(t *testing.T) {
+	// Create test services - one with the matching name
+	serviceID1 := "svc-match-123"
+	serviceName1 := "my-test-service"
+	serviceID2 := "svc-other-456"
+	serviceName2 := "other-service"
+	region := "us-east-1"
+	status1 := api.READY
+	status2 := api.READY
+	serviceType := api.TIMESCALEDB
+	created := time.Now()
+	cpuMillis := 2000
+	memoryGbs := 8
+
+	services := []api.Service{
+		{
+			ServiceId:   &serviceID1,
+			Name:        &serviceName1,
+			RegionCode:  &region,
+			Status:      &status1,
+			ServiceType: &serviceType,
+			Created:     &created,
+			Resources: &[]struct {
+				Id   *string `json:"id,omitempty"`
+				Spec *struct {
+					CpuMillis  *int    `json:"cpu_millis,omitempty"`
+					MemoryGbs  *int    `json:"memory_gbs,omitempty"`
+					VolumeType *string `json:"volume_type,omitempty"`
+				} `json:"spec,omitempty"`
+			}{
+				{
+					Spec: &struct {
+						CpuMillis  *int    `json:"cpu_millis,omitempty"`
+						MemoryGbs  *int    `json:"memory_gbs,omitempty"`
+						VolumeType *string `json:"volume_type,omitempty"`
+					}{
+						CpuMillis: &cpuMillis,
+						MemoryGbs: &memoryGbs,
+					},
+				},
+			},
+		},
+		{
+			ServiceId:   &serviceID2,
+			Name:        &serviceName2,
+			RegionCode:  &region,
+			Status:      &status2,
+			ServiceType: &serviceType,
+			Created:     &created,
+		},
+	}
+
+	// Filter to simulate find logic - single match
+	var matches []api.Service
+	searchName := "my-test-service"
+	for _, service := range services {
+		if service.Name != nil && *service.Name == searchName {
+			matches = append(matches, service)
+		}
+	}
+
+	// Verify we have exactly one match
+	if len(matches) != 1 {
+		t.Fatalf("Expected 1 match, got %d", len(matches))
+	}
+
+	// Create test command
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(new(bytes.Buffer))
+
+	// Test that single match outputs like service get (table format with details)
+	err := outputService(cmd, matches[0], "table", false, true)
+	if err != nil {
+		t.Fatalf("Failed to output service: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify output contains detailed service information (like service get)
+	expectedContents := []string{
+		"svc-match-123",
+		"my-test-service",
+		"READY",
+		"TIMESCALEDB",
+		"us-east-1",
+		"2 cores (2000m)",
+		"8 GB",
+	}
+
+	for _, content := range expectedContents {
+		if !strings.Contains(output, content) {
+			t.Errorf("Expected output to contain %q, got: %s", content, output)
+		}
+	}
+
+	// Verify it's using the detailed format (should have "PROPERTY" and "VALUE" headers)
+	if !strings.Contains(output, "PROPERTY") || !strings.Contains(output, "VALUE") {
+		t.Errorf("Single match should use detailed table format like 'service get', got: %s", output)
+	}
+}
+
+func TestServiceFind_MultipleMatches_OutputsLikeList(t *testing.T) {
+	// Create test services - multiple with the same name
+	serviceID1 := "svc-match1-123"
+	serviceName := "duplicate-service"
+	serviceID2 := "svc-match2-456"
+	serviceID3 := "svc-other-789"
+	otherName := "other-service"
+	region := "us-east-1"
+	status := api.READY
+	serviceType := api.TIMESCALEDB
+	created := time.Now()
+
+	services := []api.Service{
+		{
+			ServiceId:   &serviceID1,
+			Name:        &serviceName,
+			RegionCode:  &region,
+			Status:      &status,
+			ServiceType: &serviceType,
+			Created:     &created,
+		},
+		{
+			ServiceId:   &serviceID2,
+			Name:        &serviceName,
+			RegionCode:  &region,
+			Status:      &status,
+			ServiceType: &serviceType,
+			Created:     &created,
+		},
+		{
+			ServiceId:   &serviceID3,
+			Name:        &otherName,
+			RegionCode:  &region,
+			Status:      &status,
+			ServiceType: &serviceType,
+			Created:     &created,
+		},
+	}
+
+	// Filter to simulate find logic - multiple matches
+	var matches []api.Service
+	searchName := "duplicate-service"
+	for _, service := range services {
+		if service.Name != nil && *service.Name == searchName {
+			matches = append(matches, service)
+		}
+	}
+
+	// Verify we have exactly two matches
+	if len(matches) != 2 {
+		t.Fatalf("Expected 2 matches, got %d", len(matches))
+	}
+
+	// Create test command
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(new(bytes.Buffer))
+
+	// Test that multiple matches output like service list
+	err := outputServices(cmd, matches, "table")
+	if err != nil {
+		t.Fatalf("Failed to output services: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify output contains both services
+	expectedContents := []string{
+		"svc-match1-123",
+		"svc-match2-456",
+		"duplicate-service",
+		"READY",
+		"TIMESCALEDB",
+		"us-east-1",
+	}
+
+	for _, content := range expectedContents {
+		if !strings.Contains(output, content) {
+			t.Errorf("Expected output to contain %q, got: %s", content, output)
+		}
+	}
+
+	// Verify it's using the list format (should have "SERVICE ID", "NAME", etc. headers)
+	if !strings.Contains(output, "SERVICE ID") || !strings.Contains(output, "NAME") {
+		t.Errorf("Multiple matches should use list table format like 'service list', got: %s", output)
+	}
+
+	// Verify it doesn't show the other service
+	if strings.Contains(output, "svc-other-789") || strings.Contains(output, "other-service") {
+		t.Errorf("Output should not contain non-matching service, got: %s", output)
+	}
+}
+
+func TestServiceFind_NoMatches(t *testing.T) {
+	// Create test services - none matching the search
+	serviceID1 := "svc-one-123"
+	serviceName1 := "service-one"
+	serviceID2 := "svc-two-456"
+	serviceName2 := "service-two"
+	region := "us-east-1"
+	status := api.READY
+	serviceType := api.TIMESCALEDB
+	created := time.Now()
+
+	services := []api.Service{
+		{
+			ServiceId:   &serviceID1,
+			Name:        &serviceName1,
+			RegionCode:  &region,
+			Status:      &status,
+			ServiceType: &serviceType,
+			Created:     &created,
+		},
+		{
+			ServiceId:   &serviceID2,
+			Name:        &serviceName2,
+			RegionCode:  &region,
+			Status:      &status,
+			ServiceType: &serviceType,
+			Created:     &created,
+		},
+	}
+
+	// Filter to simulate find logic - no matches
+	var matches []api.Service
+	searchName := "non-existent-service"
+	for _, service := range services {
+		if service.Name != nil && *service.Name == searchName {
+			matches = append(matches, service)
+		}
+	}
+
+	// Verify we have no matches
+	if len(matches) != 0 {
+		t.Fatalf("Expected 0 matches, got %d", len(matches))
+	}
+
+	// The actual command would print a "not found" message to stderr
+	// This test verifies the filtering logic works correctly
+	// The actual error message is tested in the command execution test below
+}
+
+func TestServiceFind_OutputFormats(t *testing.T) {
+	// Create a test service
+	serviceID := "svc-test-123"
+	serviceName := "test-service"
+	region := "us-east-1"
+	status := api.READY
+	serviceType := api.TIMESCALEDB
+	created := time.Now()
+
+	service := api.Service{
+		ServiceId:   &serviceID,
+		Name:        &serviceName,
+		RegionCode:  &region,
+		Status:      &status,
+		ServiceType: &serviceType,
+		Created:     &created,
+	}
+
+	testCases := []struct {
+		name   string
+		format string
+		verify func(t *testing.T, output string)
+	}{
+		{
+			name:   "JSON output for single match",
+			format: "json",
+			verify: func(t *testing.T, output string) {
+				// Verify it's valid JSON
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					t.Errorf("Output should be valid JSON: %v", err)
+				}
+				// Verify it contains the service ID
+				if !strings.Contains(output, "svc-test-123") {
+					t.Errorf("JSON output should contain service ID")
+				}
+			},
+		},
+		{
+			name:   "YAML output for single match",
+			format: "yaml",
+			verify: func(t *testing.T, output string) {
+				// Verify it's valid YAML
+				var result map[string]interface{}
+				if err := yaml.Unmarshal([]byte(output), &result); err != nil {
+					t.Errorf("Output should be valid YAML: %v", err)
+				}
+				// Verify it contains the service ID
+				if !strings.Contains(output, "svc-test-123") {
+					t.Errorf("YAML output should contain service ID")
+				}
+			},
+		},
+		{
+			name:   "Table output for single match",
+			format: "table",
+			verify: func(t *testing.T, output string) {
+				// Verify it uses detailed table format
+				if !strings.Contains(output, "PROPERTY") || !strings.Contains(output, "VALUE") {
+					t.Errorf("Table output should have PROPERTY and VALUE headers")
+				}
+				if !strings.Contains(output, "svc-test-123") {
+					t.Errorf("Table output should contain service ID")
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			buf := new(bytes.Buffer)
+			cmd.SetOut(buf)
+			cmd.SetErr(new(bytes.Buffer))
+
+			err := outputService(cmd, service, tc.format, false, true)
+			if err != nil {
+				t.Fatalf("Failed to output service: %v", err)
+			}
+
+			tc.verify(t, buf.String())
+		})
+	}
+}

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -655,6 +655,7 @@ tiger config reset
 - `5`: Permission denied
 - `6`: Service not found
 - `7`: Update available (for explicit `version --check`)
+- `8`: Multiple matches found (e.g., ambiguous service name)
 
 ## Output Formats
 


### PR DESCRIPTION
This implements `tiger svc get <name>`, such that we'll return a match by the service's `name` (in addition to `id`).

If exactly one service matches, the full details are displayed and the exit code is `0` (success)
<img width="854" height="229" alt="image" src="https://github.com/user-attachments/assets/9d999ae7-2337-4d62-b5f2-9519444f6f0e" />

If multiple services have the same name, the process exits with code `8` (so scripts can handle this explicitly), while printing an error message and the list of ambiguous services.
<img width="578" height="137" alt="image" src="https://github.com/user-attachments/assets/4c027c09-f6fe-421f-99c0-2d5080c2bd9c" />

Exit code `6` is used when there are no matches
<img width="321" height="48" alt="image" src="https://github.com/user-attachments/assets/e939fb96-22c4-42dc-b53e-ae6892af7e0b" />

All other flags works as normal.
<img width="983" height="483" alt="image" src="https://github.com/user-attachments/assets/6a57e169-6321-44fa-98d2-c7ab0a70aa11" />
