### PR TITLE
Make commands and flags case-insensitive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1183,6 +1183,10 @@ Examples:
 3. **Consistent Prefixes** - Use `--no-` for negative overrides
 4. **Avoid Abbreviations** - Prefer `--no-wait` over `--nowait`
 
+### Case Insensitivity
+
+Commands, aliases, and flags are matched case-insensitively (configured in `root.go`). Always declare them in lowercase — that's the canonical form. Two names that differ only in case are a collision and must be avoided.
+
 These patterns ensure Tiger CLI maintains consistency with modern CLI tools while providing a predictable user experience.
 
 ## GitHub Workflows

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/timescale/tiger-cli/internal/analytics"
 	"github.com/timescale/tiger-cli/internal/common"
@@ -18,6 +20,11 @@ import (
 )
 
 func buildRootCmd(ctx context.Context) (*cobra.Command, error) {
+	// Match command names and aliases case-insensitively (e.g. `tiger SERVICE
+	// LIST` works the same as `tiger service list`). Cobra only exposes this as
+	// a global.
+	cobra.EnableCaseInsensitive = true
+
 	// TIGER_EXPERIMENTAL toggles preview-stage commands and MCP tools. Read at
 	// build time so ungated subtrees are never added to the command tree — the
 	// command literally does not exist when the env var is unset/false, so it
@@ -53,6 +60,12 @@ tiger auth login
 	// without this every cmd.Printf would land on stderr.
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
+
+	// Match flag names case-insensitively (e.g. `--Output` works the same as
+	// `--output`). Propagates to all subcommands added after this point.
+	cmd.SetGlobalNormalizationFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName(strings.ToLower(name))
+	})
 
 	// Add persistent flags. Values are read back from the config (see
 	// flagBindings in internal/config) rather than from the flag variables, so


### PR DESCRIPTION
Commands, aliases, and flag names are now matched case-insensitively, so `TiGeR SeRvIcE LiSt --OuTpUt json` behaves the same as the lowercase form, rather than returning an error.

Note that shorthand flags (e.g. `-o` for `--output`) remain case-sensitive. Additionally, argument and flag values are generally still case-sensitive (e.g. the output flag value must still be `json` - `JsON` doesn't work). We could change that on a case-by-case basis if we want, but I don't think it needs to happen now. Lowercase remains the canonical form for declarations, noted in CLAUDE.md.

It's worth noting that this would cause problems if we ever had two commands or flags that differed only in case. But I doubt that's a pattern we're likely to adopt.
