### PR TITLE
feat(logs): colorize log lines using structured severity field

### DIFF
--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -1598,8 +1597,7 @@ Examples:
 					if !entry.Timestamp.IsZero() {
 						line = entry.Timestamp.UTC().Format("2006-01-02 15:04:05 UTC") + " " + line
 					}
-					colorizedLog := colorizeLogLine(line, shouldColorize)
-					fmt.Fprintln(outputWriter, colorizedLog)
+					fmt.Fprintln(outputWriter, colorizeLogEntry(line, entry.Severity, shouldColorize))
 				}
 			}
 
@@ -1617,47 +1615,30 @@ Examples:
 	return cmd
 }
 
-// logLevelRegex matches PostgreSQL log levels in log lines
-// Pattern: word boundary + log level + colon
-var logLevelRegex = regexp.MustCompile(`\b(DEBUG|INFO|NOTICE|WARNING|LOG|ERROR|FATAL|PANIC|DETAIL|HINT|QUERY|CONTEXT|LOCATION):`)
-
-// colorizeLogLine applies color to the log level in a PostgreSQL log line
-// If colorEnabled is false, returns the line unchanged
-func colorizeLogLine(line string, colorEnabled bool) string {
+// colorizeLogEntry applies a color to the entire log line based on the
+// structured severity field. If colorEnabled is false, returns the line unchanged.
+func colorizeLogEntry(line, severity string, colorEnabled bool) string {
 	if !colorEnabled {
 		return line
 	}
-
-	// Find the log level in the line
-	return logLevelRegex.ReplaceAllStringFunc(line, func(match string) string {
-		// Remove the colon to get just the level
-		logLevel := strings.TrimSuffix(match, ":")
-
-		// Apply color based on severity
-		var coloredLevel string
-		switch logLevel {
-		case "ERROR", "FATAL", "PANIC":
-			coloredLevel = color.RedString(logLevel)
-		case "WARNING":
-			coloredLevel = color.YellowString(logLevel)
-		case "INFO", "NOTICE":
-			coloredLevel = color.BlueString(logLevel)
-		case "DEBUG":
-			coloredLevel = color.MagentaString(logLevel)
-		case "QUERY":
-			coloredLevel = color.GreenString(logLevel)
-		case "LOG":
-			coloredLevel = color.CyanString(logLevel)
-		case "DETAIL", "HINT", "CONTEXT", "LOCATION":
-			coloredLevel = color.WhiteString(logLevel)
-		default:
-			// Unknown level - leave uncolored
-			coloredLevel = logLevel
-		}
-
-		// Return with the colon
-		return coloredLevel + ":"
-	})
+	switch strings.ToUpper(severity) {
+	case "ERROR", "FATAL", "PANIC":
+		return color.RedString(line)
+	case "WARNING":
+		return color.YellowString(line)
+	case "INFO", "NOTICE":
+		return color.BlueString(line)
+	case "DEBUG":
+		return color.MagentaString(line)
+	case "QUERY":
+		return color.GreenString(line)
+	case "LOG":
+		return color.CyanString(line)
+	case "DETAIL", "HINT", "CONTEXT", "LOCATION":
+		return color.WhiteString(line)
+	default:
+		return line
+	}
 }
 
 func serviceIDCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1619,6 +1619,8 @@ Examples:
 // line using the API-provided severity field. Using the structured field avoids
 // false positives where a severity word appears in the message body rather than
 // as an actual log level. If colorEnabled is false, returns the line unchanged.
+//
+// PostgreSQL severity levels: https://www.postgresql.org/docs/current/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS
 func colorizeLogEntry(line, severity string, colorEnabled bool) string {
 	if !colorEnabled || severity == "" {
 		return line

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1615,30 +1615,31 @@ Examples:
 	return cmd
 }
 
-// colorizeLogEntry applies a color to the entire log line based on the
-// structured severity field. If colorEnabled is false, returns the line unchanged.
+// colorizeLogEntry colorizes the severity token (e.g. "ERROR:") within the log
+// line using the API-provided severity field. Using the structured field avoids
+// false positives where a severity word appears in the message body rather than
+// as an actual log level. If colorEnabled is false, returns the line unchanged.
 func colorizeLogEntry(line, severity string, colorEnabled bool) string {
-	if !colorEnabled {
+	if !colorEnabled || severity == "" {
 		return line
 	}
+
+	var colorFn func(string, ...interface{}) string
 	switch strings.ToUpper(severity) {
 	case "ERROR", "FATAL", "PANIC":
-		return color.RedString(line)
+		colorFn = color.RedString
 	case "WARNING":
-		return color.YellowString(line)
-	case "INFO", "NOTICE":
-		return color.BlueString(line)
+		colorFn = color.YellowString
+	case "LOG", "INFO", "NOTICE":
+		colorFn = color.BlueString
 	case "DEBUG":
-		return color.MagentaString(line)
-	case "QUERY":
-		return color.GreenString(line)
-	case "LOG":
-		return color.CyanString(line)
-	case "DETAIL", "HINT", "CONTEXT", "LOCATION":
-		return color.WhiteString(line)
+		colorFn = color.MagentaString
 	default:
 		return line
 	}
+
+	token := strings.ToUpper(severity) + ":"
+	return strings.Replace(line, token, colorFn(token), 1)
 }
 
 func serviceIDCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
## Summary

- Replaces the regex-based log level colorizer with one that uses the `severity` field from the structured `ServiceLogEntry`
- Only the severity token (e.g. `ERROR:`) is colorized within the line — not the full line — preserving the original behaviour that's easier on the eyes across different terminal color schemes
- Using the API-provided severity field eliminates false matches: the old regex would colorize any word matching a severity name anywhere in the message body (e.g. a query mentioning `WARNING` or `ERROR`), whereas now only the actual severity of that log entry is colorized
- Severity levels follow the PostgreSQL spec: https://www.postgresql.org/docs/current/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS

## Merge order

Depends on timescale/tiger-cli#143 (which introduces the structured `ServiceLogEntry` with the `severity` field). Merge that first.