### PR TITLE
Add daily execution of all tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
         env:
           TIGER_PUBLIC_KEY_INTEGRATION: ${{ secrets.TIGER_PUBLIC_KEY_INTEGRATION }}
           TIGER_SECRET_KEY_INTEGRATION: ${{ secrets.TIGER_SECRET_KEY_INTEGRATION }}
-          TIGER_PROJECT_ID_INTEGRATION: ${{ secrets.TIGER_PROJECT_ID_INTEGRATION }}
         run: go test -race -coverprofile=coverage.out -coverpkg=./... ./...
 
       - name: Generate coverage report


### PR DESCRIPTION
Wires up the CI pipeline to run the integration tests in addition to the unit tests. Also configures it to run the tests at 8am daily, and to make them runnable via a manual workflow dispatch.