### PR TITLE
Fix spinner SIGINT behavior

### DIFF
--- a/internal/tiger/cmd/spinner.go
+++ b/internal/tiger/cmd/spinner.go
@@ -41,7 +41,9 @@ func newAnimatedSpinner(output io.Writer, message string, args ...any) *animated
 		spinnerModel{
 			message: fmt.Sprintf(message, args...),
 		},
+		tea.WithInput(nil),
 		tea.WithOutput(output),
+		tea.WithoutSignalHandler(),
 	)
 
 	go func() {


### PR DESCRIPTION
See [Slack thread](https://iobeam.slack.com/archives/C098FB57WBY/p1761059336695529).

This restores the correct signal handling behavior when the spinner component (added in #63) is active, so that users can stop the program with ctrl-c.

The solution involved disabling input entirely for the spinner component (since bubbletea usually puts the input it "raw mode", which prevents ctrl-c from delivering a signal), and also disabling bubbletea's built-in signal handling (which would otherwise take effect after disabling the "raw mode" input). I think this is fine for our needs, since the spinner is just a display/output component for us.