### PR TITLE
test: sweep stale services

### DIFF
--- a/internal/tiger/cmd/integration_test.go
+++ b/internal/tiger/cmd/integration_test.go
@@ -93,15 +93,20 @@ func executeIntegrationCommand(ctx context.Context, args ...string) (string, err
 	return buf.String(), err
 }
 
+// testServicePrefix is the name prefix used by every service created by the
+// integration tests. The sweeper filters by this prefix so it only deletes
+// services this test suite owns.
+const testServicePrefix = "integration-"
+
 // sweepStaleIntegrationServices deletes any service whose name starts with
-// "integration-" and was created more than threshold ago. Best-effort: every
-// failure is logged, none is fatal.
+// testServicePrefix and was created more than threshold ago. Best-effort:
+// every failure is logged, none is fatal.
 //
 // This catches services leaked by prior runs that were killed before their
 // own deferred cleanup could fire (e.g. `go test` outer timeout, SIGKILL).
 func sweepStaleIntegrationServices(t *testing.T, threshold time.Duration) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	output, err := executeIntegrationCommand(ctx, "service", "list", "-o", "json")
 	if err != nil {
@@ -109,11 +114,7 @@ func sweepStaleIntegrationServices(t *testing.T, threshold time.Duration) {
 		return
 	}
 
-	var services []struct {
-		ServiceID *string    `json:"service_id"`
-		Name      *string    `json:"name"`
-		Created   *time.Time `json:"created"`
-	}
+	var services []api.Service
 	if err := json.Unmarshal([]byte(output), &services); err != nil {
 		t.Logf("Sweep: failed to parse service list, skipping: %v", err)
 		return
@@ -122,21 +123,21 @@ func sweepStaleIntegrationServices(t *testing.T, threshold time.Duration) {
 	cutoff := time.Now().Add(-threshold)
 	swept := 0
 	for _, s := range services {
-		if s.ServiceID == nil || s.Name == nil || s.Created == nil {
+		if s.ServiceId == nil || s.Name == nil || s.Created == nil {
 			continue
 		}
-		if !strings.HasPrefix(*s.Name, "integration-") {
+		if !strings.HasPrefix(*s.Name, testServicePrefix) {
 			continue
 		}
 		if !s.Created.Before(cutoff) {
 			continue
 		}
 		t.Logf("Sweep: deleting stale service %s (name=%s, created=%s)",
-			*s.ServiceID, *s.Name, s.Created.Format(time.RFC3339))
+			*s.ServiceId, *s.Name, s.Created.Format(time.RFC3339))
 		if _, err := executeIntegrationCommand(ctx,
-			"service", "delete", *s.ServiceID,
+			"service", "delete", *s.ServiceId,
 			"--confirm", "--no-wait"); err != nil {
-			t.Logf("Sweep: failed to delete %s: %v", *s.ServiceID, err)
+			t.Logf("Sweep: failed to delete %s: %v", *s.ServiceId, err)
 			continue
 		}
 		swept++
@@ -192,10 +193,6 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		}
 	}()
 
-	// Sweep any orphan integration services left over from prior runs.
-	// Registered last so it runs first (LIFO) — while creds are still valid.
-	defer sweepStaleIntegrationServices(t, time.Hour)
-
 	t.Run("Login", func(t *testing.T) {
 		t.Logf("Logging in with public key: %s", publicKey[:8]+"...") // Only show first 8 chars
 
@@ -217,6 +214,10 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 
 		t.Logf("Login successful")
 	})
+
+	// Sweep orphans from prior runs while we're authenticated and before
+	// the test does anything that could fail. Runs once per CI run.
+	sweepStaleIntegrationServices(t, time.Hour)
 
 	t.Run("Status", func(t *testing.T) {
 		t.Logf("Verifying authentication status")

--- a/internal/tiger/cmd/integration_test.go
+++ b/internal/tiger/cmd/integration_test.go
@@ -93,6 +93,59 @@ func executeIntegrationCommand(ctx context.Context, args ...string) (string, err
 	return buf.String(), err
 }
 
+// sweepStaleIntegrationServices deletes any service whose name starts with
+// "integration-" and was created more than threshold ago. Best-effort: every
+// failure is logged, none is fatal.
+//
+// This catches services leaked by prior runs that were killed before their
+// own deferred cleanup could fire (e.g. `go test` outer timeout, SIGKILL).
+func sweepStaleIntegrationServices(t *testing.T, threshold time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+
+	output, err := executeIntegrationCommand(ctx, "service", "list", "-o", "json")
+	if err != nil {
+		t.Logf("Sweep: failed to list services, skipping: %v", err)
+		return
+	}
+
+	var services []struct {
+		ServiceID *string    `json:"service_id"`
+		Name      *string    `json:"name"`
+		Created   *time.Time `json:"created"`
+	}
+	if err := json.Unmarshal([]byte(output), &services); err != nil {
+		t.Logf("Sweep: failed to parse service list, skipping: %v", err)
+		return
+	}
+
+	cutoff := time.Now().Add(-threshold)
+	swept := 0
+	for _, s := range services {
+		if s.ServiceID == nil || s.Name == nil || s.Created == nil {
+			continue
+		}
+		if !strings.HasPrefix(*s.Name, "integration-") {
+			continue
+		}
+		if !s.Created.Before(cutoff) {
+			continue
+		}
+		t.Logf("Sweep: deleting stale service %s (name=%s, created=%s)",
+			*s.ServiceID, *s.Name, s.Created.Format(time.RFC3339))
+		if _, err := executeIntegrationCommand(ctx,
+			"service", "delete", *s.ServiceID,
+			"--confirm", "--no-wait"); err != nil {
+			t.Logf("Sweep: failed to delete %s: %v", *s.ServiceID, err)
+			continue
+		}
+		swept++
+	}
+	if swept > 0 {
+		t.Logf("Sweep: deleted %d stale service(s)", swept)
+	}
+}
+
 // TestServiceLifecycleIntegration tests the complete authentication and service lifecycle:
 // login -> status -> create -> get -> update-password -> delete -> logout
 func TestServiceLifecycleIntegration(t *testing.T) {
@@ -138,6 +191,10 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 			}
 		}
 	}()
+
+	// Sweep any orphan integration services left over from prior runs.
+	// Registered last so it runs first (LIFO) — while creds are still valid.
+	defer sweepStaleIntegrationServices(t, time.Hour)
 
 	t.Run("Login", func(t *testing.T) {
 		t.Logf("Logging in with public key: %s", publicKey[:8]+"...") // Only show first 8 chars


### PR DESCRIPTION
  - New helper `sweepStaleIntegrationServices` deletes any service named `integration-*` older than 1 hour.                                
  - Called once per CI run, near the end of `TestServiceLifecycleIntegration` (<s>before its `Logout` subtest, while creds are still live</s> after `Login`).

`go test`'s outer 15m alarm, SIGKILL, or job cancellation kills the test process before deferred cleanups can run, leaving orphan services on the account. This sweeper catches those orphans on the next run. The 1-hour threshold protects in-flight services from concurrent runs.   