### PR TITLE
fix: correctly open browser url on windows for auth login

### DIFF
--- a/internal/tiger/cmd/oauth.go
+++ b/internal/tiger/cmd/oauth.go
@@ -233,21 +233,19 @@ func (c *oauthCallback) sendError(err error) {
 }
 
 func openBrowserImpl(url string) error {
-	var cmd string
-	var args []string
+	var cmd *exec.Cmd
 
-	// TODO: Do all of these work correctly?
 	switch runtime.GOOS {
 	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start"}
+		// Escape '&' so cmd.exe doesn't treat it as a command separator
+		cmd = exec.Command("cmd", "/c", "start", strings.ReplaceAll(url, "&", "^&"))
 	case "darwin":
-		cmd = "open"
+		cmd = exec.Command("open", url)
 	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
+		cmd = exec.Command("xdg-open", url)
 	}
-	args = append(args, url)
-	return exec.Command(cmd, args...).Start()
+
+	return cmd.Start()
 }
 
 // selectProjectID prompts the user to select a project if multiple are available


### PR DESCRIPTION
On Windows, `cmd.exe` splits commands on the `&` character. This effectively drops some necessary URL parameters for the `tiger auth login` action, leading to a broken experience.

<img width="503" height="773" alt="image" src="https://github.com/user-attachments/assets/68bea449-4724-4d25-bf57-5f45f41d181e" />

The fix is to add the correct escape sequence for all `&` characters in the URL. Note that I first tried adding quotes, and that totally fails.