### PR TITLE
feat(mcp): return logs as pre-formatted strings to reduce token usage

### DIFF
--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -1595,7 +1595,8 @@ Examples:
 				for _, entry := range logs {
 					line := entry.Message
 					if !entry.Timestamp.IsZero() {
-						line = entry.Timestamp.UTC().Format("2006-01-02 15:04:05 UTC") + " " + line
+						// Local timezone for terminal output; MCP and public API use UTC.
+						line = entry.Timestamp.Local().Format("2006-01-02 15:04:05 MST") + " " + line
 					}
 					fmt.Fprintln(outputWriter, colorizeLogEntry(line, entry.Severity, shouldColorize))
 				}

--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -395,14 +395,7 @@ func (ServiceLogsInput) Schema() *jsonschema.Schema {
 
 // ServiceLogsOutput represents output for service_logs
 type ServiceLogsOutput struct {
-	Entries []serviceLogEntryOutput `json:"entries" jsonschema:"Structured log entries with timestamp, message, and severity, ordered from oldest to newest"`
-}
-
-// serviceLogEntryOutput is the MCP output shape for a single log entry.
-type serviceLogEntryOutput struct {
-	Timestamp time.Time `json:"timestamp"`
-	Message   string    `json:"message"`
-	Severity  string    `json:"severity"`
+	Logs []string `json:"logs" jsonschema:"Log lines ordered from oldest to newest. Each line is prefixed with an RFC3339 timestamp followed by the log message."`
 }
 
 func (ServiceLogsOutput) Schema() *jsonschema.Schema {
@@ -1184,14 +1177,14 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 		return nil, ServiceLogsOutput{}, err
 	}
 
-	structured := make([]serviceLogEntryOutput, len(entries))
+	logs := make([]string, len(entries))
 	for i, e := range entries {
-		structured[i] = serviceLogEntryOutput{
-			Timestamp: e.Timestamp,
-			Message:   e.Message,
-			Severity:  e.Severity,
+		if !e.Timestamp.IsZero() {
+			logs[i] = e.Timestamp.UTC().Format(time.RFC3339) + " " + e.Message
+		} else {
+			logs[i] = e.Message
 		}
 	}
 
-	return nil, ServiceLogsOutput{Entries: structured}, nil
+	return nil, ServiceLogsOutput{Logs: logs}, nil
 }

--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -1180,7 +1180,7 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 	logs := make([]string, len(entries))
 	for i, e := range entries {
 		if !e.Timestamp.IsZero() {
-			logs[i] = e.Timestamp.UTC().Format(time.RFC3339) + " " + e.Message
+			logs[i] = e.Timestamp.UTC().Format("2006-01-02 15:04:05 UTC") + " " + e.Message
 		} else {
 			logs[i] = e.Message
 		}


### PR DESCRIPTION
## Summary

Improves on the structured log entries introduced in #143. That PR returned an `entries` array of JSON objects, each with `timestamp`, `message`, and `severity` fields. This PR replaces that with a flat `logs []string` where each line is an RFC3339 timestamp prepended to the log message.

The severity is already embedded in the message text so there is no information loss, but the token count per MCP tool call drops significantly — a JSON object with three named fields per entry becomes a single string.