### PR TITLE
feat: migrate service logs to cursor-based pagination

### DIFF
--- a/internal/tiger/api/client.go
+++ b/internal/tiger/api/client.go
@@ -1437,9 +1437,9 @@ func NewGetServiceLogsRequest(server string, projectId ProjectId, serviceId Serv
 
 		}
 
-		if params.StartTime != nil {
+		if params.From != nil {
 
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "startTime", runtime.ParamLocationQuery, *params.StartTime); err != nil {
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, *params.From); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/tiger/api/client.go
+++ b/internal/tiger/api/client.go
@@ -1437,9 +1437,9 @@ func NewGetServiceLogsRequest(server string, projectId ProjectId, serviceId Serv
 
 		}
 
-		if params.From != nil {
+		if params.Since != nil {
 
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, *params.From); err != nil {
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, *params.Since); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/tiger/api/client.go
+++ b/internal/tiger/api/client.go
@@ -1437,6 +1437,22 @@ func NewGetServiceLogsRequest(server string, projectId ProjectId, serviceId Serv
 
 		}
 
+		if params.StartTime != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "startTime", runtime.ParamLocationQuery, *params.StartTime); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Cursor != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {

--- a/internal/tiger/api/client.go
+++ b/internal/tiger/api/client.go
@@ -1437,6 +1437,22 @@ func NewGetServiceLogsRequest(server string, projectId ProjectId, serviceId Serv
 
 		}
 
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 

--- a/internal/tiger/api/types.go
+++ b/internal/tiger/api/types.go
@@ -337,12 +337,27 @@ type ServiceCreate struct {
 // ServiceCreateAddons defines model for ServiceCreate.Addons.
 type ServiceCreateAddons string
 
+// ServiceLogEntry defines model for ServiceLogEntry.
+type ServiceLogEntry struct {
+	// Message Log message text
+	Message string `json:"message"`
+
+	// Severity PostgreSQL severity level (e.g. LOG, WARNING, ERROR, FATAL)
+	Severity string `json:"severity"`
+
+	// Timestamp Timestamp of the log entry (RFC3339 format)
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // ServiceLogs defines model for ServiceLogs.
 type ServiceLogs struct {
+	// Entries Structured log entries with timestamp and severity metadata. Only present on the cursor-based path.
+	Entries *[]ServiceLogEntry `json:"entries,omitempty"`
+
 	// LastCursor Opaque cursor for the next page of results. Present when more log entries exist older than the last entry in this response. Absent when there are no further results.
 	LastCursor *string `json:"lastCursor,omitempty"`
 
-	// Logs Array of log entries (up to 500 entries per page, may be empty)
+	// Logs Array of log message strings. Preserved for backwards compatibility.
 	Logs []string `json:"logs"`
 }
 

--- a/internal/tiger/api/types.go
+++ b/internal/tiger/api/types.go
@@ -470,8 +470,8 @@ type GetServiceLogsParams struct {
 	// Until Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
 	Until *time.Time `form:"until,omitempty" json:"until,omitempty"`
 
-	// From Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z). Lower bound for the log search window.
-	From *time.Time `form:"from,omitempty" json:"from,omitempty"`
+	// Since Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z).
+	Since *time.Time `form:"since,omitempty" json:"since,omitempty"`
 
 	// Cursor Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`

--- a/internal/tiger/api/types.go
+++ b/internal/tiger/api/types.go
@@ -455,6 +455,9 @@ type GetServiceLogsParams struct {
 	// Until Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
 	Until *time.Time `form:"until,omitempty" json:"until,omitempty"`
 
+	// StartTime Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z). Lower bound for the log search window.
+	StartTime *time.Time `form:"startTime,omitempty" json:"startTime,omitempty"`
+
 	// Cursor Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 }

--- a/internal/tiger/api/types.go
+++ b/internal/tiger/api/types.go
@@ -339,6 +339,9 @@ type ServiceCreateAddons string
 
 // ServiceLogs defines model for ServiceLogs.
 type ServiceLogs struct {
+	// LastCursor Opaque cursor for the next page of results. Present when more log entries exist older than the last entry in this response. Absent when there are no further results.
+	LastCursor *string `json:"lastCursor,omitempty"`
+
 	// Logs Array of log entries (up to 500 entries per page, may be empty)
 	Logs []string `json:"logs"`
 }
@@ -451,6 +454,9 @@ type GetServiceLogsParams struct {
 
 	// Until Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
 	Until *time.Time `form:"until,omitempty" json:"until,omitempty"`
+
+	// Cursor Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
 // IdentifyUserJSONRequestBody defines body for IdentifyUser for application/json ContentType.

--- a/internal/tiger/api/types.go
+++ b/internal/tiger/api/types.go
@@ -455,8 +455,8 @@ type GetServiceLogsParams struct {
 	// Until Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
 	Until *time.Time `form:"until,omitempty" json:"until,omitempty"`
 
-	// StartTime Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z). Lower bound for the log search window.
-	StartTime *time.Time `form:"startTime,omitempty" json:"startTime,omitempty"`
+	// From Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z). Lower bound for the log search window.
+	From *time.Time `form:"from,omitempty" json:"from,omitempty"`
 
 	// Cursor Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1593,8 +1593,8 @@ Examples:
 					color.NoColor = false
 				}
 
-				for _, log := range logs {
-					colorizedLog := colorizeLogLine(log, shouldColorize)
+				for _, entry := range logs {
+					colorizedLog := colorizeLogLine(entry.Message, shouldColorize)
 					fmt.Fprintln(outputWriter, colorizedLog)
 				}
 			}

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1495,7 +1495,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 // buildServiceLogsCmd creates the logs command for viewing service logs
 func buildServiceLogsCmd() *cobra.Command {
 	var tail int
-	var from time.Time
+	var since time.Time
 	var until time.Time
 	var node int
 	var output string
@@ -1520,7 +1520,7 @@ Examples:
   tiger service logs svc-12345
 
   # View logs within a time range
-  tiger service logs --from "2024-01-15T09:00:00Z" --until "2024-01-15T10:00:00Z"
+  tiger service logs --since "2024-01-15T09:00:00Z" --until "2024-01-15T10:00:00Z"
 
   # View logs for a specific node (for services with HA replicas)
   tiger service logs --node 1
@@ -1550,9 +1550,9 @@ Examples:
 			cmd.SilenceUsage = true
 
 			// Prepare parameters
-			var fromPtr *time.Time
-			if !from.IsZero() {
-				fromPtr = &from
+			var sincePtr *time.Time
+			if !since.IsZero() {
+				sincePtr = &since
 			}
 
 			var untilPtr *time.Time
@@ -1571,7 +1571,7 @@ Examples:
 			ctx, cancel := context.WithTimeout(cmd.Context(), time.Minute)
 			defer cancel()
 
-			logs, err := common.FetchServiceLogs(ctx, cfg, serviceID, tail, fromPtr, untilPtr, nodePtr)
+			logs, err := common.FetchServiceLogs(ctx, cfg, serviceID, tail, sincePtr, untilPtr, nodePtr)
 			if err != nil {
 				return err
 			}
@@ -1609,7 +1609,7 @@ Examples:
 
 	// Add flags
 	cmd.Flags().IntVar(&tail, "tail", 100, "Number of log lines to show")
-	cmd.Flags().TimeVar(&from, "from", time.Time{}, []string{time.RFC3339}, "Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z)")
+	cmd.Flags().TimeVar(&since, "since", time.Time{}, []string{time.RFC3339}, "Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z)")
 	cmd.Flags().TimeVar(&until, "until", time.Time{}, []string{time.RFC3339}, "Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)")
 	cmd.Flags().IntVar(&node, "node", 0, "Specific service node to fetch logs from (for services with HA replicas, 0 is valid)")
 	cmd.Flags().VarP((*outputFlag)(&output), "output", "o", "Output format (text, json, yaml)")

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1495,6 +1495,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 // buildServiceLogsCmd creates the logs command for viewing service logs
 func buildServiceLogsCmd() *cobra.Command {
 	var tail int
+	var from time.Time
 	var until time.Time
 	var node int
 	var output string
@@ -1506,7 +1507,7 @@ func buildServiceLogsCmd() *cobra.Command {
 		Long: `View logs for a database service.
 
 Fetches and displays logs from the specified service. By default, shows the last
-100 log entries. Supports filtering by time.
+100 log entries. Supports filtering by time range.
 
 The service ID can be provided as an argument or will use the default service
 from your configuration.
@@ -1518,8 +1519,8 @@ Examples:
   # View logs for specific service
   tiger service logs svc-12345
 
-  # View logs before a specific time
-  tiger service logs --until "2024-01-15T10:00:00Z"
+  # View logs within a time range
+  tiger service logs --from "2024-01-15T09:00:00Z" --until "2024-01-15T10:00:00Z"
 
   # View logs for a specific node (for services with HA replicas)
   tiger service logs --node 1
@@ -1549,6 +1550,11 @@ Examples:
 			cmd.SilenceUsage = true
 
 			// Prepare parameters
+			var fromPtr *time.Time
+			if !from.IsZero() {
+				fromPtr = &from
+			}
+
 			var untilPtr *time.Time
 			if !until.IsZero() {
 				untilPtr = &until
@@ -1565,7 +1571,7 @@ Examples:
 			ctx, cancel := context.WithTimeout(cmd.Context(), time.Minute)
 			defer cancel()
 
-			logs, err := common.FetchServiceLogs(ctx, cfg, serviceID, tail, untilPtr, nodePtr)
+			logs, err := common.FetchServiceLogs(ctx, cfg, serviceID, tail, fromPtr, untilPtr, nodePtr)
 			if err != nil {
 				return err
 			}
@@ -1599,6 +1605,7 @@ Examples:
 
 	// Add flags
 	cmd.Flags().IntVar(&tail, "tail", 100, "Number of log lines to show")
+	cmd.Flags().TimeVar(&from, "from", time.Time{}, []string{time.RFC3339}, "Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z)")
 	cmd.Flags().TimeVar(&until, "until", time.Time{}, []string{time.RFC3339}, "Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)")
 	cmd.Flags().IntVar(&node, "node", 0, "Specific service node to fetch logs from (for services with HA replicas, 0 is valid)")
 	cmd.Flags().VarP((*outputFlag)(&output), "output", "o", "Output format (text, json, yaml)")

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1594,7 +1594,11 @@ Examples:
 				}
 
 				for _, entry := range logs {
-					colorizedLog := colorizeLogLine(entry.Message, shouldColorize)
+					line := entry.Message
+					if !entry.Timestamp.IsZero() {
+						line = entry.Timestamp.UTC().Format("2006-01-02 15:04:05 UTC") + " " + line
+					}
+					colorizedLog := colorizeLogLine(line, shouldColorize)
 					fmt.Fprintln(outputWriter, colorizedLog)
 				}
 			}

--- a/internal/tiger/common/logs.go
+++ b/internal/tiger/common/logs.go
@@ -8,12 +8,11 @@ import (
 	"time"
 
 	"github.com/timescale/tiger-cli/internal/tiger/api"
-	"github.com/timescale/tiger-cli/internal/tiger/util"
 )
 
-// FetchServiceLogs fetches service logs with pagination support up to the specified
+// FetchServiceLogs fetches service logs with cursor-based pagination up to the specified
 // tail limit. Returns logs in ascending order by timestamp (oldest first, newest last).
-// NOTE: The node parameter specifies the Specific service node to fetch logs
+// NOTE: The node parameter specifies the specific service node to fetch logs
 // from, for services with HA replicas. If nil, the backend automatically
 // returns logs for the primary.
 func FetchServiceLogs(
@@ -24,21 +23,19 @@ func FetchServiceLogs(
 	until *time.Time,
 	node *int,
 ) ([]string, error) {
-	// Initialize params
 	params := &api.GetServiceLogsParams{
 		Node:  node,
-		Page:  util.Ptr(0),
 		Until: until,
 	}
 
-	// Set until time to current time if not provided for
-	// consistent pagination across multiple page requests
+	// Fix the upper time bound so that all paginated requests share the same
+	// window — without this, a clock tick between requests could cause the
+	// second page to return logs already included on the first page.
 	if params.Until == nil {
 		now := time.Now()
 		params.Until = &now
 	}
 
-	// Fetch pages until we have enough logs or reach the end
 	var logs []string
 	for {
 		resp, err := cfg.Client.GetServiceLogsWithResponse(ctx, cfg.ProjectID, serviceID, params)
@@ -54,28 +51,22 @@ func FetchServiceLogs(
 			return nil, fmt.Errorf("unexpected empty response")
 		}
 
-		pageLogs := resp.JSON200.Logs
-		logs = append(logs, pageLogs...)
+		logs = append(logs, resp.JSON200.Logs...)
 
-		// Stop conditions:
-		// 1. Page is empty (no more logs available)
-		// 2. We have enough logs to satisfy tail requirement
-		if len(pageLogs) == 0 || len(logs) >= tail {
+		// Stop when we have enough logs or the server signals no further pages.
+		if len(logs) >= tail || resp.JSON200.LastCursor == nil {
 			break
 		}
 
-		*params.Page++
+		params.Cursor = resp.JSON200.LastCursor
 	}
 
-	// Apply tail filter
+	// Trim to the requested tail count.
 	if len(logs) > tail {
 		logs = logs[:tail]
 	}
 
-	// Reverse the order of the logs. This is necessary because the API
-	// returns logs in descending order by timestamp (with the most
-	// recent logs first), whereas in terminal output, it's more natural
-	// for the most recent logs to appear last.
+	// Reverse: the API returns logs newest-first; terminal output is oldest-first.
 	slices.Reverse(logs)
 
 	return logs, nil

--- a/internal/tiger/common/logs.go
+++ b/internal/tiger/common/logs.go
@@ -25,9 +25,9 @@ func FetchServiceLogs(
 	node *int,
 ) ([]string, error) {
 	params := &api.GetServiceLogsParams{
-		Node:      node,
-		StartTime: from,
-		Until:     until,
+		Node:  node,
+		From:  from,
+		Until: until,
 	}
 
 	// Fix the upper time bound so that all paginated requests share the same

--- a/internal/tiger/common/logs.go
+++ b/internal/tiger/common/logs.go
@@ -20,13 +20,13 @@ func FetchServiceLogs(
 	cfg *Config,
 	serviceID string,
 	tail int,
-	from *time.Time,
+	since *time.Time,
 	until *time.Time,
 	node *int,
 ) ([]api.ServiceLogEntry, error) {
 	params := &api.GetServiceLogsParams{
 		Node:  node,
-		From:  from,
+		Since: since,
 		Until: until,
 	}
 
@@ -53,8 +53,9 @@ func FetchServiceLogs(
 			return nil, fmt.Errorf("unexpected empty response")
 		}
 
-		page := toEntries(resp.JSON200)
-		entries = append(entries, page...)
+		if resp.JSON200.Entries != nil {
+			entries = append(entries, *resp.JSON200.Entries...)
+		}
 
 		// Stop when we have enough logs or the server signals no further pages.
 		if len(entries) >= tail || resp.JSON200.LastCursor == nil {
@@ -73,18 +74,4 @@ func FetchServiceLogs(
 	slices.Reverse(entries)
 
 	return entries, nil
-}
-
-// toEntries converts a ServiceLogs response to a slice of ServiceLogEntry.
-// Uses the structured entries field when available (cursor path); falls back
-// to constructing minimal entries from the plain logs strings (legacy path).
-func toEntries(logs *api.ServiceLogs) []api.ServiceLogEntry {
-	if logs.Entries != nil {
-		return *logs.Entries
-	}
-	entries := make([]api.ServiceLogEntry, len(logs.Logs))
-	for i, msg := range logs.Logs {
-		entries[i] = api.ServiceLogEntry{Message: msg}
-	}
-	return entries
 }

--- a/internal/tiger/common/logs.go
+++ b/internal/tiger/common/logs.go
@@ -20,12 +20,14 @@ func FetchServiceLogs(
 	cfg *Config,
 	serviceID string,
 	tail int,
+	from *time.Time,
 	until *time.Time,
 	node *int,
 ) ([]string, error) {
 	params := &api.GetServiceLogsParams{
-		Node:  node,
-		Until: until,
+		Node:      node,
+		StartTime: from,
+		Until:     until,
 	}
 
 	// Fix the upper time bound so that all paginated requests share the same

--- a/internal/tiger/common/logs.go
+++ b/internal/tiger/common/logs.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FetchServiceLogs fetches service logs with cursor-based pagination up to the specified
-// tail limit. Returns logs in ascending order by timestamp (oldest first, newest last).
+// tail limit. Returns entries in ascending order by timestamp (oldest first, newest last).
 // NOTE: The node parameter specifies the specific service node to fetch logs
 // from, for services with HA replicas. If nil, the backend automatically
 // returns logs for the primary.
@@ -23,7 +23,7 @@ func FetchServiceLogs(
 	from *time.Time,
 	until *time.Time,
 	node *int,
-) ([]string, error) {
+) ([]api.ServiceLogEntry, error) {
 	params := &api.GetServiceLogsParams{
 		Node:  node,
 		From:  from,
@@ -38,7 +38,7 @@ func FetchServiceLogs(
 		params.Until = &now
 	}
 
-	var logs []string
+	var entries []api.ServiceLogEntry
 	for {
 		resp, err := cfg.Client.GetServiceLogsWithResponse(ctx, cfg.ProjectID, serviceID, params)
 		if err != nil {
@@ -53,10 +53,11 @@ func FetchServiceLogs(
 			return nil, fmt.Errorf("unexpected empty response")
 		}
 
-		logs = append(logs, resp.JSON200.Logs...)
+		page := toEntries(resp.JSON200)
+		entries = append(entries, page...)
 
 		// Stop when we have enough logs or the server signals no further pages.
-		if len(logs) >= tail || resp.JSON200.LastCursor == nil {
+		if len(entries) >= tail || resp.JSON200.LastCursor == nil {
 			break
 		}
 
@@ -64,12 +65,26 @@ func FetchServiceLogs(
 	}
 
 	// Trim to the requested tail count.
-	if len(logs) > tail {
-		logs = logs[:tail]
+	if len(entries) > tail {
+		entries = entries[:tail]
 	}
 
 	// Reverse: the API returns logs newest-first; terminal output is oldest-first.
-	slices.Reverse(logs)
+	slices.Reverse(entries)
 
-	return logs, nil
+	return entries, nil
+}
+
+// toEntries converts a ServiceLogs response to a slice of ServiceLogEntry.
+// Uses the structured entries field when available (cursor path); falls back
+// to constructing minimal entries from the plain logs strings (legacy path).
+func toEntries(logs *api.ServiceLogs) []api.ServiceLogEntry {
+	if logs.Entries != nil {
+		return *logs.Entries
+	}
+	entries := make([]api.ServiceLogEntry, len(logs.Logs))
+	for i, msg := range logs.Logs {
+		entries[i] = api.ServiceLogEntry{Message: msg}
+	}
+	return entries
 }

--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -366,7 +366,7 @@ type ServiceLogsInput struct {
 	ServiceID string     `json:"service_id"`
 	Node      *int       `json:"node,omitempty"`
 	Tail      int        `json:"tail,omitempty"`
-	From      *time.Time `json:"from,omitempty"`
+	Since     *time.Time `json:"since,omitempty"`
 	Until     *time.Time `json:"until,omitempty"`
 }
 
@@ -384,8 +384,8 @@ func (ServiceLogsInput) Schema() *jsonschema.Schema {
 	schema.Properties["tail"].Minimum = util.Ptr(1.0)
 	schema.Properties["tail"].Examples = []any{50, 100, 1000}
 
-	schema.Properties["from"].Description = "Fetch logs after this timestamp (RFC3339 format, e.g., '2024-01-15T09:00:00Z'). Lower bound for the log search window."
-	schema.Properties["from"].Examples = []any{"2024-01-15T09:00:00Z", "2025-01-16T08:00:00Z"}
+	schema.Properties["since"].Description = "Fetch logs after this timestamp (RFC3339 format, e.g., '2024-01-15T09:00:00Z'). If not provided, only the tail parameter limits how far back logs are fetched."
+	schema.Properties["since"].Examples = []any{"2024-01-15T09:00:00Z", "2025-01-16T08:00:00Z"}
 
 	schema.Properties["until"].Description = "Fetch logs before this timestamp (RFC3339 format, e.g., '2024-01-15T10:00:00Z'). If not provided, fetches logs up to the current time."
 	schema.Properties["until"].Examples = []any{"2024-01-15T10:00:00Z", "2025-01-16T08:30:00Z"}
@@ -395,10 +395,7 @@ func (ServiceLogsInput) Schema() *jsonschema.Schema {
 
 // ServiceLogsOutput represents output for service_logs
 type ServiceLogsOutput struct {
-	// Logs contains plain message strings, preserved for backwards compatibility.
-	Logs []string `json:"logs" jsonschema:"Array of log message strings, ordered from oldest to newest"`
-	// Entries contains structured log data with timestamp and severity.
-	Entries []serviceLogEntryOutput `json:"entries" jsonschema:"Structured log entries with timestamp and severity, ordered from oldest to newest"`
+	Entries []serviceLogEntryOutput `json:"entries" jsonschema:"Structured log entries with timestamp, message, and severity, ordered from oldest to newest"`
 }
 
 // serviceLogEntryOutput is the MCP output shape for a single log entry.
@@ -572,7 +569,9 @@ WARNING: Creates billable resource changes. Increasing resources will increase c
 		Title: "Get Service Logs",
 		Description: `View logs for a database service.
 
-Fetches and displays logs from the specified service. By default, shows the last 100 log entries. Supports filtering by time and node (for services with HA replicas).`,
+Fetches and displays logs from the specified service. By default, shows the last 100 log entries.
+
+Supports filtering by time (via since/until parameters) and node (for services with HA replicas).`,
 		InputSchema:  ServiceLogsInput{}.Schema(),
 		OutputSchema: ServiceLogsOutput{}.Schema(),
 		Annotations: &mcp.ToolAnnotations{
@@ -1172,7 +1171,7 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 		zap.String("service_id", input.ServiceID),
 		zap.Intp("node", input.Node),
 		zap.Int("tail", input.Tail),
-		zap.Timep("from", input.From),
+		zap.Timep("since", input.Since),
 		zap.Timep("until", input.Until),
 	)
 
@@ -1180,15 +1179,13 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 	logsCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	entries, err := common.FetchServiceLogs(logsCtx, cfg, input.ServiceID, input.Tail, input.From, input.Until, input.Node)
+	entries, err := common.FetchServiceLogs(logsCtx, cfg, input.ServiceID, input.Tail, input.Since, input.Until, input.Node)
 	if err != nil {
 		return nil, ServiceLogsOutput{}, err
 	}
 
-	logs := make([]string, len(entries))
 	structured := make([]serviceLogEntryOutput, len(entries))
 	for i, e := range entries {
-		logs[i] = e.Message
 		structured[i] = serviceLogEntryOutput{
 			Timestamp: e.Timestamp,
 			Message:   e.Message,
@@ -1196,10 +1193,5 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 		}
 	}
 
-	output := ServiceLogsOutput{
-		Logs:    logs,
-		Entries: structured,
-	}
-
-	return nil, output, nil
+	return nil, ServiceLogsOutput{Entries: structured}, nil
 }

--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -395,7 +395,17 @@ func (ServiceLogsInput) Schema() *jsonschema.Schema {
 
 // ServiceLogsOutput represents output for service_logs
 type ServiceLogsOutput struct {
-	Logs []string `json:"logs" jsonschema:"Array of log entries, ordered from oldest to newest"`
+	// Logs contains plain message strings, preserved for backwards compatibility.
+	Logs []string `json:"logs" jsonschema:"Array of log message strings, ordered from oldest to newest"`
+	// Entries contains structured log data with timestamp and severity.
+	Entries []serviceLogEntryOutput `json:"entries" jsonschema:"Structured log entries with timestamp and severity, ordered from oldest to newest"`
+}
+
+// serviceLogEntryOutput is the MCP output shape for a single log entry.
+type serviceLogEntryOutput struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message"`
+	Severity  string    `json:"severity"`
 }
 
 func (ServiceLogsOutput) Schema() *jsonschema.Schema {
@@ -1170,14 +1180,25 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 	logsCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	logs, err := common.FetchServiceLogs(logsCtx, cfg, input.ServiceID, input.Tail, input.From, input.Until, input.Node)
+	entries, err := common.FetchServiceLogs(logsCtx, cfg, input.ServiceID, input.Tail, input.From, input.Until, input.Node)
 	if err != nil {
 		return nil, ServiceLogsOutput{}, err
 	}
 
-	// Return logs as array
+	logs := make([]string, len(entries))
+	structured := make([]serviceLogEntryOutput, len(entries))
+	for i, e := range entries {
+		logs[i] = e.Message
+		structured[i] = serviceLogEntryOutput{
+			Timestamp: e.Timestamp,
+			Message:   e.Message,
+			Severity:  e.Severity,
+		}
+	}
+
 	output := ServiceLogsOutput{
-		Logs: logs,
+		Logs:    logs,
+		Entries: structured,
 	}
 
 	return nil, output, nil

--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -366,6 +366,7 @@ type ServiceLogsInput struct {
 	ServiceID string     `json:"service_id"`
 	Node      *int       `json:"node,omitempty"`
 	Tail      int        `json:"tail,omitempty"`
+	From      *time.Time `json:"from,omitempty"`
 	Until     *time.Time `json:"until,omitempty"`
 }
 
@@ -382,6 +383,9 @@ func (ServiceLogsInput) Schema() *jsonschema.Schema {
 	schema.Properties["tail"].Default = util.Must(json.Marshal(100))
 	schema.Properties["tail"].Minimum = util.Ptr(1.0)
 	schema.Properties["tail"].Examples = []any{50, 100, 1000}
+
+	schema.Properties["from"].Description = "Fetch logs after this timestamp (RFC3339 format, e.g., '2024-01-15T09:00:00Z'). Lower bound for the log search window."
+	schema.Properties["from"].Examples = []any{"2024-01-15T09:00:00Z", "2025-01-16T08:00:00Z"}
 
 	schema.Properties["until"].Description = "Fetch logs before this timestamp (RFC3339 format, e.g., '2024-01-15T10:00:00Z'). If not provided, fetches logs up to the current time."
 	schema.Properties["until"].Examples = []any{"2024-01-15T10:00:00Z", "2025-01-16T08:30:00Z"}
@@ -1158,6 +1162,7 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 		zap.String("service_id", input.ServiceID),
 		zap.Intp("node", input.Node),
 		zap.Int("tail", input.Tail),
+		zap.Timep("from", input.From),
 		zap.Timep("until", input.Until),
 	)
 
@@ -1165,7 +1170,7 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 	logsCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	logs, err := common.FetchServiceLogs(logsCtx, cfg, input.ServiceID, input.Tail, input.Until, input.Node)
+	logs, err := common.FetchServiceLogs(logsCtx, cfg, input.ServiceID, input.Tail, input.From, input.Until, input.Node)
 	if err != nil {
 		return nil, ServiceLogsOutput{}, err
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -598,6 +598,7 @@ paths:
         - name: page
           in: query
           required: false
+          deprecated: true
           schema:
             type: integer
           description: Page number for pagination (0-based)
@@ -608,13 +609,13 @@ paths:
             type: string
             format: date-time
           description: Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
-        - name: from
+        - name: since
           in: query
           required: false
           schema:
             type: string
             format: date-time
-          description: Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z). Lower bound for the log search window.
+          description: Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z).
         - name: cursor
           in: query
           required: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -608,13 +608,13 @@ paths:
             type: string
             format: date-time
           description: Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
-        - name: startTime
+        - name: from
           in: query
           required: false
           schema:
             type: string
             format: date-time
-          description: Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z). Lower bound for the log search window.
+          description: Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z). Lower bound for the log search window.
         - name: cursor
           in: query
           required: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -608,6 +608,13 @@ paths:
             type: string
             format: date-time
           description: Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
+        - name: startTime
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z). Lower bound for the log search window.
         - name: cursor
           in: query
           required: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -608,6 +608,12 @@ paths:
             type: string
             format: date-time
           description: Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
       responses:
         '200':
           description: Service logs retrieved successfully
@@ -1332,6 +1338,9 @@ components:
           items:
             type: string
           description: Array of log entries (up to 500 entries per page, may be empty)
+        lastCursor:
+          type: string
+          description: Opaque cursor for the next page of results. Present when more log entries exist older than the last entry in this response. Absent when there are no further results.
     Error:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1335,6 +1335,23 @@ components:
           type: string
           description: The ID of the VPC to attach the service to.
           example: "1234567890"
+    ServiceLogEntry:
+      type: object
+      required:
+        - timestamp
+        - message
+        - severity
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Timestamp of the log entry (RFC3339 format)
+        message:
+          type: string
+          description: Log message text
+        severity:
+          type: string
+          description: PostgreSQL severity level (e.g. LOG, WARNING, ERROR, FATAL)
     ServiceLogs:
       type: object
       required:
@@ -1344,7 +1361,12 @@ components:
           type: array
           items:
             type: string
-          description: Array of log entries (up to 500 entries per page, may be empty)
+          description: Array of log message strings. Preserved for backwards compatibility.
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceLogEntry'
+          description: Structured log entries with timestamp and severity metadata. Only present on the cursor-based path.
         lastCursor:
           type: string
           description: Opaque cursor for the next page of results. Present when more log entries exist older than the last entry in this response. Absent when there are no further results.


### PR DESCRIPTION
## Summary

- Rewrites `FetchServiceLogs` to use cursor-based pagination — `lastCursor` from each response is passed back as `cursor` on the next request, removing the Elasticsearch 10,000-hit window limit that silently capped offset pagination
- `FetchServiceLogs` now returns `[]api.ServiceLogEntry` (structured) instead of `[]string`; each entry carries `timestamp`, `message`, and `severity` from Elasticsearch
- Adds `--since` flag (lower-bound timestamp) to `tiger service logs` alongside the existing `--until`
- Adds `Since` field to `ServiceLogsInput` in the MCP `service_logs` tool; MCP output returns structured `entries` with timestamp, message, and severity (no redundant flat `logs` array)
- `openapi.yaml` updated: adds `since`, `cursor` params; `ServiceLogEntry` schema; `entries` field on `ServiceLogs`; `page` param marked deprecated; regenerated `types.go` and `client.go`

## Merge order

Depends on savannah-public adding `entries` and `lastCursor` to the response (timescale/savannah-public#88), which depends on timescale/timescale-graphql-client#18. Merge those first.