### PR TITLE
Run `go mod tidy --diff` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
           eval $(echo 'test' | gnome-keyring-daemon --start --components=secrets)
           echo "GNOME_KEYRING_CONTROL=$GNOME_KEYRING_CONTROL" >> $GITHUB_ENV
 
+      - name: ShellCheck
+        run: shellcheck scripts/install.sh
+
+      - name: Mod
+        run: go mod tidy --diff
+
       - name: Build
         run: go build ./...
 
@@ -46,14 +52,11 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.out -coverpkg=./... ./...
 
-      - name: Generate Coverage Report
+      - name: Generate coverage report
         run: go tool cover -html=coverage.out -o=coverage.html
 
-      - name: Upload Coverage Report
+      - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage.html
           path: coverage.html
-
-      - name: ShellCheck
-        run: shellcheck scripts/install.sh


### PR DESCRIPTION
Runs `go mod tidy --diff` in the CI pipeline, to ensure that the `go.mod` and `go.sum` files correctly reflects the modules needed by the source code (i.e. no missing modules and no extra unused modules). This is basically a way to make sure people run `go mod tidy` after adding/removing dependencies.

Per `go help mod tidy`:

> The -diff flag causes tidy not to modify go.mod or go.sum but
> instead print the necessary changes as a unified diff. It exits
> with a non-zero code if the diff is not empty.