### PR TITLE
Read only cli commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ The Tiger MCP server provides AI assistants with programmatic access to Tiger re
 
 **Read-Only Mode Gate:**
 
-Write/destructive MCP tool handlers must call `checkReadOnly(cfg.Config)` (defined in `internal/tiger/mcp/errors.go`) immediately after `common.LoadConfig(ctx)`. When `cfg.ReadOnly` is `true`, the handler returns `errReadOnly` and the API client is never invoked.
+Write/destructive MCP tool handlers and CLI command `RunE` functions must call `common.CheckReadOnly(cfg.Config)` (defined in `internal/tiger/common/errors.go`) immediately after `common.LoadConfig(ctx)`. When `cfg.ReadOnly` is `true`, the call returns `common.ErrReadOnly` and the API client is never invoked. The gated CLI commands today are `service create`, `service fork`, `service start`, `service stop`, `service resize`, `service update-password`, and `service delete`.
 
 **Tool Definition Pattern:**
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `docs_mcp` - Enable/disable docs MCP proxy (default: `true`)
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
-- `read_only` - When `true`, write/destructive operations refuse to run for both the CLI and the Tiger MCP server. The gated CLI commands are `tiger service create`, `service fork`, `service start`, `service stop`, `service resize`, `service update-password`, and `service delete`; the corresponding MCP tools (`service_create`, `service_fork`, `service_start`, `service_stop`, `service_resize`, `service_update_password`) refuse to run as well. Read commands/tools are unaffected. `db_execute_query` is still available, but its database connection is opened with an immutable Tiger Cloud read-only GUC so writes and DDL are rejected by the server. Default: `false`.
+- `read_only` - When `true`, mutating operations are refused: the `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` CLI commands and their MCP equivalents return an error, and `tiger db connect`, `tiger db connection-string`, and the `db_execute_query` MCP tool open the database session in Tiger Cloud's immutable read-only mode (writes and DDL are rejected by the server). Read commands/tools are unaffected. Default: `false`.
 - `service_id` - Default service ID
 - `version_check_interval` - How often the CLI will check for new versions, 0 to disable (default: `24h`)
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `docs_mcp` - Enable/disable docs MCP proxy (default: `true`)
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
-- `read_only` - When `true`, write/destructive Tiger MCP tools (`service_create`, `service_fork`, `service_start`, `service_stop`, `service_resize`, `service_update_password`) refuse to run. Read tools are unaffected. `db_execute_query` is still available, but its database connection is opened with an immutable Tiger Cloud read-only GUC so writes and DDL are rejected by the server. Default: `false`.
+- `read_only` - When `true`, write/destructive operations refuse to run for both the CLI and the Tiger MCP server. The gated CLI commands are `tiger service create`, `service fork`, `service start`, `service stop`, `service resize`, `service update-password`, and `service delete`; the corresponding MCP tools (`service_create`, `service_fork`, `service_start`, `service_stop`, `service_resize`, `service_update_password`) refuse to run as well. Read commands/tools are unaffected. `db_execute_query` is still available, but its database connection is opened with an immutable Tiger Cloud read-only GUC so writes and DDL are rejected by the server. Default: `false`.
 - `service_id` - Default service ID
 - `version_check_interval` - How often the CLI will check for new versions, 0 to disable (default: `24h`)
 
@@ -249,7 +249,7 @@ Environment variables override configuration file values. All variables use the 
 - `TIGER_DOCS_MCP` - Enable/disable docs MCP proxy
 - `TIGER_OUTPUT` - Output format: `json`, `yaml`, or `table`
 - `TIGER_PASSWORD_STORAGE` - Password storage method: `keyring`, `pgpass`, or `none`
-- `TIGER_READ_ONLY` - When `true`, write/destructive Tiger MCP tools refuse to run and `db_execute_query` runs against a read-only database connection
+- `TIGER_READ_ONLY` - When `true`, write/destructive CLI commands and Tiger MCP tools refuse to run, and `db_execute_query` runs against a read-only database connection
 - `TIGER_PUBLIC_KEY` - Public key to use for authentication (takes priority over stored credentials)
 - `TIGER_SECRET_KEY` - Secret key to use for authentication (takes priority over stored credentials)
 - `TIGER_SERVICE_ID` - Default service ID

--- a/internal/tiger/cmd/db.go
+++ b/internal/tiger/cmd/db.go
@@ -145,11 +145,16 @@ from your configuration. This command will launch an interactive psql session
 with the appropriate connection parameters.
 
 Authentication is handled automatically using:
-1. Stored password (keyring, ~/.pgpass, or none based on --password-storage setting)  
+1. Stored password (keyring, ~/.pgpass, or none based on --password-storage setting)
 2. PGPASSWORD environment variable
 3. If authentication fails, offers interactive options:
    - Enter password manually (will be saved for future use)
    - Reset password (update or generates a new password via the API)
+
+Use --read-only to open the psql session in Tiger Cloud's immutable read-only
+mode (writes and DDL are rejected by the server). The global read_only config
+option (or TIGER_READ_ONLY=true) also forces this behavior, so sessions started
+while read-only mode is on are always read-only.
 
 Examples:
   # Connect to default service

--- a/internal/tiger/cmd/db.go
+++ b/internal/tiger/cmd/db.go
@@ -61,6 +61,9 @@ Use --with-password to include the password directly in the connection string.
 
 Use --read-only to emit a connection string that opens the session in Tiger
 Cloud's immutable read-only mode (writes and DDL are rejected by the server).
+The global read_only config option (or TIGER_READ_ONLY=true) also forces this
+behavior, so connection strings produced while read-only mode is on always
+open read-only sessions.
 
 Examples:
   # Get connection string for default service
@@ -98,7 +101,7 @@ Examples:
 				Pooled:       dbConnectionStringPooled,
 				Role:         dbConnectionStringRole,
 				WithPassword: dbConnectionStringWithPassword,
-				ReadOnly:     dbConnectionStringReadOnly,
+				ReadOnly:     dbConnectionStringReadOnly || cfg.ReadOnly,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to build connection string: %w", err)
@@ -197,7 +200,7 @@ Examples:
 			details, err := common.GetConnectionDetails(service, common.ConnectionDetailsOptions{
 				Pooled:   dbConnectPooled,
 				Role:     dbConnectRole,
-				ReadOnly: dbConnectReadOnly,
+				ReadOnly: dbConnectReadOnly || cfg.ReadOnly,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to build connection string: %w", err)

--- a/internal/tiger/cmd/db_test.go
+++ b/internal/tiger/cmd/db_test.go
@@ -1462,3 +1462,65 @@ func TestDBSavePassword_PgpassStorage(t *testing.T) {
 		t.Errorf("Expected password %q, got %q", testPassword, retrievedPassword)
 	}
 }
+
+// TestDBConnectionString_ReadOnlyConfig verifies that the global read_only
+// config option forces the read-only GUC into the emitted connection string
+// even when --read-only is not passed on the command line.
+func TestDBConnectionString_ReadOnlyConfig(t *testing.T) {
+	const readOnlyMarker = "tsdb_admin.read_only_connection"
+
+	cases := []struct {
+		name      string
+		readOnly  bool
+		extraArgs []string
+		want      bool
+	}{
+		{"flag off, config off", false, nil, false},
+		{"flag on, config off", false, []string{"--read-only"}, true},
+		{"flag off, config on", true, nil, true},
+		{"flag on, config on", true, []string{"--read-only"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := setupDBTest(t)
+
+			_, err := config.UseTestConfig(tmpDir, map[string]any{
+				"api_url":    "http://localhost:9999",
+				"project_id": "test-project-123",
+				"service_id": "svc-ro-test",
+				"read_only":  tc.readOnly,
+			})
+			if err != nil {
+				t.Fatalf("Failed to save test config: %v", err)
+			}
+
+			originalGetCredentials := common.GetCredentials
+			common.GetCredentials = func() (string, string, error) {
+				return "test-api-key", "test-project-123", nil
+			}
+			t.Cleanup(func() { common.GetCredentials = originalGetCredentials })
+
+			originalGetServiceDetails := getServiceDetailsFunc
+			getServiceDetailsFunc = func(cmd *cobra.Command, cfg *common.Config, args []string) (api.Service, error) {
+				host := "test-host.com"
+				port := 5432
+				return api.Service{
+					Endpoint: &api.Endpoint{Host: &host, Port: &port},
+				}, nil
+			}
+			t.Cleanup(func() { getServiceDetailsFunc = originalGetServiceDetails })
+
+			args := append([]string{"db", "connection-string"}, tc.extraArgs...)
+			out, err := executeDBCommand(t.Context(), args...)
+			if err != nil {
+				t.Fatalf("executeDBCommand failed: %v", err)
+			}
+
+			got := strings.Contains(out, readOnlyMarker)
+			if got != tc.want {
+				t.Errorf("read-only marker present = %v, want %v\noutput: %s", got, tc.want, out)
+			}
+		})
+	}
+}

--- a/internal/tiger/cmd/service.go
+++ b/internal/tiger/cmd/service.go
@@ -293,6 +293,10 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 				return err
 			}
 
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
+				return err
+			}
+
 			// Prepare service creation request
 			environmentTag := api.EnvironmentTag(createEnvironment)
 			serviceCreateReq := api.ServiceCreate{
@@ -447,6 +451,11 @@ Examples:
 			// Load config and API client
 			cfg, err := common.LoadConfig(cmd.Context())
 			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
 				cmd.SilenceUsage = true
 				return err
 			}
@@ -825,6 +834,17 @@ Examples:
 
 			cmd.SilenceUsage = true
 
+			// Load config before the confirmation prompt so read-only mode
+			// refuses without asking the user to type the service ID.
+			cfg, err := common.LoadConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
+				return err
+			}
+
 			statusOutput := cmd.ErrOrStderr()
 
 			// Prompt for confirmation unless --confirm is used
@@ -842,12 +862,6 @@ Examples:
 					fmt.Fprintln(statusOutput, "❌ Delete operation cancelled.")
 					return nil
 				}
-			}
-
-			// Load config and API client
-			cfg, err := common.LoadConfig(cmd.Context())
-			if err != nil {
-				return err
 			}
 
 			// Make the delete request
@@ -930,6 +944,11 @@ Examples:
 			// Load config and API client
 			cfg, err := common.LoadConfig(cmd.Context())
 			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
 				cmd.SilenceUsage = true
 				return err
 			}
@@ -1030,6 +1049,11 @@ Examples:
 			// Load config and API client
 			cfg, err := common.LoadConfig(cmd.Context())
 			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
 				cmd.SilenceUsage = true
 				return err
 			}
@@ -1192,6 +1216,11 @@ Examples:
 			// Load config and API client
 			cfg, err := common.LoadConfig(cmd.Context())
 			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
 				cmd.SilenceUsage = true
 				return err
 			}
@@ -1397,6 +1426,11 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			// Load config and API client
 			cfg, err := common.LoadConfig(cmd.Context())
 			if err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
+
+			if err := common.CheckReadOnly(cfg.Config); err != nil {
 				cmd.SilenceUsage = true
 				return err
 			}

--- a/internal/tiger/cmd/service_test.go
+++ b/internal/tiger/cmd/service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -1764,5 +1765,50 @@ func TestServiceResize_InvalidCPUMemoryCombination(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "invalid CPU/Memory combination") {
 		t.Errorf("Expected invalid combination error, got: %v", err)
+	}
+}
+
+// TestDestructiveCommands_ReadOnly verifies that destructive service commands
+// refuse to run when read_only mode is enabled, before any API call is made.
+func TestDestructiveCommands_ReadOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"create", []string{"service", "create", "--addons", "none", "--region", "us-east-1", "--cpu", "1000", "--memory", "4", "--replicas", "1"}},
+		{"fork", []string{"service", "fork", "source-service-123", "--now"}},
+		{"start", []string{"service", "start", "source-service-123"}},
+		{"stop", []string{"service", "stop", "source-service-123"}},
+		{"resize", []string{"service", "resize", "source-service-123", "--cpu", "1000", "--memory", "4"}},
+		{"update-password", []string{"service", "update-password", "source-service-123", "--auto-generate"}},
+		{"delete", []string{"service", "delete", "source-service-123", "--confirm"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := setupServiceTest(t)
+
+			_, err := config.UseTestConfig(tmpDir, map[string]any{
+				"api_url":   "http://localhost:9999",
+				"read_only": true,
+			})
+			if err != nil {
+				t.Fatalf("Failed to save test config: %v", err)
+			}
+
+			originalGetCredentials := common.GetCredentials
+			common.GetCredentials = func() (string, string, error) {
+				return "test-api-key", "test-project-123", nil
+			}
+			defer func() { common.GetCredentials = originalGetCredentials }()
+
+			_, err, _ = executeServiceCommand(t.Context(), tc.args...)
+			if err == nil {
+				t.Fatalf("Expected error in read-only mode for %q, got nil", tc.name)
+			}
+			if !errors.Is(err, common.ErrReadOnly) {
+				t.Errorf("Expected common.ErrReadOnly for %q, got: %v", tc.name, err)
+			}
+		})
 	}
 }

--- a/internal/tiger/cmd/service_test.go
+++ b/internal/tiger/cmd/service_test.go
@@ -1770,44 +1770,38 @@ func TestServiceResize_InvalidCPUMemoryCombination(t *testing.T) {
 
 // TestDestructiveCommands_ReadOnly verifies that destructive service commands
 // refuse to run when read_only mode is enabled, before any API call is made.
+// The localhost:9999 api_url would surface any unintended request as a
+// connection-refused error rather than ErrReadOnly.
 func TestDestructiveCommands_ReadOnly(t *testing.T) {
-	cases := []struct {
-		name string
-		args []string
-	}{
-		{"create", []string{"service", "create", "--addons", "none", "--region", "us-east-1", "--cpu", "1000", "--memory", "4", "--replicas", "1"}},
-		{"fork", []string{"service", "fork", "source-service-123", "--now"}},
-		{"start", []string{"service", "start", "source-service-123"}},
-		{"stop", []string{"service", "stop", "source-service-123"}},
-		{"resize", []string{"service", "resize", "source-service-123", "--cpu", "1000", "--memory", "4"}},
-		{"update-password", []string{"service", "update-password", "source-service-123", "--auto-generate"}},
-		{"delete", []string{"service", "delete", "source-service-123", "--confirm"}},
+	tmpDir := setupServiceTest(t)
+	if _, err := config.UseTestConfig(tmpDir, map[string]any{
+		"api_url":   "http://localhost:9999",
+		"read_only": true,
+	}); err != nil {
+		t.Fatalf("Failed to save test config: %v", err)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := setupServiceTest(t)
+	originalGetCredentials := common.GetCredentials
+	common.GetCredentials = func() (string, string, error) {
+		return "test-api-key", "test-project-123", nil
+	}
+	t.Cleanup(func() { common.GetCredentials = originalGetCredentials })
 
-			_, err := config.UseTestConfig(tmpDir, map[string]any{
-				"api_url":   "http://localhost:9999",
-				"read_only": true,
-			})
-			if err != nil {
-				t.Fatalf("Failed to save test config: %v", err)
-			}
+	cases := [][]string{
+		{"service", "create", "--addons", "none", "--region", "us-east-1", "--cpu", "1000", "--memory", "4", "--replicas", "1"},
+		{"service", "fork", "source-service-123", "--now"},
+		{"service", "start", "source-service-123"},
+		{"service", "stop", "source-service-123"},
+		{"service", "resize", "source-service-123", "--cpu", "1000", "--memory", "4"},
+		{"service", "update-password", "source-service-123", "--auto-generate"},
+		{"service", "delete", "source-service-123", "--confirm"},
+	}
 
-			originalGetCredentials := common.GetCredentials
-			common.GetCredentials = func() (string, string, error) {
-				return "test-api-key", "test-project-123", nil
-			}
-			defer func() { common.GetCredentials = originalGetCredentials }()
-
-			_, err, _ = executeServiceCommand(t.Context(), tc.args...)
-			if err == nil {
-				t.Fatalf("Expected error in read-only mode for %q, got nil", tc.name)
-			}
+	for _, args := range cases {
+		t.Run(args[1], func(t *testing.T) {
+			_, err, _ := executeServiceCommand(t.Context(), args...)
 			if !errors.Is(err, common.ErrReadOnly) {
-				t.Errorf("Expected common.ErrReadOnly for %q, got: %v", tc.name, err)
+				t.Errorf("Expected common.ErrReadOnly, got: %v", err)
 			}
 		})
 	}

--- a/internal/tiger/common/errors.go
+++ b/internal/tiger/common/errors.go
@@ -1,6 +1,23 @@
 package common
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/timescale/tiger-cli/internal/tiger/config"
+)
+
+// ErrReadOnly is returned when a destructive operation is attempted while
+// read-only mode is enabled in the user's config.
+var ErrReadOnly = errors.New("this operation is not allowed in read-only mode")
+
+// CheckReadOnly returns ErrReadOnly if read-only mode is enabled. Callers
+// should invoke this before any destructive API call.
+func CheckReadOnly(cfg *config.Config) error {
+	if cfg != nil && cfg.ReadOnly {
+		return ErrReadOnly
+	}
+	return nil
+}
 
 // Exit codes as defined in the CLI specification
 const (

--- a/internal/tiger/common/errors.go
+++ b/internal/tiger/common/errors.go
@@ -13,7 +13,7 @@ var ErrReadOnly = errors.New("this operation is not allowed in read-only mode")
 // CheckReadOnly returns ErrReadOnly if read-only mode is enabled. Callers
 // should invoke this before any destructive API call.
 func CheckReadOnly(cfg *config.Config) error {
-	if cfg != nil && cfg.ReadOnly {
+	if cfg.ReadOnly {
 		return ErrReadOnly
 	}
 	return nil

--- a/internal/tiger/common/errors_test.go
+++ b/internal/tiger/common/errors_test.go
@@ -1,9 +1,33 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
+
+func TestCheckReadOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantErr error
+	}{
+		{name: "nil cfg allows writes", cfg: nil, wantErr: nil},
+		{name: "read-only off allows writes", cfg: &config.Config{ReadOnly: false}, wantErr: nil},
+		{name: "read-only on blocks writes", cfg: &config.Config{ReadOnly: true}, wantErr: ErrReadOnly},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckReadOnly(tt.cfg)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("CheckReadOnly(%+v) error = %v, want %v", tt.cfg, err, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestExitCodeError(t *testing.T) {
 	// Test the ExitCodeError type

--- a/internal/tiger/common/errors_test.go
+++ b/internal/tiger/common/errors_test.go
@@ -14,7 +14,6 @@ func TestCheckReadOnly(t *testing.T) {
 		cfg     *config.Config
 		wantErr error
 	}{
-		{name: "nil cfg allows writes", cfg: nil, wantErr: nil},
 		{name: "read-only off allows writes", cfg: &config.Config{ReadOnly: false}, wantErr: nil},
 		{name: "read-only on blocks writes", cfg: &config.Config{ReadOnly: true}, wantErr: ErrReadOnly},
 	}

--- a/internal/tiger/mcp/errors.go
+++ b/internal/tiger/mcp/errors.go
@@ -1,13 +1,5 @@
 package mcp
 
-import (
-	"errors"
-
-	"github.com/timescale/tiger-cli/internal/tiger/config"
-)
-
-var errReadOnly = errors.New("this operation is not allowed in read-only mode")
-
 var readOnlyGatedTools = []string{
 	toolServiceCreate,
 	toolServiceFork,
@@ -15,11 +7,4 @@ var readOnlyGatedTools = []string{
 	toolServiceStop,
 	toolServiceResize,
 	toolServiceUpdatePassword,
-}
-
-func checkReadOnly(cfg *config.Config) error {
-	if cfg.ReadOnly {
-		return errReadOnly
-	}
-	return nil
 }

--- a/internal/tiger/mcp/errors_test.go
+++ b/internal/tiger/mcp/errors_test.go
@@ -1,33 +1,11 @@
 package mcp
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
 	"github.com/timescale/tiger-cli/internal/tiger/config"
 )
-
-func TestCheckReadOnly(t *testing.T) {
-	tests := []struct {
-		name     string
-		readOnly bool
-		wantErr  error
-	}{
-		{name: "read-only off allows writes", readOnly: false, wantErr: nil},
-		{name: "read-only on blocks writes", readOnly: true, wantErr: errReadOnly},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{ReadOnly: tt.readOnly}
-			err := checkReadOnly(cfg)
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("checkReadOnly(ReadOnly=%t) error = %v, want %v", tt.readOnly, err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func TestBuildServerInstructions(t *testing.T) {
 	const capabilitiesMarker = "Tiger MCP provides tools"

--- a/internal/tiger/mcp/service_tools.go
+++ b/internal/tiger/mcp/service_tools.go
@@ -681,7 +681,7 @@ func (s *Server) handleServiceCreate(ctx context.Context, req *mcp.CallToolReque
 		return nil, ServiceCreateOutput{}, err
 	}
 
-	if err := checkReadOnly(cfg.Config); err != nil {
+	if err := common.CheckReadOnly(cfg.Config); err != nil {
 		return nil, ServiceCreateOutput{}, err
 	}
 
@@ -801,7 +801,7 @@ func (s *Server) handleServiceFork(ctx context.Context, req *mcp.CallToolRequest
 		return nil, ServiceForkOutput{}, err
 	}
 
-	if err := checkReadOnly(cfg.Config); err != nil {
+	if err := common.CheckReadOnly(cfg.Config); err != nil {
 		return nil, ServiceForkOutput{}, err
 	}
 
@@ -931,7 +931,7 @@ func (s *Server) handleServiceUpdatePassword(ctx context.Context, req *mcp.CallT
 		return nil, ServiceUpdatePasswordOutput{}, err
 	}
 
-	if err := checkReadOnly(cfg.Config); err != nil {
+	if err := common.CheckReadOnly(cfg.Config); err != nil {
 		return nil, ServiceUpdatePasswordOutput{}, err
 	}
 
@@ -988,7 +988,7 @@ func (s *Server) handleServiceStart(ctx context.Context, req *mcp.CallToolReques
 		return nil, ServiceStartOutput{}, err
 	}
 
-	if err := checkReadOnly(cfg.Config); err != nil {
+	if err := common.CheckReadOnly(cfg.Config); err != nil {
 		return nil, ServiceStartOutput{}, err
 	}
 
@@ -1053,7 +1053,7 @@ func (s *Server) handleServiceStop(ctx context.Context, req *mcp.CallToolRequest
 		return nil, ServiceStopOutput{}, err
 	}
 
-	if err := checkReadOnly(cfg.Config); err != nil {
+	if err := common.CheckReadOnly(cfg.Config); err != nil {
 		return nil, ServiceStopOutput{}, err
 	}
 
@@ -1118,7 +1118,7 @@ func (s *Server) handleServiceResize(ctx context.Context, req *mcp.CallToolReque
 		return nil, ServiceResizeOutput{}, err
 	}
 
-	if err := checkReadOnly(cfg.Config); err != nil {
+	if err := common.CheckReadOnly(cfg.Config); err != nil {
 		return nil, ServiceResizeOutput{}, err
 	}
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -32,6 +32,7 @@ Environment variables override configuration file values. All variables use the 
 - `TIGER_DOCS_MCP` - Enable/disable docs MCP proxy
 - `TIGER_OUTPUT` - Output format: json, yaml, or table
 - `TIGER_PASSWORD_STORAGE` - Password storage method: keyring, pgpass, or none
+- `TIGER_READ_ONLY` - When `true`, write/destructive CLI commands and Tiger MCP tools refuse to run
 - `TIGER_SERVICE_ID` - Default service ID
 - `TIGER_VERSION_CHECK_INTERVAL` - How often the CLI will check for new versions, 0 to disable
 
@@ -47,6 +48,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `docs_mcp` - Enable/disable docs MCP proxy (default: true)
 - `output` - Output format: json, yaml, or table (default: table)
 - `password_storage` - Password storage method: keyring, pgpass, or none (default: keyring)
+- `read_only` - When `true`, write/destructive CLI commands (`tiger service create`, `fork`, `start`, `stop`, `resize`, `update-password`, `delete`) and Tiger MCP tools refuse to run; `db_execute_query` is opened against an immutable read-only database connection (default: false). See `specs/spec_mcp.md` for the MCP-side details.
 - `service_id` - Default service ID
 - `version_check_interval` - How often the CLI will check for new versions, 0 to disable (default: 24h)
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -48,7 +48,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `docs_mcp` - Enable/disable docs MCP proxy (default: true)
 - `output` - Output format: json, yaml, or table (default: table)
 - `password_storage` - Password storage method: keyring, pgpass, or none (default: keyring)
-- `read_only` - When `true`, write/destructive CLI commands (`tiger service create`, `fork`, `start`, `stop`, `resize`, `update-password`, `delete`) and Tiger MCP tools refuse to run; `db_execute_query` is opened against an immutable read-only database connection (default: false). See `specs/spec_mcp.md` for the MCP-side details.
+- `read_only` - When `true`, mutating operations are refused: `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` and their MCP equivalents return an error, and `tiger db connect`/`connection-string`/`db_execute_query` open against an immutable read-only database connection regardless of `--read-only` (default: false). See `specs/spec_mcp.md` for details.
 - `service_id` - Default service ID
 - `version_check_interval` - How often the CLI will check for new versions, 0 to disable (default: 24h)
 

--- a/specs/spec_mcp.md
+++ b/specs/spec_mcp.md
@@ -61,17 +61,13 @@ The MCP server will automatically use the CLI's stored authentication and config
 
 ### Read-Only Mode
 
-When the `read_only` config option is `true` (or `TIGER_READ_ONLY=true`), write/destructive MCP tools refuse to run and return an error. The same flag also gates the corresponding CLI commands (`tiger service create`, `service fork`, `service start`, `service stop`, `service resize`, `service update-password`, `service delete`), so flipping it on prevents accidental mutation through either entry point. This is intended for AI agent setups that need to inspect Tiger Cloud resources without risk of mutation.
+When `read_only` is `true` (or `TIGER_READ_ONLY=true`), Tiger refuses any mutating operation:
 
-Tools gated by read-only mode:
-- `service_create`
-- `service_fork`
-- `service_start`
-- `service_stop`
-- `service_resize`
-- `service_update_password`
+- **Tiger MCP** — write tools (`service_create`, `service_fork`, `service_start`, `service_stop`, `service_resize`, `service_update_password`) return an error.
+- **Tiger CLI** — the matching `tiger service` subcommands (plus `service delete`) return an error.
+- **Database sessions** — `tiger db connect`, `tiger db connection-string`, and the `db_execute_query` MCP tool open with `tsdb_admin.read_only_connection=true` even without `--read-only`.
 
-`db_execute_query` is **not** gated — instead, when read-only mode is enabled the database connection used by the tool is opened with the `tsdb_admin.read_only_connection=true` GUC injected as a startup `options` parameter. This is a Tiger Cloud GUC that activates an immutable read-only connection for the session, so writes and DDL are rejected by the server itself and cannot be re-enabled by the LLM with a `SET` statement.
+Intended for AI agents that should be able to read Tiger Cloud resources without risk of mutation. `tsdb_admin.read_only_connection` is a Tiger Cloud GUC injected as a startup `options` parameter; it activates an immutable read-only connection so writes and DDL are rejected by the server itself and cannot be re-enabled with a `SET` statement.
 
 To toggle: `tiger config set read_only true` / `tiger config unset read_only`.
 

--- a/specs/spec_mcp.md
+++ b/specs/spec_mcp.md
@@ -61,7 +61,7 @@ The MCP server will automatically use the CLI's stored authentication and config
 
 ### Read-Only Mode
 
-When the `read_only` config option is `true` (or `TIGER_READ_ONLY=true`), write/destructive MCP tools refuse to run and return an error. This is intended for AI agent setups that need to inspect Tiger Cloud resources without risk of mutation.
+When the `read_only` config option is `true` (or `TIGER_READ_ONLY=true`), write/destructive MCP tools refuse to run and return an error. The same flag also gates the corresponding CLI commands (`tiger service create`, `service fork`, `service start`, `service stop`, `service resize`, `service update-password`, `service delete`), so flipping it on prevents accidental mutation through either entry point. This is intended for AI agent setups that need to inspect Tiger Cloud resources without risk of mutation.
 
 Tools gated by read-only mode:
 - `service_create`


### PR DESCRIPTION
Extend read-only mode enforcement to CLI commands and DB connections
  
Previously, read-only mode only blocked MCP tool calls. This PR extends the gate to:
  - CLI destructive commands — service create/fork/start/stop/resize/update-password/delete now call `common.CheckReadOnly` before any API request
  - DB connections — db connection-string and db connect now OR the `--read-only` flag with `cfg.ReadOnly`, so the global config forces read-only PostgreSQL sessions even without the flag

@ggodeke requested the change, we prefer a more locked-down experience in the tiger CLI compared to ghost
