### PR TITLE
feat: send CLI User-Agent on the OAuth token exchange

### DIFF
--- a/internal/tiger/api/client_util.go
+++ b/internal/tiger/api/client_util.go
@@ -44,7 +44,7 @@ func NewTigerClient(cfg *config.Config, apiKey string) (*ClientWithResponses, er
 	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(apiKey))
 	client, err := NewClientWithResponses(cfg.APIURL, WithHTTPClient(getHTTPClient()), WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", authHeader)
-		req.Header.Set("User-Agent", fmt.Sprintf("tiger-cli/%s", config.Version))
+		req.Header.Set("User-Agent", config.UserAgent())
 		return nil
 	}))
 	if err != nil {
@@ -82,7 +82,7 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 	httpClient.Timeout = 30 * time.Second
 
 	client, err := NewClientWithResponses(cfg.APIURL, WithHTTPClient(httpClient), WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
-		req.Header.Set("User-Agent", fmt.Sprintf("tiger-cli/%s", config.Version))
+		req.Header.Set("User-Agent", config.UserAgent())
 		return nil
 	}))
 	if err != nil {

--- a/internal/tiger/api/client_util_test.go
+++ b/internal/tiger/api/client_util_test.go
@@ -50,7 +50,7 @@ func TestNewTigerClientUserAgent(t *testing.T) {
 	}
 
 	// Verify the User-Agent header was set correctly
-	expectedUserAgent := "tiger-cli/" + config.Version
+	expectedUserAgent := config.UserAgent()
 	if capturedUserAgent != expectedUserAgent {
 		t.Errorf("Expected User-Agent %q, got %q", expectedUserAgent, capturedUserAgent)
 	}

--- a/internal/tiger/cmd/auth_test.go
+++ b/internal/tiger/cmd/auth_test.go
@@ -232,6 +232,10 @@ func startMockOAuthServer(t *testing.T, projects []api.Project) *httptest.Server
 				http.Error(w, "Missing required parameters", http.StatusBadRequest)
 				return
 			}
+			// Exchange must carry the CLI User-Agent.
+			if ua := r.Header.Get("User-Agent"); !strings.HasPrefix(ua, "tiger-cli/") {
+				t.Errorf("code exchange User-Agent = %q, want \"tiger-cli/\" prefix", ua)
+			}
 		}
 
 		tokenResponse := map[string]interface{}{

--- a/internal/tiger/cmd/oauth.go
+++ b/internal/tiger/cmd/oauth.go
@@ -167,6 +167,14 @@ type oauthCallback struct {
 	resultChan    chan<- oauthResult
 }
 
+// userAgentTransport sets the CLI User-Agent on outgoing requests.
+type userAgentTransport struct{}
+
+func (userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", config.UserAgent())
+	return http.DefaultTransport.RoundTrip(req)
+}
+
 func (c *oauthCallback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
@@ -188,8 +196,10 @@ func (c *oauthCallback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Exchange authorization code for tokens
-	token, err := c.oauthCfg.Exchange(r.Context(), code, oauth2.VerifierOption(c.codeVerifier))
+	// The exchange's User-Agent is recorded as the CLI session's user_agent.
+	ctx := context.WithValue(r.Context(), oauth2.HTTPClient,
+		&http.Client{Transport: userAgentTransport{}})
+	token, err := c.oauthCfg.Exchange(ctx, code, oauth2.VerifierOption(c.codeVerifier))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "Failed to exchange authorization code for tokens")

--- a/internal/tiger/config/version.go
+++ b/internal/tiger/config/version.go
@@ -1,7 +1,17 @@
 package config
 
+import (
+	"fmt"
+	"runtime"
+)
+
 // These variables are set at build time via ldflags in the GoReleaser pipeline
 // for production releases. Default values are used for local development builds.
 var Version = "dev"
 var BuildTime = "unknown"
 var GitCommit = "unknown"
+
+// UserAgent returns the User-Agent the CLI sends on HTTP requests.
+func UserAgent() string {
+	return fmt.Sprintf("tiger-cli/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
The login token exchange used oauth2's default HTTP client, so it sent no `tiger-cli` User-Agent — the gateway recorded the CLI session's `device_name` as the Go default. This routes the exchange through a client that sets the CLI User-Agent (enriched with OS/arch, `tiger-cli/<version> (os/arch)`) via a shared `config.UserAgent()` helper reused by the API client.

Completes the CLI side of session device-info recording:
- **tiger-cli** (this PR) — sends the User-Agent on the token exchange.
- timescale/savannah-gateway#1837 — forwards `x-forwarded-user-agent` / `x-forwarded-for` to the User service.
- timescale/savannah-users#560 — records `device_name` / `device_ip` on the session.