### PR TITLE
feat: read only mode guc injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `docs_mcp` - Enable/disable docs MCP proxy (default: `true`)
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
-- `read_only` - When `true`, write/destructive Tiger MCP tools (`service_create`, `service_fork`, `service_start`, `service_stop`, `service_resize`, `service_update_password`) refuse to run. Read tools (`service_list`, `service_get`, `service_logs`) and `db_execute_query` are unaffected. Default: `false`.
+- `read_only` - When `true`, write/destructive Tiger MCP tools (`service_create`, `service_fork`, `service_start`, `service_stop`, `service_resize`, `service_update_password`) refuse to run. Read tools are unaffected. `db_execute_query` is still available, but its database connection is opened with an immutable Tiger Cloud read-only GUC so writes and DDL are rejected by the server. Default: `false`.
 - `service_id` - Default service ID
 - `version_check_interval` - How often the CLI will check for new versions, 0 to disable (default: `24h`)
 
@@ -249,7 +249,7 @@ Environment variables override configuration file values. All variables use the 
 - `TIGER_DOCS_MCP` - Enable/disable docs MCP proxy
 - `TIGER_OUTPUT` - Output format: `json`, `yaml`, or `table`
 - `TIGER_PASSWORD_STORAGE` - Password storage method: `keyring`, `pgpass`, or `none`
-- `TIGER_READ_ONLY` - When `true`, write/destructive Tiger MCP tools refuse to run
+- `TIGER_READ_ONLY` - When `true`, write/destructive Tiger MCP tools refuse to run and `db_execute_query` runs against a read-only database connection
 - `TIGER_PUBLIC_KEY` - Public key to use for authentication (takes priority over stored credentials)
 - `TIGER_SECRET_KEY` - Secret key to use for authentication (takes priority over stored credentials)
 - `TIGER_SERVICE_ID` - Default service ID

--- a/internal/tiger/cmd/db.go
+++ b/internal/tiger/cmd/db.go
@@ -45,6 +45,7 @@ func buildDbConnectionStringCmd() *cobra.Command {
 	var dbConnectionStringPooled bool
 	var dbConnectionStringRole string
 	var dbConnectionStringWithPassword bool
+	var dbConnectionStringReadOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "connection-string [service-id]",
@@ -58,6 +59,9 @@ for establishing a database connection to the TimescaleDB/PostgreSQL service.
 By default, passwords are excluded from the connection string for security.
 Use --with-password to include the password directly in the connection string.
 
+Use --read-only to emit a connection string that opens the session in Tiger
+Cloud's immutable read-only mode (writes and DDL are rejected by the server).
+
 Examples:
   # Get connection string for default service
   tiger db connection-string
@@ -70,6 +74,9 @@ Examples:
 
   # Get connection string with custom role/username
   tiger db connection-string svc-12345 --role readonly
+
+  # Get a read-only connection string
+  tiger db connection-string svc-12345 --read-only
 
   # Get connection string with password included (less secure)
   tiger db connection-string svc-12345 --with-password`,
@@ -91,6 +98,7 @@ Examples:
 				Pooled:       dbConnectionStringPooled,
 				Role:         dbConnectionStringRole,
 				WithPassword: dbConnectionStringWithPassword,
+				ReadOnly:     dbConnectionStringReadOnly,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to build connection string: %w", err)
@@ -113,6 +121,7 @@ Examples:
 	cmd.Flags().BoolVar(&dbConnectionStringPooled, "pooled", false, "Use connection pooling")
 	cmd.Flags().StringVar(&dbConnectionStringRole, "role", "tsdbadmin", "Database role/username")
 	cmd.Flags().BoolVar(&dbConnectionStringWithPassword, "with-password", false, "Include password in connection string (less secure)")
+	cmd.Flags().BoolVar(&dbConnectionStringReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
 
 	return cmd
 }
@@ -120,6 +129,7 @@ Examples:
 func buildDbConnectCmd() *cobra.Command {
 	var dbConnectPooled bool
 	var dbConnectRole string
+	var dbConnectReadOnly bool
 
 	cmd := &cobra.Command{
 		Use:     "connect [service-id]",
@@ -155,6 +165,9 @@ Examples:
   tiger db connect svc-12345 --role readonly
   tiger db psql svc-12345 --role readonly
 
+  # Connect in read-only mode (writes and DDL are rejected by the server)
+  tiger db connect svc-12345 --read-only
+
   # Pass additional flags to psql (use -- to separate)
   tiger db connect svc-12345 -- --single-transaction --quiet
   tiger db psql svc-12345 -- -c "SELECT version();" --no-psqlrc`,
@@ -182,8 +195,9 @@ Examples:
 			}
 
 			details, err := common.GetConnectionDetails(service, common.ConnectionDetailsOptions{
-				Pooled: dbConnectPooled,
-				Role:   dbConnectRole,
+				Pooled:   dbConnectPooled,
+				Role:     dbConnectRole,
+				ReadOnly: dbConnectReadOnly,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to build connection string: %w", err)
@@ -200,6 +214,7 @@ Examples:
 	// Add flags for db connect command (works for both connect and psql)
 	cmd.Flags().BoolVar(&dbConnectPooled, "pooled", false, "Use connection pooling")
 	cmd.Flags().StringVar(&dbConnectRole, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().BoolVar(&dbConnectReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
 
 	return cmd
 }

--- a/internal/tiger/common/connection.go
+++ b/internal/tiger/common/connection.go
@@ -21,6 +21,12 @@ type ConnectionDetailsOptions struct {
 	// If provided and WithPassword is true, this password will be used
 	// instead of fetching from password storage. This is useful when password_storage=none.
 	InitialPassword string
+
+	// ReadOnly forces the connection into Tiger Cloud's immutable read-only
+	// mode by injecting the tsdb_admin.read_only_connection GUC as a startup
+	// parameter. The GUC cannot be disabled with SET for the duration of the
+	// session, so this is safe to use even when the LLM controls the SQL.
+	ReadOnly bool
 }
 
 type ConnectionDetails struct {
@@ -30,7 +36,12 @@ type ConnectionDetails struct {
 	Port     int    `json:"port,omitempty"`
 	Database string `json:"database,omitempty"`
 	IsPooler bool   `json:"is_pooler,omitempty"`
+	readOnly bool
 }
+
+// readOnlyConnectionOption is the URL-encoded `options` query parameter that
+// activates Tiger Cloud's immutable read-only connection mode.
+const readOnlyConnectionOption = "options=-c%20tsdb_admin.read_only_connection%3Dtrue"
 
 func GetConnectionDetails(service api.Service, opts ConnectionDetailsOptions) (*ConnectionDetails, error) {
 	if service.Endpoint == nil {
@@ -62,6 +73,7 @@ func GetConnectionDetails(service api.Service, opts ConnectionDetailsOptions) (*
 		Port:     *endpoint.Port,
 		Database: "tsdb", // Database is always "tsdb" for TimescaleDB/PostgreSQL services
 		IsPooler: isPooler,
+		readOnly: opts.ReadOnly,
 	}
 
 	if opts.WithPassword {
@@ -77,12 +89,17 @@ func GetConnectionDetails(service api.Service, opts ConnectionDetailsOptions) (*
 
 // String creates a PostgreSQL connection string from service details
 func (d *ConnectionDetails) String() string {
+	query := "sslmode=require"
+	if d.readOnly {
+		query += "&" + readOnlyConnectionOption
+	}
+
 	if d.Password == "" {
 		// Build connection string without password (default behavior)
-		return fmt.Sprintf("postgresql://%s@%s:%d/%s?sslmode=require", d.Role, d.Host, d.Port, d.Database)
+		return fmt.Sprintf("postgresql://%s@%s:%d/%s?%s", d.Role, d.Host, d.Port, d.Database, query)
 	}
 	// Include password in connection string
-	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=require", d.Role, d.Password, d.Host, d.Port, d.Database)
+	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?%s", d.Role, d.Password, d.Host, d.Port, d.Database, query)
 }
 
 // GetPassword fetches the password for the specified service from the

--- a/internal/tiger/common/connection_test.go
+++ b/internal/tiger/common/connection_test.go
@@ -88,6 +88,20 @@ func TestBuildConnectionString_Basic(t *testing.T) {
 			expectedIsPooler: true,
 		},
 		{
+			name: "Read-only injects tsdb_admin.read_only_connection GUC",
+			service: api.Service{
+				Endpoint: &api.Endpoint{
+					Host: util.Ptr("test-host.tigerdata.com"),
+					Port: util.Ptr(5432),
+				},
+			},
+			opts: ConnectionDetailsOptions{
+				Role:     "tsdbadmin",
+				ReadOnly: true,
+			},
+			expectedString: "postgresql://tsdbadmin@test-host.tigerdata.com:5432/tsdb?sslmode=require&options=-c%20tsdb_admin.read_only_connection%3Dtrue",
+		},
+		{
 			name: "Pooled connection fallback to direct when pooler unavailable",
 			service: api.Service{
 				Endpoint: &api.Endpoint{
@@ -378,6 +392,52 @@ func TestBuildConnectionString_WithPassword_NoPasswordAvailable(t *testing.T) {
 	expectedString := "postgresql://tsdbadmin@test-host.com:5432/tsdb?sslmode=require"
 	if result.String() != expectedString {
 		t.Errorf("Expected connection string %q, got %q", expectedString, result.String())
+	}
+}
+
+func TestBuildConnectionString_ReadOnly_WithPassword(t *testing.T) {
+	config.SetTestServiceName(t)
+
+	originalStorage := viper.GetString("password_storage")
+	viper.Set("password_storage", "keyring")
+	defer viper.Set("password_storage", originalStorage)
+
+	serviceID := "test-readonly-service"
+	projectID := "test-readonly-project"
+	host := "test-host.com"
+	port := 5432
+	service := api.Service{
+		ServiceId: &serviceID,
+		ProjectId: &projectID,
+		Endpoint: &api.Endpoint{
+			Host: &host,
+			Port: &port,
+		},
+	}
+
+	testPassword := "test-password-readonly-789"
+	role := "tsdbadmin"
+	storage := GetPasswordStorage()
+	if err := storage.Save(service, testPassword, role); err != nil {
+		t.Fatalf("Failed to save test password: %v", err)
+	}
+	defer storage.Remove(service, role)
+
+	details, err := GetConnectionDetails(service, ConnectionDetailsOptions{
+		Role:         role,
+		WithPassword: true,
+		ReadOnly:     true,
+	})
+	if err != nil {
+		t.Fatalf("GetConnectionDetails failed: %v", err)
+	}
+
+	expected := fmt.Sprintf(
+		"postgresql://tsdbadmin:%s@%s:%d/tsdb?sslmode=require&options=-c%%20tsdb_admin.read_only_connection%%3Dtrue",
+		testPassword, host, port,
+	)
+	if got := details.String(); got != expected {
+		t.Errorf("Expected connection string %q, got %q", expected, got)
 	}
 }
 

--- a/internal/tiger/mcp/db_tools.go
+++ b/internal/tiger/mcp/db_tools.go
@@ -116,6 +116,8 @@ Connects to a PostgreSQL database service in Tiger Cloud and executes the provid
 
 Multi-statement queries (semicolon-separated) are supported when no parameters are provided. All result sets are returned. By default, statements execute in an implicit transaction that automatically commits on success or rolls back on error. Explicit transactions (opened with BEGIN) must be explicitly committed with COMMIT, or they roll back when the connection closes.
 
+When read-only mode is enabled in the Tiger CLI configuration, the database connection is opened with an immutable read-only GUC, so writes and DDL will be rejected by the server regardless of the query contents.
+
 WARNING: Can execute any SQL statement including INSERT, UPDATE, DELETE, and DDL commands. Always review queries before execution.`,
 		InputSchema:  DBExecuteQueryInput{}.Schema(),
 		OutputSchema: DBExecuteQueryOutput{}.Schema(),
@@ -146,6 +148,7 @@ func (s *Server) handleDBExecuteQuery(ctx context.Context, req *mcp.CallToolRequ
 		zap.Duration("timeout", timeout),
 		zap.String("role", input.Role),
 		zap.Bool("pooled", input.Pooled),
+		zap.Bool("read_only", cfg.ReadOnly),
 	)
 
 	// Get service details to construct connection string
@@ -169,6 +172,7 @@ func (s *Server) handleDBExecuteQuery(ctx context.Context, req *mcp.CallToolRequ
 		Pooled:       input.Pooled,
 		Role:         input.Role,
 		WithPassword: true,
+		ReadOnly:     cfg.ReadOnly,
 	})
 	if err != nil {
 		return nil, DBExecuteQueryOutput{}, fmt.Errorf("failed to build connection string: %w", err)

--- a/internal/tiger/mcp/db_tools.go
+++ b/internal/tiger/mcp/db_tools.go
@@ -116,8 +116,6 @@ Connects to a PostgreSQL database service in Tiger Cloud and executes the provid
 
 Multi-statement queries (semicolon-separated) are supported when no parameters are provided. All result sets are returned. By default, statements execute in an implicit transaction that automatically commits on success or rolls back on error. Explicit transactions (opened with BEGIN) must be explicitly committed with COMMIT, or they roll back when the connection closes.
 
-When read-only mode is enabled in the Tiger CLI configuration, the database connection is opened with an immutable read-only GUC, so writes and DDL will be rejected by the server regardless of the query contents.
-
 WARNING: Can execute any SQL statement including INSERT, UPDATE, DELETE, and DDL commands. Always review queries before execution.`,
 		InputSchema:  DBExecuteQueryInput{}.Schema(),
 		OutputSchema: DBExecuteQueryOutput{}.Schema(),

--- a/internal/tiger/mcp/errors.go
+++ b/internal/tiger/mcp/errors.go
@@ -41,5 +41,7 @@ func buildServerInstructions(cfg *config.Config) string {
 	return "READ-ONLY MODE IS ENABLED. The following Tiger MCP tools will refuse to run: " +
 		strings.Join(readOnlyGatedTools, ", ") + ". " +
 		"Before asking the user to provide inputs for any of these operations, " +
-		"tell them read-only mode is on."
+		"tell them read-only mode is on. " +
+		"db_execute_query is still available, but the database connection is opened with " +
+		"an immutable read-only GUC, so writes and DDL will be rejected by the server."
 }

--- a/internal/tiger/mcp/errors.go
+++ b/internal/tiger/mcp/errors.go
@@ -41,7 +41,5 @@ func buildServerInstructions(cfg *config.Config) string {
 	return "READ-ONLY MODE IS ENABLED. The following Tiger MCP tools will refuse to run: " +
 		strings.Join(readOnlyGatedTools, ", ") + ". " +
 		"Before asking the user to provide inputs for any of these operations, " +
-		"tell them read-only mode is on. " +
-		"db_execute_query is still available, but the database connection is opened with " +
-		"an immutable read-only GUC, so writes and DDL will be rejected by the server."
+		"tell them read-only mode is on."
 }

--- a/internal/tiger/mcp/errors.go
+++ b/internal/tiger/mcp/errors.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
@@ -25,21 +24,4 @@ func checkReadOnly(cfg *config.Config) error {
 		return errReadOnly
 	}
 	return nil
-}
-
-// buildServerInstructions returns the `instructions` string the MCP SDK
-// sends to clients at initialize. Empty when read-only is off so the SDK
-// omits the field.
-//
-// Instructions are evaluated once at server start; toggling read_only
-// mid-session leaves the warning stale until the MCP client restarts. The
-// gate itself stays correct because handlers reload config per call.
-func buildServerInstructions(cfg *config.Config) string {
-	if cfg == nil || !cfg.ReadOnly {
-		return ""
-	}
-	return "READ-ONLY MODE IS ENABLED. The following Tiger MCP tools will refuse to run: " +
-		strings.Join(readOnlyGatedTools, ", ") + ". " +
-		"Before asking the user to provide inputs for any of these operations, " +
-		"tell them read-only mode is on."
 }

--- a/internal/tiger/mcp/errors_test.go
+++ b/internal/tiger/mcp/errors_test.go
@@ -30,17 +30,29 @@ func TestCheckReadOnly(t *testing.T) {
 }
 
 func TestBuildServerInstructions(t *testing.T) {
-	if got := buildServerInstructions(nil); got != "" {
-		t.Errorf("nil cfg should produce empty instructions, got %q", got)
-	}
+	const capabilitiesMarker = "Tiger MCP provides tools"
 
-	if got := buildServerInstructions(&config.Config{ReadOnly: false}); got != "" {
-		t.Errorf("read-only off should produce empty instructions, got %q", got)
+	for _, tt := range []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "nil cfg", cfg: nil},
+		{name: "read-only off", cfg: &config.Config{ReadOnly: false}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildServerInstructions(tt.cfg)
+			if !strings.Contains(got, capabilitiesMarker) {
+				t.Errorf("instructions missing capabilities blurb: %q", got)
+			}
+			if strings.Contains(got, "READ-ONLY MODE IS ENABLED") {
+				t.Errorf("instructions should not contain read-only banner when read-only is off: %q", got)
+			}
+		})
 	}
 
 	got := buildServerInstructions(&config.Config{ReadOnly: true})
-	if got == "" {
-		t.Fatal("read-only on should produce non-empty instructions")
+	if !strings.Contains(got, capabilitiesMarker) {
+		t.Errorf("instructions missing capabilities blurb: %q", got)
 	}
 	if !strings.Contains(got, "READ-ONLY MODE IS ENABLED") {
 		t.Errorf("instructions missing read-only banner: %q", got)
@@ -49,8 +61,5 @@ func TestBuildServerInstructions(t *testing.T) {
 		if !strings.Contains(got, tool) {
 			t.Errorf("instructions missing gated tool %q in: %q", tool, got)
 		}
-	}
-	if !strings.Contains(got, "db_execute_query") {
-		t.Errorf("instructions should mention db_execute_query's read-only GUC behavior: %q", got)
 	}
 }

--- a/internal/tiger/mcp/errors_test.go
+++ b/internal/tiger/mcp/errors_test.go
@@ -50,4 +50,7 @@ func TestBuildServerInstructions(t *testing.T) {
 			t.Errorf("instructions missing gated tool %q in: %q", tool, got)
 		}
 	}
+	if !strings.Contains(got, "db_execute_query") {
+		t.Errorf("instructions should mention db_execute_query's read-only GUC behavior: %q", got)
+	}
 }

--- a/internal/tiger/mcp/server.go
+++ b/internal/tiger/mcp/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -28,19 +29,33 @@ type Server struct {
 	docsProxyClient *ProxyClient
 }
 
+// buildServerInstructions returns the `instructions` string the MCP SDK
+// sends to clients at initialize.
+//
+// Instructions are evaluated once at server start; toggling read_only
+// mid-session leaves the warning stale until the MCP client restarts. The
+// gate itself stays correct because handlers reload config per call.
+func buildServerInstructions(cfg *config.Config) string {
+	base := "Tiger MCP provides tools for creating, managing, and querying Tiger Cloud database services (managed TimescaleDB/PostgreSQL). " +
+		"Use it to provision and fork services, start/stop/resize instances, rotate credentials, fetch service logs, execute SQL queries, and search Tiger documentation."
+
+	if cfg == nil || !cfg.ReadOnly {
+		return base
+	}
+	return base + " " +
+		"READ-ONLY MODE IS ENABLED. The following Tiger MCP tools will refuse to run: " +
+		strings.Join(readOnlyGatedTools, ", ") + ". " +
+		"Before asking the user to provide inputs for any of these operations, tell them read-only mode is on."
+}
+
 // NewServer creates a new Tiger MCP server instance. The caller-supplied cfg
 // is used only to render the read-only warning in server instructions.
 func NewServer(ctx context.Context, cfg *config.Config) (*Server, error) {
-	var opts *mcp.ServerOptions
-	if instructions := buildServerInstructions(cfg); instructions != "" {
-		opts = &mcp.ServerOptions{Instructions: instructions}
-	}
-
 	mcpServer := mcp.NewServer(&mcp.Implementation{
 		Name:    ServerName,
 		Title:   serverTitle,
 		Version: config.Version,
-	}, opts)
+	}, &mcp.ServerOptions{Instructions: buildServerInstructions(cfg)})
 
 	server := &Server{
 		mcpServer: mcpServer,

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -423,6 +423,11 @@ tiger db connect svc-12345 --pooled --role readonly -- --no-psqlrc -v ON_ERROR_S
 tiger db connection-string svc-12345
 # Get pooled connection string
 tiger db connection-string svc-12345 --pooled
+# Get a read-only connection string (Tiger Cloud immutable read-only GUC)
+tiger db connection-string svc-12345 --read-only
+
+# Connect in read-only mode (writes and DDL rejected by the server)
+tiger db connect svc-12345 --read-only
 
 # Test database connectivity
 tiger db test-connection svc-12345

--- a/specs/spec_mcp.md
+++ b/specs/spec_mcp.md
@@ -71,9 +71,11 @@ Tools gated by read-only mode:
 - `service_resize`
 - `service_update_password`
 
+`db_execute_query` is **not** gated — instead, when read-only mode is enabled the database connection used by the tool is opened with the `tsdb_admin.read_only_connection=true` GUC injected as a startup `options` parameter. This is a Tiger Cloud GUC that activates an immutable read-only connection for the session, so writes and DDL are rejected by the server itself and cannot be re-enabled by the LLM with a `SET` statement.
+
 To toggle: `tiger config set read_only true` / `tiger config unset read_only`.
 
-When read-only mode is enabled, the MCP server includes a warning in its `initialize` response `instructions` field listing the gated tools and asking the LLM to inform the user before gathering inputs for them. The instructions are read at server start; if the user toggles `read_only` mid-session, the warning is stale until the MCP client restarts (the gate itself is unaffected because handlers reload config per call).
+When read-only mode is enabled, the MCP server includes a warning in its `initialize` response `instructions` field listing the gated tools, mentioning that `db_execute_query` runs against a read-only connection, and asking the LLM to inform the user before gathering inputs for the gated tools. The instructions are read at server start; if the user toggles `read_only` mid-session, the warning is stale until the MCP client restarts (the gate and the GUC injection are both unaffected because handlers reload config per call).
 
 ### CLI MCP Commands
 


### PR DESCRIPTION
When read-only mode is enabled, the `db_execute_query` MCP tool and the new `--read-only` CLI flag open the database connection with Tiger Cloud's `tsdb_admin.read_only_connection=true`. The GUC is immutable for the session, so writes and DDL are rejected by the server regardless of the SQL the caller (or LLM) sends.
