### PR TITLE
feat(auth): add read-only mode hint to login next steps

### DIFF
--- a/internal/tiger/cmd/auth.go
+++ b/internal/tiger/cmd/auth.go
@@ -31,6 +31,7 @@ const nextStepsMessage = `
 • Install MCP server for your favorite AI coding tool: tiger mcp install
 • List existing services: tiger service list
 • Create a new service: tiger service create
+• Enable read-only mode: tiger config set read_only true
 `
 
 type credentials struct {


### PR DESCRIPTION
## Summary
Adds a hint about read-only mode to the post-login next-steps message to create more awareness of the feature after install.

The new bullet appears in `tiger auth login`'s success output:
```
🎉 Next steps:
• Install MCP server for your favorite AI coding tool: tiger mcp install
• List existing services: tiger service list
• Create a new service: tiger service create
• Enable read-only mode: tiger config set read_only true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)