### PR TITLE
Sync openapi.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,12 +357,12 @@ Note that not all config options have corresponding global flags, and not all gl
 ### Experimental Feature Gating
 
 Some surfaces (currently `tiger service metrics …` CLI commands and the
-`service_metrics_*` MCP tools) call gateway endpoints marked `x-preview: true`
-in `openapi.yaml` — their request/response shape is still in flux. Upstream
-(`savannah-gateway/internal/rest/openapi.yaml`) uses the same marker; the
-Stainless SDK pipeline drops `x-preview` operations entirely, but
-oapi-codegen ignores the extension, so tiger-cli's generated v1 client
-includes them. We gate access at registration time, behind an
+`service_metrics_*` MCP tools) call gateway endpoints marked
+`x-tigerdata-preview: true` in `openapi.yaml` — their request/response shape is
+still in flux. Upstream (`savannah-gateway/internal/rest/openapi.yaml`) uses the
+same marker; the Stainless SDK pipeline drops `x-tigerdata-preview` operations
+entirely, but oapi-codegen ignores the extension, so tiger-cli's generated v1
+client includes them. We gate access at registration time, behind an
 intentionally-undocumented env var — `TIGER_EXPERIMENTAL` (default `false`).
 
 **This is env-var only** — deliberately not a config-file key, not a flag, and
@@ -375,8 +375,8 @@ and the MCP server read at registration time.
 - MCP: `NewServer` passes `app.Experimental` to `registerServiceTools(readOnly, experimental bool)`, which guards the metrics tool `addTool` calls the same way, so the tools aren't advertised to MCP clients when the env var is off. Restart the MCP server after toggling.
 
 **Do not mention `TIGER_EXPERIMENTAL` in user-facing docs, command help, spec
-files, or error messages.** When a feature graduates, remove the `x-preview:
-true` marker upstream, delete the `if app.Experimental { … }` / `if experimental
+files, or error messages.** When a feature graduates, remove the
+`x-tigerdata-preview: true` marker upstream, delete the `if app.Experimental { … }` / `if experimental
 { … }` wrappers (both CLI and MCP), drop the `experimental bool` parameter from
 `registerServiceTools`, and remove the `Experimental` field from `common.App`. The
 call sites already use the normal v1 client — no client wiring needs to change.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -156,6 +156,11 @@ type ClientInterface interface {
 
 	GetServiceMetricsSeries(ctx context.Context, projectID ProjectID, serviceID ServiceID, body GetServiceMetricsSeriesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RenameServiceWithBody request with any body
+	RenameServiceWithBody(ctx context.Context, projectID ProjectID, serviceID ServiceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RenameService(ctx context.Context, projectID ProjectID, serviceID ServiceID, body RenameServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetReplicaSets request
 	GetReplicaSets(ctx context.Context, projectID ProjectID, serviceID ServiceID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -533,6 +538,30 @@ func (c *Client) GetServiceMetricsSeriesWithBody(ctx context.Context, projectID 
 
 func (c *Client) GetServiceMetricsSeries(ctx context.Context, projectID ProjectID, serviceID ServiceID, body GetServiceMetricsSeriesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetServiceMetricsSeriesRequest(c.Server, projectID, serviceID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RenameServiceWithBody(ctx context.Context, projectID ProjectID, serviceID ServiceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRenameServiceRequestWithBody(c.Server, projectID, serviceID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RenameService(ctx context.Context, projectID ProjectID, serviceID ServiceID, body RenameServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRenameServiceRequest(c.Server, projectID, serviceID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1560,9 +1589,9 @@ func NewGetServiceLogsRequest(server string, projectID ProjectID, serviceID Serv
 
 		}
 
-		if params.Page != nil {
+		if params.Cursor != nil {
 
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -1608,9 +1637,25 @@ func NewGetServiceLogsRequest(server string, projectID ProjectID, serviceID Serv
 
 		}
 
-		if params.Cursor != nil {
+		if params.Search != nil {
 
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "search", runtime.ParamLocationQuery, *params.Search); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Severities != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "severities", runtime.ParamLocationQuery, *params.Severities); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -1711,6 +1756,60 @@ func NewGetServiceMetricsSeriesRequestWithBody(server string, projectID ProjectI
 	}
 
 	operationPath := fmt.Sprintf("/projects/%s/services/%s/metrics/series", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRenameServiceRequest calls the generic RenameService builder with application/json body
+func NewRenameServiceRequest(server string, projectID ProjectID, serviceID ServiceID, body RenameServiceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRenameServiceRequestWithBody(server, projectID, serviceID, "application/json", bodyReader)
+}
+
+// NewRenameServiceRequestWithBody generates requests for RenameService with any type of body
+func NewRenameServiceRequestWithBody(server string, projectID ProjectID, serviceID ServiceID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "project_id", runtime.ParamLocationPath, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "service_id", runtime.ParamLocationPath, serviceID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/services/%s/rename", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2907,6 +3006,11 @@ type ClientWithResponsesInterface interface {
 
 	GetServiceMetricsSeriesWithResponse(ctx context.Context, projectID ProjectID, serviceID ServiceID, body GetServiceMetricsSeriesJSONRequestBody, reqEditors ...RequestEditorFn) (*GetServiceMetricsSeriesResponse, error)
 
+	// RenameServiceWithBodyWithResponse request with any body
+	RenameServiceWithBodyWithResponse(ctx context.Context, projectID ProjectID, serviceID ServiceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RenameServiceResponse, error)
+
+	RenameServiceWithResponse(ctx context.Context, projectID ProjectID, serviceID ServiceID, body RenameServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*RenameServiceResponse, error)
+
 	// GetReplicaSetsWithResponse request
 	GetReplicaSetsWithResponse(ctx context.Context, projectID ProjectID, serviceID ServiceID, reqEditors ...RequestEditorFn) (*GetReplicaSetsResponse, error)
 
@@ -3383,6 +3487,29 @@ func (r GetServiceMetricsSeriesResponse) StatusCode() int {
 	return 0
 }
 
+type RenameServiceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Service
+	JSON4XX      *ClientError
+}
+
+// Status returns HTTPResponse.Status
+func (r RenameServiceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RenameServiceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetReplicaSetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3500,6 +3627,7 @@ func (r EnableReplicaPoolerResponse) StatusCode() int {
 type ResizeReplicaSetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON202      *SuccessMessage
 	JSON4XX      *ClientError
 }
 
@@ -3864,7 +3992,7 @@ func (r GetVPCPeeringResponse) StatusCode() int {
 type RenameVPCResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *VPC
+	JSON200      *SuccessMessage
 	JSON4XX      *ClientError
 }
 
@@ -4099,6 +4227,23 @@ func (c *ClientWithResponses) GetServiceMetricsSeriesWithResponse(ctx context.Co
 		return nil, err
 	}
 	return ParseGetServiceMetricsSeriesResponse(rsp)
+}
+
+// RenameServiceWithBodyWithResponse request with arbitrary body returning *RenameServiceResponse
+func (c *ClientWithResponses) RenameServiceWithBodyWithResponse(ctx context.Context, projectID ProjectID, serviceID ServiceID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RenameServiceResponse, error) {
+	rsp, err := c.RenameServiceWithBody(ctx, projectID, serviceID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRenameServiceResponse(rsp)
+}
+
+func (c *ClientWithResponses) RenameServiceWithResponse(ctx context.Context, projectID ProjectID, serviceID ServiceID, body RenameServiceJSONRequestBody, reqEditors ...RequestEditorFn) (*RenameServiceResponse, error) {
+	rsp, err := c.RenameService(ctx, projectID, serviceID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRenameServiceResponse(rsp)
 }
 
 // GetReplicaSetsWithResponse request returning *GetReplicaSetsResponse
@@ -4926,6 +5071,39 @@ func ParseGetServiceMetricsSeriesResponse(rsp *http.Response) (*GetServiceMetric
 	return response, nil
 }
 
+// ParseRenameServiceResponse parses an HTTP response from a RenameServiceWithResponse call
+func ParseRenameServiceResponse(rsp *http.Response) (*RenameServiceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RenameServiceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Service
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 4:
+		var dest ClientError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON4XX = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetReplicaSetsResponse parses an HTTP response from a GetReplicaSetsWithResponse call
 func ParseGetReplicaSetsResponse(rsp *http.Response) (*GetReplicaSetsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -5098,6 +5276,13 @@ func ParseResizeReplicaSetResponse(rsp *http.Response) (*ResizeReplicaSetRespons
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest SuccessMessage
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode/100 == 4:
 		var dest ClientError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -5599,7 +5784,7 @@ func ParseRenameVPCResponse(rsp *http.Response) (*RenameVPCResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest VPC
+		var dest SuccessMessage
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/api/mocks/mock_client.go
+++ b/internal/api/mocks/mock_client.go
@@ -862,6 +862,46 @@ func (mr *MockClientInterfaceMockRecorder) LogoutWithBody(ctx, contentType, body
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogoutWithBody", reflect.TypeOf((*MockClientInterface)(nil).LogoutWithBody), varargs...)
 }
 
+// RenameService mocks base method.
+func (m *MockClientInterface) RenameService(ctx context.Context, projectID api.ProjectID, serviceID api.ServiceID, body api.RenameServiceJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectID, serviceID, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RenameService", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameService indicates an expected call of RenameService.
+func (mr *MockClientInterfaceMockRecorder) RenameService(ctx, projectID, serviceID, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectID, serviceID, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameService", reflect.TypeOf((*MockClientInterface)(nil).RenameService), varargs...)
+}
+
+// RenameServiceWithBody mocks base method.
+func (m *MockClientInterface) RenameServiceWithBody(ctx context.Context, projectID api.ProjectID, serviceID api.ServiceID, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectID, serviceID, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RenameServiceWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameServiceWithBody indicates an expected call of RenameServiceWithBody.
+func (mr *MockClientInterfaceMockRecorder) RenameServiceWithBody(ctx, projectID, serviceID, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectID, serviceID, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameServiceWithBody", reflect.TypeOf((*MockClientInterface)(nil).RenameServiceWithBody), varargs...)
+}
+
 // RenameVPC mocks base method.
 func (m *MockClientInterface) RenameVPC(ctx context.Context, projectID api.ProjectID, vpcID api.VPCId, body api.RenameVPCJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -2024,6 +2064,46 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) LogoutWithResponse(ctx, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogoutWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).LogoutWithResponse), varargs...)
+}
+
+// RenameServiceWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RenameServiceWithBodyWithResponse(ctx context.Context, projectID api.ProjectID, serviceID api.ServiceID, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*api.RenameServiceResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectID, serviceID, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RenameServiceWithBodyWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.RenameServiceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameServiceWithBodyWithResponse indicates an expected call of RenameServiceWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RenameServiceWithBodyWithResponse(ctx, projectID, serviceID, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectID, serviceID, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameServiceWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RenameServiceWithBodyWithResponse), varargs...)
+}
+
+// RenameServiceWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RenameServiceWithResponse(ctx context.Context, projectID api.ProjectID, serviceID api.ServiceID, body api.RenameServiceJSONRequestBody, reqEditors ...api.RequestEditorFn) (*api.RenameServiceResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, projectID, serviceID, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RenameServiceWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.RenameServiceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RenameServiceWithResponse indicates an expected call of RenameServiceWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RenameServiceWithResponse(ctx, projectID, serviceID, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, projectID, serviceID, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameServiceWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RenameServiceWithResponse), varargs...)
 }
 
 // RenameVPCWithBodyWithResponse mocks base method.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -9,6 +9,11 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+const (
+	BasicAuthScopes  = "basicAuth.Scopes"
+	BearerAuthScopes = "bearerAuth.Scopes"
+)
+
 // Defines values for AuthInfoType.
 const (
 	AuthInfoTypeAPIKey AuthInfoType = "apiKey"
@@ -87,93 +92,131 @@ const (
 )
 
 // AuthInfo Information about the authentication credentials being used. Exactly one
-// of `apiKey` or `oauth` is populated; the `type` field discriminates.
+// of `api_key` or `oauth` is populated; the `type` field discriminates.
 type AuthInfo struct {
-	// APIKey Information about the API key credentials
-	APIKey *struct {
-		// Created When the client credentials were created
-		Created time.Time `json:"created"`
+	// APIKeyDeprecated Deprecated. Use `api_key` instead.
+	// Deprecated: Use `api_key` instead.
+	APIKeyDeprecated *AuthInfoAPIKey `json:"apiKey,omitempty"`
 
-		// IssuingUser Information about the user who created the credentials
-		IssuingUser struct {
-			// Email The user's email
-			Email openapi_types.Email `json:"email"`
-
-			// ID The user ID
-			ID string `json:"id"`
-
-			// Name The user's name
-			Name string `json:"name"`
-		} `json:"issuing_user"`
-
-		// Name The name of the credential
-		Name string `json:"name"`
-
-		// Project Information about the project
-		Project struct {
-			// ID The project ID
-			ID string `json:"id"`
-
-			// Name The name of the project
-			Name string `json:"name"`
-
-			// PlanType The plan type for the project
-			PlanType string `json:"plan_type"`
-		} `json:"project"`
-
-		// PublicKey The public key of the client credentials
-		PublicKey string `json:"public_key"`
-	} `json:"apiKey,omitempty"`
+	// APIKey Information about the API key credentials (PAT).
+	APIKey *AuthInfoAPIKey `json:"api_key,omitempty"`
 
 	// Oauth OAuth user details. Present for OAuth user callers.
-	Oauth *struct {
-		User struct {
-			// Email The user's email
-			Email openapi_types.Email `json:"email"`
+	Oauth *AuthInfoOAuth `json:"oauth,omitempty"`
 
-			// ID The numeric user ID
-			ID string `json:"id"`
-
-			// Name The user's name
-			Name string `json:"name"`
-		} `json:"user"`
-	} `json:"oauth,omitempty"`
-
-	// Type Discriminator for the credential shape. `apiKey` for PAT callers;
-	// `oauth` for OAuth user callers.
+	// Type Discriminator for the credential shape. `apiKey` for PAT callers; `oauth` for OAuth
+	// user callers.
 	Type AuthInfoType `json:"type"`
 }
 
-// AuthInfoType Discriminator for the credential shape. `apiKey` for PAT callers;
-// `oauth` for OAuth user callers.
+// AuthInfoType Discriminator for the credential shape. `apiKey` for PAT callers; `oauth` for OAuth
+// user callers.
 type AuthInfoType string
 
-// ConnectionPooler defines model for ConnectionPooler.
+// AuthInfoAPIKey Information about the API key credentials (PAT).
+type AuthInfoAPIKey struct {
+	// Created When the client credentials were created.
+	Created time.Time `json:"created"`
+
+	// IssuingUser Information about the user who created the credentials.
+	IssuingUser AuthInfoIssuingUser `json:"issuing_user"`
+
+	// Name The name of the credential.
+	Name string `json:"name"`
+
+	// Project Information about the project.
+	Project AuthInfoProject `json:"project"`
+
+	// PublicKey The public key of the client credentials.
+	PublicKey string `json:"public_key"`
+}
+
+// AuthInfoIssuingUser Information about the user who created the credentials.
+type AuthInfoIssuingUser struct {
+	// Email The user's email.
+	Email openapi_types.Email `json:"email"`
+
+	// ID The user ID.
+	ID string `json:"id"`
+
+	// Name The user's name.
+	Name string `json:"name"`
+}
+
+// AuthInfoOAuth OAuth user details. Present for OAuth user callers.
+type AuthInfoOAuth struct {
+	// User The authenticated OAuth user.
+	User AuthInfoUser `json:"user"`
+}
+
+// AuthInfoProject Information about the project.
+type AuthInfoProject struct {
+	// ID The project ID.
+	ID string `json:"id"`
+
+	// Name The name of the project.
+	Name string `json:"name"`
+
+	// PlanType The plan type for the project.
+	PlanType string `json:"plan_type"`
+}
+
+// AuthInfoUser The authenticated OAuth user.
+type AuthInfoUser struct {
+	// Email The user's email.
+	Email openapi_types.Email `json:"email"`
+
+	// ID The numeric user ID.
+	ID string `json:"id"`
+
+	// Name The user's name.
+	Name string `json:"name"`
+}
+
+// ConnectionPooler Connection pooler configuration for a service.
 type ConnectionPooler struct {
+	// Endpoint A network endpoint for connecting to a service.
 	Endpoint *Endpoint `json:"endpoint,omitempty"`
 }
 
-// DeployStatus defines model for DeployStatus.
+// DeployStatus The current deployment status of the service:
+// - QUEUED: the create request has been submitted and is queued
+// - DELETING: the service is being deleted
+// - CONFIGURING: the service is up but still completing configuration
+// - READY: fully configured and serving traffic
+// - DELETED: the service has been deleted
+// - UNSTABLE: the service was ready but is not currently reachable
+// - PAUSING: the service is being paused
+// - PAUSED: the service is paused (temporarily shut down)
+// - RESUMING: the service is resuming after being paused
+// - UPGRADING: the service is being updated
+//
+// OPTIMIZING is deprecated and should not be used.
 type DeployStatus string
 
-// Endpoint defines model for Endpoint.
+// Endpoint A network endpoint for connecting to a service.
 type Endpoint struct {
+	// Host The hostname of the endpoint.
 	Host *string `json:"host,omitempty"`
-	Port *int    `json:"port,omitempty"`
+
+	// Port The port of the endpoint.
+	Port *int `json:"port,omitempty"`
 }
 
-// EnvironmentTag The environment tag for the service.
+// EnvironmentTag The environment tag for the service:
+// - DEV: a development environment
+// - PROD: a production environment
 type EnvironmentTag string
 
-// Error defines model for Error.
+// Error An error returned when a request cannot be completed.
 type Error struct {
+	// Code A machine-readable error code.
 	Code *string `json:"code,omitempty"`
 
-	// Details Additional context about the failure. Often the actionable part
-	// of the error (e.g. "bearer auth is not enabled on this server"
-	// for a generic UNAUTHORIZED). Optional; absent on errors with no
-	// extra detail.
+	// Details additional context, sent by the API but not yet in its spec. Hand-added, not regenerated from openapi.yaml.
 	Details *string `json:"details,omitempty"`
+
+	// Message A human-readable error message.
 	Message *string `json:"message,omitempty"`
 }
 
@@ -183,7 +226,7 @@ type ForkServiceCreate struct {
 	// CPUMillis The initial CPU allocation in milli-cores, or 'shared' for a shared-resource service. If not provided, will inherit from parent service.
 	CPUMillis *string `json:"cpu_millis,omitempty"`
 
-	// EnvironmentTag The environment tag for the service.
+	// EnvironmentTag The environment tag for the forked service.
 	EnvironmentTag *EnvironmentTag `json:"environment_tag,omitempty"`
 
 	// ForkStrategy Strategy for creating the fork:
@@ -202,10 +245,15 @@ type ForkServiceCreate struct {
 	TargetTime *time.Time `json:"target_time,omitempty"`
 }
 
-// ForkSpec defines model for ForkSpec.
+// ForkSpec The service this service was forked from.
 type ForkSpec struct {
-	IsStandby *bool   `json:"is_standby,omitempty"`
+	// IsStandby Whether this service is a standby of the parent service.
+	IsStandby *bool `json:"is_standby,omitempty"`
+
+	// ProjectID The project of the parent service.
 	ProjectID *string `json:"project_id,omitempty"`
+
+	// ServiceID The ID of the parent service.
 	ServiceID *string `json:"service_id,omitempty"`
 }
 
@@ -215,7 +263,7 @@ type ForkSpec struct {
 // - PITR: Point-in-time recovery using target_time
 type ForkStrategy string
 
-// HAReplica defines model for HAReplica.
+// HAReplica High-availability replica configuration for a service.
 type HAReplica struct {
 	// ReplicaCount Number of high-availability replicas (all replicas are asynchronous by default).
 	ReplicaCount *int `json:"replica_count,omitempty"`
@@ -229,10 +277,10 @@ type MetricDataPoint struct {
 	// Time The bucket start timestamp.
 	Time time.Time `json:"time"`
 
-	// Value The aggregated value at this bucket. Buckets without collected
-	// data are omitted from the parent series' `data` array; the API
-	// does not currently emit null values.
-	Value *float64 `json:"value,omitempty"`
+	// Value The aggregated value at this bucket, or null for a gap bucket with
+	// no collected data. Gap buckets are still emitted (one entry per
+	// bucket in the window), so this is null rather than omitted.
+	Value *float64 `json:"value"`
 }
 
 // MetricLabelFilter A single key/value label match applied to a metric series query.
@@ -274,8 +322,10 @@ type MetricsSeriesRequest struct {
 	// response are lowercased.
 	Filters *[]MetricLabelFilter `json:"filters,omitempty"`
 
-	// Fn Aggregation function applied per bucket. Optional: when omitted,
-	// the server picks the default for the metric (currently `LAST`).
+	// Fn Aggregation function applied to raw/pre-aggregated samples when
+	// collapsing them into one value per output bucket. Optional: when
+	// omitted the server picks the default for the metric (currently
+	// `LAST`).
 	//
 	// Not accepted on the following metrics — requests are rejected
 	// with `INVALID_REQUEST`:
@@ -294,6 +344,18 @@ type MetricsSeriesRequest struct {
 	//   - `timescale_cloud_database_num_connections`
 	//   - `timescale_cloud_database_job_duration_usecs`
 	//   - `timescale_cloud_database_job_success`
+	//
+	// Values:
+	//   - `RATE`: counter-reset-aware per-second rate of change.
+	//   - `INCREASE`: counter-reset-aware total increase over the bucket.
+	//   - `SUM`: sum of samples in the bucket.
+	//   - `AVG`: mean of samples in the bucket.
+	//   - `MIN`: minimum sample in the bucket.
+	//   - `MAX`: maximum sample in the bucket.
+	//   - `COUNT`: number of samples in the bucket.
+	//   - `P50` / `P90` / `P99`: percentile approximations (only valid
+	//     for metrics stored as sketches).
+	//   - `LAST`: the most recent sample in the bucket (default).
 	Fn *MetricsSeriesRequestFn `json:"fn,omitempty"`
 
 	// From Start of the time window (RFC3339; nanosecond precision accepted).
@@ -306,8 +368,10 @@ type MetricsSeriesRequest struct {
 	To time.Time `json:"to"`
 }
 
-// MetricsSeriesRequestFn Aggregation function applied per bucket. Optional: when omitted,
-// the server picks the default for the metric (currently `LAST`).
+// MetricsSeriesRequestFn Aggregation function applied to raw/pre-aggregated samples when
+// collapsing them into one value per output bucket. Optional: when
+// omitted the server picks the default for the metric (currently
+// `LAST`).
 //
 // Not accepted on the following metrics — requests are rejected
 // with `INVALID_REQUEST`:
@@ -326,60 +390,109 @@ type MetricsSeriesRequest struct {
 //   - `timescale_cloud_database_num_connections`
 //   - `timescale_cloud_database_job_duration_usecs`
 //   - `timescale_cloud_database_job_success`
+//
+// Values:
+//   - `RATE`: counter-reset-aware per-second rate of change.
+//   - `INCREASE`: counter-reset-aware total increase over the bucket.
+//   - `SUM`: sum of samples in the bucket.
+//   - `AVG`: mean of samples in the bucket.
+//   - `MIN`: minimum sample in the bucket.
+//   - `MAX`: maximum sample in the bucket.
+//   - `COUNT`: number of samples in the bucket.
+//   - `P50` / `P90` / `P99`: percentile approximations (only valid
+//     for metrics stored as sketches).
+//   - `LAST`: the most recent sample in the bucket (default).
 type MetricsSeriesRequestFn string
 
-// Peering defines model for Peering.
+// Peering A VPC peering connection to an external cloud account.
 type Peering struct {
-	ErrorMessage   *string `json:"error_message,omitempty"`
-	ID             *string `json:"id,omitempty"`
-	PeerAccountID  *string `json:"peer_account_id,omitempty"`
-	PeerRegionCode *string `json:"peer_region_code,omitempty"`
-	PeerVpcID      *string `json:"peer_vpc_id,omitempty"`
-	ProvisionedID  *string `json:"provisioned_id,omitempty"`
-	Status         *string `json:"status,omitempty"`
-}
+	// ErrorMessage A human-readable error message when the peering connection failed.
+	ErrorMessage *string `json:"error_message,omitempty"`
 
-// PeeringCreate defines model for PeeringCreate.
-type PeeringCreate struct {
-	PeerAccountID  string `json:"peer_account_id"`
+	// ID The unique identifier for the peering connection.
+	ID *string `json:"id,omitempty"`
+
+	// PeerAccountID The cloud account ID of the peer VPC.
+	PeerAccountID string `json:"peer_account_id"`
+
+	// PeerRegionCode The cloud region of the peer VPC.
 	PeerRegionCode string `json:"peer_region_code"`
-	PeerVpcID      string `json:"peer_vpc_id"`
+
+	// PeerVpcID The ID of the peer VPC.
+	PeerVpcID string `json:"peer_vpc_id"`
+
+	// ProvisionedID The provider-assigned identifier for the provisioned peering.
+	ProvisionedID *string `json:"provisioned_id,omitempty"`
+
+	// Status The current status of the peering connection.
+	Status *string `json:"status,omitempty"`
 }
 
-// Project defines model for Project.
+// PeeringCreate Parameters for creating a VPC peering connection.
+type PeeringCreate struct {
+	// PeerAccountID The cloud account ID of the peer VPC.
+	PeerAccountID string `json:"peer_account_id"`
+
+	// PeerRegionCode The cloud region of the peer VPC.
+	PeerRegionCode string `json:"peer_region_code"`
+
+	// PeerVpcID The ID of the peer VPC.
+	PeerVpcID string `json:"peer_vpc_id"`
+}
+
+// Project A project that organizes your Tiger Cloud resources, such as services and VPCs.
 type Project struct {
-	ID   string `json:"id"`
+	// ID The unique identifier for the project.
+	ID string `json:"id"`
+
+	// Name The name of the project.
 	Name string `json:"name"`
 }
 
-// ReadReplicaSet defines model for ReadReplicaSet.
+// ReadReplicaSet A set of read replicas for a service.
 type ReadReplicaSet struct {
+	// ConnectionPooler Connection pooler configuration for a service.
 	ConnectionPooler *ConnectionPooler `json:"connection_pooler,omitempty"`
 
 	// CPUMillis CPU allocation in milli-cores.
-	CPUMillis *int      `json:"cpu_millis,omitempty"`
-	Endpoint  *Endpoint `json:"endpoint,omitempty"`
-	ID        *string   `json:"id,omitempty"`
+	CPUMillis int `json:"cpu_millis"`
+
+	// Endpoint A network endpoint for connecting to a service.
+	Endpoint *Endpoint `json:"endpoint,omitempty"`
+
+	// ID The unique identifier for the read replica set.
+	ID string `json:"id"`
 
 	// MemoryGbs Memory allocation in gigabytes.
-	MemoryGbs *int `json:"memory_gbs,omitempty"`
+	MemoryGbs int `json:"memory_gbs"`
 
-	// Metadata Additional metadata for the read replica set
-	Metadata *struct {
-		// Environment Environment tag for the read replica set
-		Environment *string `json:"environment,omitempty"`
-	} `json:"metadata,omitempty"`
-	Name *string `json:"name,omitempty"`
+	// Metadata Additional metadata for the read replica set.
+	Metadata *ReplicaSetMetadata `json:"metadata,omitempty"`
+
+	// Name The name of the read replica set.
+	Name string `json:"name"`
 
 	// Nodes Number of nodes in the replica set.
-	Nodes  *int                  `json:"nodes,omitempty"`
-	Status *ReadReplicaSetStatus `json:"status,omitempty"`
+	Nodes int `json:"nodes"`
+
+	// Status The current status of the read replica set:
+	// - creating: the replica set is being provisioned
+	// - active: the replica set is provisioned and serving traffic
+	// - resizing: the replica set is being resized
+	// - deleting: the replica set is being deleted
+	// - error: the replica set is in an error state
+	Status ReadReplicaSetStatus `json:"status"`
 }
 
-// ReadReplicaSetStatus defines model for ReadReplicaSet.Status.
+// ReadReplicaSetStatus The current status of the read replica set:
+// - creating: the replica set is being provisioned
+// - active: the replica set is provisioned and serving traffic
+// - resizing: the replica set is being resized
+// - deleting: the replica set is being deleted
+// - error: the replica set is in an error state
 type ReadReplicaSetStatus string
 
-// ReadReplicaSetCreate defines model for ReadReplicaSetCreate.
+// ReadReplicaSetCreate Parameters for creating a read replica set.
 type ReadReplicaSetCreate struct {
 	// CPUMillis The initial CPU allocation in milli-cores.
 	CPUMillis int `json:"cpu_millis"`
@@ -394,7 +507,13 @@ type ReadReplicaSetCreate struct {
 	Nodes int `json:"nodes"`
 }
 
-// ResizeInput defines model for ResizeInput.
+// ReplicaSetMetadata Additional metadata for the read replica set.
+type ReplicaSetMetadata struct {
+	// Environment Environment tag for the read replica set.
+	Environment *string `json:"environment,omitempty"`
+}
+
+// ResizeInput Parameters for resizing a service.
 type ResizeInput struct {
 	// CPUMillis The new CPU allocation in milli-cores.
 	CPUMillis string `json:"cpu_millis"`
@@ -403,63 +522,86 @@ type ResizeInput struct {
 	MemoryGbs string `json:"memory_gbs"`
 }
 
-// Service defines model for Service.
+// Resource A resource allocated to the service.
+type Resource struct {
+	// ID Resource identifier.
+	ID *string `json:"id,omitempty"`
+
+	// Spec Resource specification.
+	Spec *ResourceSpec `json:"spec,omitempty"`
+}
+
+// ResourceSpec Resource specification.
+type ResourceSpec struct {
+	// CPUMillis CPU allocation in millicores.
+	CPUMillis *int `json:"cpu_millis,omitempty"`
+
+	// MemoryGbs Memory allocation in gigabytes.
+	MemoryGbs *int `json:"memory_gbs,omitempty"`
+
+	// VolumeType Type of storage volume.
+	VolumeType *string `json:"volume_type,omitempty"`
+}
+
+// Service A database service and its current configuration.
 type Service struct {
+	// ConnectionPooler Connection pooler configuration for a service.
 	ConnectionPooler *ConnectionPooler `json:"connection_pooler,omitempty"`
 
-	// Created Creation timestamp
-	Created    *time.Time `json:"created,omitempty"`
-	Endpoint   *Endpoint  `json:"endpoint,omitempty"`
-	ForkedFrom *ForkSpec  `json:"forked_from,omitempty"`
+	// Created Creation timestamp.
+	Created time.Time `json:"created"`
+
+	// Endpoint A network endpoint for connecting to a service.
+	Endpoint *Endpoint `json:"endpoint,omitempty"`
+
+	// ForkedFrom The service this service was forked from.
+	ForkedFrom *ForkSpec `json:"forked_from,omitempty"`
+
+	// HaReplicas High-availability replica configuration for a service.
 	HaReplicas *HAReplica `json:"ha_replicas,omitempty"`
 
 	// InitialPassword The initial password for the service.
 	InitialPassword *string `json:"initial_password,omitempty"`
 
-	// Metadata Additional metadata for the service
-	Metadata *struct {
-		// Environment Environment tag for the service
-		Environment *string `json:"environment,omitempty"`
-	} `json:"metadata,omitempty"`
+	// Metadata Additional metadata for the service.
+	Metadata *ServiceMetadata `json:"metadata,omitempty"`
+
+	// Metrics Resource usage metrics for the service.
+	Metrics *ServiceMetrics `json:"metrics"`
 
 	// Name The name of the service.
-	Name *string `json:"name,omitempty"`
+	Name string `json:"name"`
 
 	// ProjectID The project this service belongs to.
-	ProjectID       *string           `json:"project_id,omitempty"`
+	ProjectID string `json:"project_id"`
+
+	// ReadReplicaSets The read replica sets attached to the service.
 	ReadReplicaSets *[]ReadReplicaSet `json:"read_replica_sets,omitempty"`
 
 	// RegionCode The cloud region where the service is hosted.
-	RegionCode *string `json:"region_code,omitempty"`
+	RegionCode string `json:"region_code"`
 
-	// Resources List of resources allocated to the service
-	Resources *[]struct {
-		// ID Resource identifier
-		ID *string `json:"id,omitempty"`
-
-		// Spec Resource specification
-		Spec *struct {
-			// CPUMillis CPU allocation in millicores
-			CPUMillis *int `json:"cpu_millis,omitempty"`
-
-			// MemoryGbs Memory allocation in gigabytes
-			MemoryGbs *int `json:"memory_gbs,omitempty"`
-
-			// VolumeType Type of storage volume
-			VolumeType *string `json:"volume_type,omitempty"`
-		} `json:"spec,omitempty"`
-	} `json:"resources,omitempty"`
+	// Resources List of resources allocated to the service.
+	Resources []Resource `json:"resources"`
 
 	// ServiceID The unique identifier for the service.
-	ServiceID   *string       `json:"service_id,omitempty"`
-	ServiceType *ServiceType  `json:"service_type,omitempty"`
-	Status      *DeployStatus `json:"status,omitempty"`
+	ServiceID string `json:"service_id"`
 
-	// VpcEndpoint VPC endpoint configuration if available
-	VpcEndpoint *map[string]interface{} `json:"vpcEndpoint"`
+	// ServiceType The type of the service.
+	ServiceType ServiceType `json:"service_type"`
+
+	// Status Current status of the service.
+	Status DeployStatus `json:"status"`
+
+	// VpcEndpointDeprecated Deprecated. Use `vpc_endpoint` instead.
+	// Deprecated: Use `vpc_endpoint` instead.
+	VpcEndpointDeprecated *VPCEndpoint `json:"vpcEndpoint,omitempty"`
+
+	// VpcEndpoint VPC endpoint configuration if available.
+	VpcEndpoint *VPCEndpoint `json:"vpc_endpoint,omitempty"`
 }
 
-// ServiceCreate defines model for ServiceCreate.
+// ServiceCreate Parameters for creating a service.
 type ServiceCreate struct {
 	// Addons List of addons to enable for the service. 'time-series' enables TimescaleDB, 'ai' enables AI/vector extensions.
 	Addons *[]ServiceCreateAddons `json:"addons,omitempty"`
@@ -486,46 +628,88 @@ type ServiceCreate struct {
 // ServiceCreateAddons defines model for ServiceCreate.Addons.
 type ServiceCreateAddons string
 
-// ServiceLogEntry defines model for ServiceLogEntry.
+// ServiceLogEntry A single structured log entry from a service.
 type ServiceLogEntry struct {
-	// Message Log message text
+	// Message Log message text.
 	Message string `json:"message"`
 
-	// Severity PostgreSQL severity level (e.g. LOG, WARNING, ERROR, FATAL)
+	// Severity PostgreSQL severity level (e.g. LOG, WARNING, ERROR, FATAL).
 	Severity string `json:"severity"`
 
-	// Timestamp Timestamp of the log entry (RFC3339 format)
+	// Timestamp Timestamp of the log entry (RFC3339 format).
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// ServiceLogs defines model for ServiceLogs.
+// ServiceLogs The logs for a service.
 type ServiceLogs struct {
-	// Entries Structured log entries with timestamp and severity metadata. Only present on the cursor-based path.
+	// Entries Structured log entries with timestamp and severity metadata.
+	// Entries are in the same order as logs and can be used in place of it
+	// by callers that need structured data.
 	Entries *[]ServiceLogEntry `json:"entries,omitempty"`
 
-	// LastCursor Opaque cursor for the next page of results. Present when more log entries exist older than the last entry in this response. Absent when there are no further results.
-	LastCursor *string `json:"lastCursor,omitempty"`
+	// LastCursorDeprecated Deprecated. Use `last_cursor` instead.
+	// Deprecated: Use `last_cursor` instead.
+	LastCursorDeprecated *string `json:"lastCursor,omitempty"`
+
+	// LastCursor Opaque cursor for the next page of results. Present when more log entries
+	// exist older than the last entry in this response. Pass this value as the
+	// `cursor` query parameter to retrieve the next page. Absent when there are
+	// no further results.
+	LastCursor *string `json:"last_cursor,omitempty"`
 
 	// Logs Array of log message strings. Preserved for backwards compatibility.
+	// Deprecated: Use `entries` instead.
 	Logs []string `json:"logs"`
 }
 
-// ServiceType defines model for ServiceType.
+// ServiceMetadata Additional metadata for the service.
+type ServiceMetadata struct {
+	// Environment Environment tag for the service.
+	Environment *string `json:"environment,omitempty"`
+}
+
+// ServiceMetrics Resource usage metrics for the service.
+type ServiceMetrics struct {
+	// MemoryMb Memory usage in megabytes.
+	MemoryMb *int `json:"memory_mb"`
+
+	// MilliCPU CPU usage in millicores.
+	MilliCPU *int `json:"milli_cpu"`
+
+	// StorageMb Storage usage in megabytes.
+	StorageMb *int `json:"storage_mb"`
+}
+
+// ServiceRename Parameters for renaming a service.
+type ServiceRename struct {
+	// Name The new name for the service.
+	Name string `json:"name"`
+}
+
+// ServiceType The type of the service:
+// - TIMESCALEDB: a TimescaleDB service (PostgreSQL with the TimescaleDB extension)
+// - POSTGRES: a standard PostgreSQL service
+//
+// VECTOR is deprecated and should not be used.
 type ServiceType string
 
-// ServiceVPCInput defines model for ServiceVPCInput.
+// ServiceVPCInput Parameters for attaching a service to a VPC.
 type ServiceVPCInput struct {
 	// VpcID The ID of the VPC to attach the service to.
 	VpcID string `json:"vpc_id"`
 }
 
-// SetEnvironmentInput defines model for SetEnvironmentInput.
+// SetEnvironmentInput Parameters for setting a service's environment.
 type SetEnvironmentInput struct {
-	// Environment The target environment for the service.
+	// Environment The target environment for the service:
+	// - PROD: a production environment
+	// - DEV: a development environment
 	Environment SetEnvironmentInputEnvironment `json:"environment"`
 }
 
-// SetEnvironmentInputEnvironment The target environment for the service.
+// SetEnvironmentInputEnvironment The target environment for the service:
+// - PROD: a production environment
+// - DEV: a development environment
 type SetEnvironmentInputEnvironment string
 
 // SetHAReplicaInput At least one of sync_replica_count or replica_count must be provided.
@@ -537,28 +721,52 @@ type SetHAReplicaInput struct {
 	SyncReplicaCount *int `json:"sync_replica_count,omitempty"`
 }
 
-// UpdatePasswordInput defines model for UpdatePasswordInput.
+// UpdatePasswordInput Parameters for updating a service's password.
 type UpdatePasswordInput struct {
 	// Password The new password.
 	Password string `json:"password"`
 }
 
-// VPC defines model for VPC.
+// VPC A virtual private cloud that services can be attached to.
 type VPC struct {
-	Cidr       *string `json:"cidr,omitempty"`
-	ID         *string `json:"id,omitempty"`
-	Name       *string `json:"name,omitempty"`
-	RegionCode *string `json:"region_code,omitempty"`
-}
+	// Cidr The IPv4 CIDR block for the VPC, in address/prefix notation (e.g. 10.0.0.0/16).
+	Cidr string `json:"cidr"`
 
-// VPCCreate defines model for VPCCreate.
-type VPCCreate struct {
-	Cidr       string `json:"cidr"`
-	Name       string `json:"name"`
+	// ID The unique identifier for the VPC.
+	ID *string `json:"id,omitempty"`
+
+	// Name The name of the VPC.
+	Name string `json:"name"`
+
+	// RegionCode The cloud region where the VPC is hosted.
 	RegionCode string `json:"region_code"`
 }
 
-// VPCRename defines model for VPCRename.
+// VPCCreate Parameters for creating a VPC.
+type VPCCreate struct {
+	// Cidr The IPv4 CIDR block for the VPC, in address/prefix notation (e.g. 10.0.0.0/16).
+	Cidr string `json:"cidr"`
+
+	// Name The name of the VPC.
+	Name string `json:"name"`
+
+	// RegionCode The cloud region where the VPC will be created.
+	RegionCode string `json:"region_code"`
+}
+
+// VPCEndpoint VPC endpoint configuration for connecting to a service over VPC peering.
+type VPCEndpoint struct {
+	// Host The hostname for connecting to the service over VPC peering.
+	Host *string `json:"host,omitempty"`
+
+	// Port The port for connecting to the service over VPC peering.
+	Port *int `json:"port,omitempty"`
+
+	// VpcID The ID of the VPC the endpoint is associated with.
+	VpcID *string `json:"vpc_id,omitempty"`
+}
+
+// VPCRename Parameters for renaming a VPC.
 type VPCRename struct {
 	// Name The new name for the VPC.
 	Name string `json:"name"`
@@ -581,11 +789,11 @@ type VPCId = string
 
 // AnalyticsResponse defines model for AnalyticsResponse.
 type AnalyticsResponse struct {
-	// Status Status of the analytics operation
+	// Status Status of the analytics operation.
 	Status *string `json:"status,omitempty"`
 }
 
-// ClientError defines model for ClientError.
+// ClientError An error returned when a request cannot be completed.
 type ClientError = Error
 
 // SuccessMessage defines model for SuccessMessage.
@@ -595,41 +803,47 @@ type SuccessMessage struct {
 
 // IdentifyUserJSONBody defines parameters for IdentifyUser.
 type IdentifyUserJSONBody struct {
-	// Properties Optional map of arbitrary properties associated with the user
+	// Properties Optional map of arbitrary properties associated with the user.
 	Properties *map[string]interface{} `json:"properties,omitempty"`
 }
 
 // TrackEventJSONBody defines parameters for TrackEvent.
 type TrackEventJSONBody struct {
-	// Event The name of the event to track
+	// Event The name of the event to track.
 	Event string `json:"event"`
 
-	// Properties Optional map of arbitrary properties associated with the event
+	// Properties Optional map of arbitrary properties associated with the event.
 	Properties *map[string]interface{} `json:"properties,omitempty"`
 }
 
 // LogoutJSONBody defines parameters for Logout.
 type LogoutJSONBody struct {
-	// RefreshToken The OAuth refresh token to revoke.
+	// RefreshToken The OAuth refresh token to revoke. Omit for sessions without a refresh token.
 	RefreshToken *string `json:"refresh_token,omitempty"`
 }
 
 // GetServiceLogsParams defines parameters for GetServiceLogs.
 type GetServiceLogsParams struct {
-	// Node Specific service node to fetch logs from (for multi-node services)
+	// Node Specific service node to fetch logs from (for multi-node services).
 	Node *int `form:"node,omitempty" json:"node,omitempty"`
 
-	// Page Page number for pagination (0-based)
-	Page *int `form:"page,omitempty" json:"page,omitempty"`
+	// Cursor Opaque pagination cursor returned as `last_cursor` in a previous response.
+	// When provided, returns the next page of logs older than the cursor position.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 
-	// Until Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
+	// Until Upper bound timestamp — fetch logs before this time (RFC3339 format, e.g., 2024-01-15T10:00:00Z).
 	Until *time.Time `form:"until,omitempty" json:"until,omitempty"`
 
-	// Since Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z).
+	// Since Lower bound timestamp — fetch logs after this time (RFC3339 format).
 	Since *time.Time `form:"since,omitempty" json:"since,omitempty"`
 
-	// Cursor Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
-	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+	// Search Full-text search terms to filter log lines. Repeat the parameter for multiple values
+	// (e.g. `?search=slow+query&search=ERROR`).
+	Search *[]string `form:"search,omitempty" json:"search,omitempty"`
+
+	// Severities Severity levels to filter results. Repeat the parameter for multiple values
+	// (e.g. `?severities=ERROR&severities=WARNING`).
+	Severities *[]string `form:"severities,omitempty" json:"severities,omitempty"`
 }
 
 // IdentifyUserJSONRequestBody defines body for IdentifyUser for application/json ContentType.
@@ -655,6 +869,9 @@ type ForkServiceJSONRequestBody = ForkServiceCreate
 
 // GetServiceMetricsSeriesJSONRequestBody defines body for GetServiceMetricsSeries for application/json ContentType.
 type GetServiceMetricsSeriesJSONRequestBody = MetricsSeriesRequest
+
+// RenameServiceJSONRequestBody defines body for RenameService for application/json ContentType.
+type RenameServiceJSONRequestBody = ServiceRename
 
 // CreateReplicaSetJSONRequestBody defines body for CreateReplicaSet for application/json ContentType.
 type CreateReplicaSetJSONRequestBody = ReadReplicaSetCreate

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -272,7 +272,7 @@ func TestAuthLogin_APIKeyValidationSuccess(t *testing.T) {
 	// Mock the validator to return success
 	validateAPIKey = func(ctx context.Context, cfg *config.Config, client api.ClientWithResponsesInterface) (*api.AuthInfo, error) {
 		authInfo := &api.AuthInfo{}
-		json.Unmarshal([]byte(`{"type":"apiKey","apiKey":{"public_key":"test-access-key","project":{"id":"test-project-valid"}}}`), authInfo)
+		json.Unmarshal([]byte(`{"type":"apiKey","api_key":{"public_key":"test-access-key","project":{"id":"test-project-valid"}}}`), authInfo)
 		return authInfo, nil // Success
 	}
 

--- a/internal/cmd/auth_status_test.go
+++ b/internal/cmd/auth_status_test.go
@@ -21,7 +21,7 @@ func TestAuthStatus_LoggedIn(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{
 				"type": "apiKey",
-				"apiKey": {
+				"api_key": {
 					"public_key": "test-access-key",
 					"name": "Test Credentials",
 					"created": "2025-01-01T00:00:00Z",

--- a/internal/cmd/auth_test.go
+++ b/internal/cmd/auth_test.go
@@ -21,7 +21,7 @@ func setupAuthTest(t *testing.T) string {
 	originalValidator := validateAPIKey
 	validateAPIKey = func(ctx context.Context, cfg *config.Config, client api.ClientWithResponsesInterface) (*api.AuthInfo, error) {
 		authInfo := &api.AuthInfo{}
-		json.Unmarshal([]byte(`{"type":"apiKey","apiKey":{"public_key":"test-access-key","project":{"id":"test-project-id"}}}`), authInfo)
+		json.Unmarshal([]byte(`{"type":"apiKey","api_key":{"public_key":"test-access-key","project":{"id":"test-project-id"}}}`), authInfo)
 		return authInfo, nil
 	}
 

--- a/internal/cmd/completion_helper.go
+++ b/internal/cmd/completion_helper.go
@@ -46,8 +46,8 @@ func serviceIDCompletion(app *common.App) cobra.CompletionFunc {
 
 		results := make([]string, 0, len(services))
 		for _, service := range services {
-			if service.ServiceID != nil && strings.HasPrefix(*service.ServiceID, toComplete) {
-				results = append(results, cobra.CompletionWithDesc(*service.ServiceID, *service.Name))
+			if strings.HasPrefix(service.ServiceID, toComplete) {
+				results = append(results, cobra.CompletionWithDesc(service.ServiceID, service.Name))
 			}
 		}
 		return results, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -187,7 +187,7 @@ func selectConnection(
 	// Offer the replica menu only for a primary on an interactive terminal.
 	if !target.IsReplica && !noReplicaPrompt && util.IsTerminal(cmd.InOrStdin()) && util.IsTerminal(cmd.ErrOrStderr()) {
 		primary := target.ConnectionService
-		replicas, err := fetchReplicaSets(ctx, client, projectID, util.DerefStr(primary.ServiceID))
+		replicas, err := fetchReplicaSets(ctx, client, projectID, primary.ServiceID)
 		if err != nil {
 			// Don't block the connection if we can't list replicas.
 			cmd.PrintErrf("Warning: could not list read replicas: %v\n", err)
@@ -211,7 +211,7 @@ func selectConnection(
 	}
 
 	if chosen.IsReplica {
-		cmd.PrintErrf("Connecting to read replica '%s'...\n", util.DerefStr(chosen.ConnectionService.Name))
+		cmd.PrintErrf("Connecting to read replica '%s'...\n", chosen.ConnectionService.Name)
 	}
 	return details, nil
 }
@@ -220,7 +220,7 @@ func selectConnection(
 func connectableReplicas(replicas []api.ReadReplicaSet) []api.ReadReplicaSet {
 	var out []api.ReadReplicaSet
 	for _, r := range replicas {
-		if r.Status != nil && *r.Status == api.ReadReplicaSetStatusActive && r.Endpoint != nil {
+		if r.Status == api.ReadReplicaSetStatusActive && r.Endpoint != nil {
 			out = append(out, r)
 		}
 	}
@@ -274,14 +274,14 @@ type connectTargetModel struct {
 func newConnectTargetModel(primary api.Service, replicas []api.ReadReplicaSet) connectTargetModel {
 	choices := []connectTargetChoice{{
 		kind:  targetPrimary,
-		label: fmt.Sprintf("Connect to primary service (%s)", util.DerefStr(primary.ServiceID)),
+		label: fmt.Sprintf("Connect to primary service (%s)", primary.ServiceID),
 	}}
 
 	for i := range replicas {
 		choices = append(choices, connectTargetChoice{
 			kind:    targetReplica,
 			replica: &replicas[i],
-			label:   fmt.Sprintf("Connect to read replica '%s'", util.DerefStr(replicas[i].Name)),
+			label:   fmt.Sprintf("Connect to read replica '%s'", replicas[i].Name),
 		})
 	}
 

--- a/internal/cmd/db_connect_test.go
+++ b/internal/cmd/db_connect_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
 	"github.com/timescale/tiger-cli/internal/config"
-	"github.com/timescale/tiger-cli/internal/util"
 )
 
 func TestDBConnect_NoServiceID(t *testing.T) {
@@ -197,15 +196,15 @@ func equalStringSlices(a, b []string) bool {
 
 func testPrimary() api.Service {
 	return api.Service{
-		ServiceID: util.Ptr("svc-primary"),
-		Name:      util.Ptr("my-db"),
+		ServiceID: "svc-primary",
+		Name:      "my-db",
 	}
 }
 
 func testReplicas() []api.ReadReplicaSet {
 	return []api.ReadReplicaSet{
-		{ID: util.Ptr("rep-1"), Name: util.Ptr("replica-a")},
-		{ID: util.Ptr("rep-2"), Name: util.Ptr("replica-b")},
+		{ID: "rep-1", Name: "replica-a"},
+		{ID: "rep-2", Name: "replica-b"},
 	}
 }
 
@@ -227,10 +226,10 @@ func TestNewConnectTargetModel_Options(t *testing.T) {
 	if len(m.choices) != 4 {
 		t.Fatalf("expected 4 choices with two replicas, got %d: %v", len(m.choices), m.choices)
 	}
-	if m.choices[1].kind != targetReplica || m.choices[1].replica == nil || *m.choices[1].replica.ID != "rep-1" {
+	if m.choices[1].kind != targetReplica || m.choices[1].replica == nil || m.choices[1].replica.ID != "rep-1" {
 		t.Errorf("expected second choice to be replica rep-1, got %+v", m.choices[1])
 	}
-	if m.choices[2].kind != targetReplica || *m.choices[2].replica.ID != "rep-2" {
+	if m.choices[2].kind != targetReplica || m.choices[2].replica.ID != "rep-2" {
 		t.Errorf("expected third choice to be replica rep-2, got %+v", m.choices[2])
 	}
 	if m.choices[3].kind != targetCancel {
@@ -268,7 +267,7 @@ func TestConnectTargetModel_KeySelection(t *testing.T) {
 			if choice.kind != tc.wantKind {
 				t.Fatalf("expected kind %v, got %v", tc.wantKind, choice.kind)
 			}
-			if tc.wantReplicaID != "" && (choice.replica == nil || *choice.replica.ID != tc.wantReplicaID) {
+			if tc.wantReplicaID != "" && (choice.replica == nil || choice.replica.ID != tc.wantReplicaID) {
 				t.Errorf("expected replica %s, got %+v", tc.wantReplicaID, choice.replica)
 			}
 		})
@@ -295,8 +294,8 @@ func TestSelectConnection_NoReplicasSkipsPrompt(t *testing.T) {
 	host := "primary.example.com"
 	port := 5432
 	primary := api.Service{
-		ServiceID: util.Ptr("svc-primary"),
-		Name:      util.Ptr("my-db"),
+		ServiceID: "svc-primary",
+		Name:      "my-db",
 		Endpoint:  &api.Endpoint{Host: &host, Port: &port},
 	}
 
@@ -459,8 +458,8 @@ func TestBuildPsqlCommand_KeyringPasswordEnvVar(t *testing.T) {
 	serviceID := "test-psql-service"
 	projectID := "test-psql-project"
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 	}
 
 	// Store a test password in keyring
@@ -516,8 +515,8 @@ func TestBuildPsqlCommand_PgpassStorage_NoEnvVar(t *testing.T) {
 	serviceID := "test-service-id"
 	projectID := "test-project-id"
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 	}
 
 	psqlPath := "/usr/bin/psql"

--- a/internal/cmd/db_connection_string_test.go
+++ b/internal/cmd/db_connection_string_test.go
@@ -114,8 +114,8 @@ func TestDBConnectionString_WithPassword(t *testing.T) {
 	host := "test-e2e-host.com"
 	port := 5432
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,

--- a/internal/cmd/db_create_role.go
+++ b/internal/cmd/db_create_role.go
@@ -105,7 +105,7 @@ PostgreSQL Configuration Parameters That May Be Set:
 			// A read replica is read-only, so a role can't be created there.
 			if common.IsReadReplica(service) {
 				return fmt.Errorf("%q is a read replica; create the role on its primary service %q instead",
-					util.Deref(service.ServiceID), util.DerefStr(service.ForkedFrom.ServiceID))
+					service.ServiceID, util.DerefStr(service.ForkedFrom.ServiceID))
 			}
 
 			// Get password

--- a/internal/cmd/db_create_role_test.go
+++ b/internal/cmd/db_create_role_test.go
@@ -27,8 +27,8 @@ func TestDBCreateRole_ReadReplicaRejected(t *testing.T) {
 	mockTestPAT(t)
 
 	standby := api.Service{
-		ServiceID:  util.Ptr("rep1234567"),
-		ProjectID:  util.Ptr("test-project-123"),
+		ServiceID:  "rep1234567",
+		ProjectID:  "test-project-123",
 		ForkedFrom: &api.ForkSpec{IsStandby: util.Ptr(true), ServiceID: util.Ptr("svcprimary")},
 	}
 	orig := getServiceDetailsFunc

--- a/internal/cmd/db_save_password.go
+++ b/internal/cmd/db_save_password.go
@@ -102,10 +102,10 @@ Examples:
 
 			if target.IsReplica {
 				cmd.PrintErrf("Read replicas share the primary's credentials; saving against primary %s.\n",
-					*service.ServiceID)
+					service.ServiceID)
 			}
 			cmd.PrintErrf("Password saved successfully for service %s (role: %s)\n",
-				*service.ServiceID, dbSavePasswordRole)
+				service.ServiceID, dbSavePasswordRole)
 			return nil
 		},
 	}

--- a/internal/cmd/db_save_password_test.go
+++ b/internal/cmd/db_save_password_test.go
@@ -40,8 +40,8 @@ func TestDBSavePassword_ExplicitPassword(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	mockService := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -98,13 +98,13 @@ func TestDBSavePassword_ReplicaResolvesToParent(t *testing.T) {
 	primaryHost := "svcprimary.example.com"
 	replicaHost := "replica.example.com"
 	primary := api.Service{
-		ServiceID: util.Ptr("svcprimary"),
-		ProjectID: util.Ptr(projectID),
+		ServiceID: "svcprimary",
+		ProjectID: projectID,
 		Endpoint:  &api.Endpoint{Host: &primaryHost, Port: &port},
 	}
 	replica := api.Service{
-		ServiceID: util.Ptr("rep1234567"),
-		ProjectID: util.Ptr(projectID),
+		ServiceID: "rep1234567",
+		ProjectID: projectID,
 		Endpoint:  &api.Endpoint{Host: &replicaHost, Port: &port},
 		ForkedFrom: &api.ForkSpec{
 			IsStandby: util.Ptr(true),
@@ -192,8 +192,8 @@ func TestDBSavePassword_EnvironmentVariable(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	mockService := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -260,8 +260,8 @@ func TestDBSavePassword_InteractivePrompt(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	mockService := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -333,8 +333,8 @@ func TestDBSavePassword_InteractivePromptEmpty(t *testing.T) {
 	serviceID := "svc-empty-test"
 	projectID := "test-project-123"
 	mockService := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 	}
 
 	originalGetServiceDetails := getServiceDetailsFunc
@@ -389,8 +389,8 @@ func TestDBSavePassword_CustomRole(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	mockService := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -517,8 +517,8 @@ func TestDBSavePassword_PgpassStorage(t *testing.T) {
 	host := "pgpass-host.com"
 	port := 5432
 	mockService := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,

--- a/internal/cmd/db_schema_test.go
+++ b/internal/cmd/db_schema_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
 	"github.com/timescale/tiger-cli/internal/config"
-	"github.com/timescale/tiger-cli/internal/util"
 )
 
 func TestDBSchema_NoServiceID(t *testing.T) {
@@ -90,8 +89,8 @@ func TestDBSchema_NotReadyStates(t *testing.T) {
 
 			mockTestPAT(t)
 			withMockService(t, api.Service{
-				ServiceID: util.Ptr("svc-12345"),
-				Status:    util.Ptr(tt.status),
+				ServiceID: "svc-12345",
+				Status:    tt.status,
 			})
 
 			_, err := executeDBCommand(t.Context(), "db", "schema")

--- a/internal/cmd/db_test.go
+++ b/internal/cmd/db_test.go
@@ -94,9 +94,9 @@ func primarySvc() api.Service {
 	host := "svcprimary.example.com"
 	port := 5432
 	return api.Service{
-		ServiceID: util.Ptr("svcprimary"),
-		ProjectID: util.Ptr("proj1"),
-		Name:      util.Ptr("my-db"),
+		ServiceID: "svcprimary",
+		ProjectID: "proj1",
+		Name:      "my-db",
 		Endpoint:  &api.Endpoint{Host: &host, Port: &port},
 	}
 }
@@ -105,9 +105,9 @@ func standbySvc() api.Service {
 	host := "replica.example.com"
 	port := 5432
 	return api.Service{
-		ServiceID: util.Ptr("rep1234567"),
-		ProjectID: util.Ptr("proj1"),
-		Name:      util.Ptr("reporting-replica"),
+		ServiceID: "rep1234567",
+		ProjectID: "proj1",
+		Name:      "reporting-replica",
 		Endpoint:  &api.Endpoint{Host: &host, Port: &port},
 		ForkedFrom: &api.ForkSpec{
 			IsStandby: util.Ptr(true),
@@ -137,8 +137,8 @@ func TestLookupConnectionTarget_Primary(t *testing.T) {
 	if target.IsReplica {
 		t.Fatal("expected a primary target")
 	}
-	if util.DerefStr(target.ConnectionService.ServiceID) != "svcprimary" {
-		t.Errorf("expected connect svcprimary, got %q", util.DerefStr(target.ConnectionService.ServiceID))
+	if target.ConnectionService.ServiceID != "svcprimary" {
+		t.Errorf("expected connect svcprimary, got %q", target.ConnectionService.ServiceID)
 	}
 }
 
@@ -162,11 +162,11 @@ func TestLookupConnectionTarget_Replica(t *testing.T) {
 	if !target.IsReplica {
 		t.Fatal("expected a replica target")
 	}
-	if util.DerefStr(target.ConnectionService.ServiceID) != "rep1234567" {
-		t.Errorf("expected connect rep1234567, got %q", util.DerefStr(target.ConnectionService.ServiceID))
+	if target.ConnectionService.ServiceID != "rep1234567" {
+		t.Errorf("expected connect rep1234567, got %q", target.ConnectionService.ServiceID)
 	}
-	if util.DerefStr(target.CredentialService.ServiceID) != "svcprimary" {
-		t.Errorf("expected credential svcprimary, got %q", util.DerefStr(target.CredentialService.ServiceID))
+	if target.CredentialService.ServiceID != "svcprimary" {
+		t.Errorf("expected credential svcprimary, got %q", target.CredentialService.ServiceID)
 	}
 }
 
@@ -194,11 +194,11 @@ func TestBuildConnectionDetailsForTarget_ReplicaPoolerFallback(t *testing.T) {
 	rport := 5432
 	target := &common.ConnectionTarget{
 		ConnectionService: api.Service{
-			ServiceID: util.Ptr("rep1234567"),
-			Name:      util.Ptr("reporting-replica"),
+			ServiceID: "rep1234567",
+			Name:      "reporting-replica",
 			Endpoint:  &api.Endpoint{Host: &rhost, Port: &rport},
 		},
-		CredentialService: api.Service{ServiceID: util.Ptr("svcprimary"), ProjectID: util.Ptr("proj1")},
+		CredentialService: api.Service{ServiceID: "svcprimary", ProjectID: "proj1"},
 		IsReplica:         true,
 	}
 
@@ -228,7 +228,7 @@ func TestBuildConnectionDetailsForTarget_PrimaryRequiresPooler(t *testing.T) {
 	host := "primary.example.com"
 	port := 5432
 	svc := api.Service{
-		ServiceID: util.Ptr("svcprimary"),
+		ServiceID: "svcprimary",
 		Endpoint:  &api.Endpoint{Host: &host, Port: &port},
 	}
 	target := &common.ConnectionTarget{ConnectionService: svc, CredentialService: svc}

--- a/internal/cmd/integration_test.go
+++ b/internal/cmd/integration_test.go
@@ -104,21 +104,18 @@ func sweepStaleIntegrationServices(t *testing.T, threshold time.Duration) {
 	cutoff := time.Now().Add(-threshold)
 	swept := 0
 	for _, s := range services {
-		if s.ServiceID == nil || s.Name == nil || s.Created == nil {
-			continue
-		}
-		if !strings.HasPrefix(*s.Name, testServicePrefix) {
+		if !strings.HasPrefix(s.Name, testServicePrefix) {
 			continue
 		}
 		if !s.Created.Before(cutoff) {
 			continue
 		}
 		t.Logf("Sweep: deleting stale service %s (name=%s, created=%s)",
-			*s.ServiceID, *s.Name, s.Created.Format(time.RFC3339))
+			s.ServiceID, s.Name, s.Created.Format(time.RFC3339))
 		if _, err := executeIntegrationCommand(ctx,
-			"service", "delete", *s.ServiceID,
+			"service", "delete", s.ServiceID,
 			"--confirm", "--no-wait"); err != nil {
-			t.Logf("Sweep: failed to delete %s: %v", *s.ServiceID, err)
+			t.Logf("Sweep: failed to delete %s: %v", s.ServiceID, err)
 			continue
 		}
 		swept++
@@ -295,11 +292,11 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		}
 
 		// Verify service details
-		if service.ServiceID == nil || *service.ServiceID != serviceID {
+		if service.ServiceID != serviceID {
 			t.Errorf("Expected service ID %s, got %v", serviceID, service.ServiceID)
 		}
 
-		if service.Name == nil || *service.Name != serviceName {
+		if service.Name != serviceName {
 			t.Errorf("Expected service name %s, got %v", serviceName, service.Name)
 		}
 
@@ -954,10 +951,7 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 			t.Fatalf("Failed to parse service JSON: %v", err)
 		}
 
-		var status string
-		if service.Status != nil {
-			status = string(*service.Status)
-		}
+		status := string(service.Status)
 
 		t.Logf("Service status after stop: %s", status)
 
@@ -1042,10 +1036,7 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 			t.Fatalf("Failed to parse service JSON: %v", err)
 		}
 
-		var status string
-		if service.Status != nil {
-			status = string(*service.Status)
-		}
+		status := string(service.Status)
 
 		t.Logf("Service status after start: %s", status)
 
@@ -1112,8 +1103,8 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		}
 
 		var currentCPU, currentMemory string
-		if serviceBefore.Resources != nil && len(*serviceBefore.Resources) > 0 {
-			resource := (*serviceBefore.Resources)[0]
+		if len(serviceBefore.Resources) > 0 {
+			resource := serviceBefore.Resources[0]
 			if resource.Spec != nil {
 				if resource.Spec.CPUMillis != nil {
 					cpuCores := float64(*resource.Spec.CPUMillis) / 1000
@@ -1179,8 +1170,8 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		}
 
 		var newCPUMillis, newMemoryGbs int
-		if serviceAfter.Resources != nil && len(*serviceAfter.Resources) > 0 {
-			resource := (*serviceAfter.Resources)[0]
+		if len(serviceAfter.Resources) > 0 {
+			resource := serviceAfter.Resources[0]
 			if resource.Spec != nil {
 				if resource.Spec.CPUMillis != nil {
 					newCPUMillis = *resource.Spec.CPUMillis
@@ -1213,10 +1204,7 @@ func TestServiceLifecycleIntegration(t *testing.T) {
 		}
 
 		// Verify service is still in READY state after resize
-		var status string
-		if serviceAfter.Status != nil {
-			status = string(*serviceAfter.Status)
-		}
+		status := string(serviceAfter.Status)
 
 		if status != "READY" {
 			t.Logf("Warning: Expected service status to be READY after resize, got %s", status)
@@ -1324,8 +1312,8 @@ func extractServiceIDFromCreateOutput(t *testing.T, output string) string {
 	// Try to parse as JSON first (if --output json was used)
 	var service api.Service
 	if err := json.Unmarshal([]byte(output), &service); err == nil {
-		if service.ServiceID != nil {
-			return *service.ServiceID
+		if service.ServiceID != "" {
+			return service.ServiceID
 		}
 	}
 

--- a/internal/cmd/password_helper.go
+++ b/internal/cmd/password_helper.go
@@ -25,7 +25,7 @@ func updateAndSaveServicePassword(
 ) error {
 	// Call API to update password
 	updateReq := api.UpdatePasswordInput{Password: newPassword}
-	resp, err := client.UpdatePasswordWithResponse(ctx, *service.ProjectID, *service.ServiceID, updateReq)
+	resp, err := client.UpdatePasswordWithResponse(ctx, service.ProjectID, service.ServiceID, updateReq)
 	if err != nil {
 		return fmt.Errorf("failed to update password: %w", err)
 	}
@@ -39,7 +39,7 @@ func updateAndSaveServicePassword(
 		cmd.PrintErrf("Warning: could not save password: %v\n", err)
 	} else if result.Success {
 		cmd.PrintErrf("%s\n", result.Message)
-		cmd.PrintErrf("To view your new password, run: \n\t tiger service get %s --with-password\n", util.Deref(service.ServiceID))
+		cmd.PrintErrf("To view your new password, run: \n\t tiger service get %s --with-password\n", service.ServiceID)
 	}
 
 	return nil

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -59,7 +59,7 @@ func outputService(cmd *cobra.Command, cfg *config.Config, service api.Service, 
 	// Prepare the output service with computed fields
 	outputSvc := prepareServiceForOutput(cmd, cfg, service, withPassword)
 	if strict && withPassword && outputSvc.Password == "" {
-		return fmt.Errorf("password requested but not available for service %s", util.Deref(outputSvc.ServiceID))
+		return fmt.Errorf("password requested but not available for service %s", outputSvc.ServiceID)
 	}
 	outputWriter := cmd.OutOrStdout()
 
@@ -93,11 +93,11 @@ func outputServiceTable(service OutputService, output io.Writer) error {
 	table.Header("PROPERTY", "VALUE")
 
 	// Basic service information
-	table.Append("Service ID", util.Deref(service.ServiceID))
-	table.Append("Name", util.Deref(service.Name))
-	table.Append("Status", util.DerefStr(service.Status))
-	table.Append("Type", util.DerefStr(service.ServiceType))
-	table.Append("Region", util.Deref(service.RegionCode))
+	table.Append("Service ID", service.ServiceID)
+	table.Append("Name", service.Name)
+	table.Append("Status", string(service.Status))
+	table.Append("Type", string(service.ServiceType))
+	table.Append("Region", service.RegionCode)
 
 	// Environment tag
 	if service.Metadata != nil && service.Metadata.Environment != nil {
@@ -105,8 +105,8 @@ func outputServiceTable(service OutputService, output io.Writer) error {
 	}
 
 	// Resource information from Resources slice
-	if service.Resources != nil && len(*service.Resources) > 0 {
-		resource := (*service.Resources)[0] // Get first resource
+	if len(service.Resources) > 0 {
+		resource := service.Resources[0] // Get first resource
 		if resource.Spec != nil {
 			if resource.Spec.CPUMillis != nil {
 				cpuCores := float64(*resource.Spec.CPUMillis) / 1000
@@ -159,9 +159,7 @@ func outputServiceTable(service OutputService, output io.Writer) error {
 	}
 
 	// Timestamps
-	if service.Created != nil {
-		table.Append("Created", service.Created.Format("2006-01-02 15:04:05 MST"))
-	}
+	table.Append("Created", service.Created.Format("2006-01-02 15:04:05 MST"))
 
 	// Output password if available
 	if service.Password != "" {
@@ -203,7 +201,7 @@ func prepareServiceForOutput(cmd *cobra.Command, cfg *config.Config, service api
 	}
 
 	// Build console URL
-	outputSvc.ConsoleURL = fmt.Sprintf("%s/dashboard/services/%s", cfg.ConsoleURL, *service.ServiceID)
+	outputSvc.ConsoleURL = fmt.Sprintf("%s/dashboard/services/%s", cfg.ConsoleURL, service.ServiceID)
 
 	return outputSvc
 }

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -163,7 +163,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 				return fmt.Errorf("empty response from API")
 			}
 			service := *resp.JSON202
-			serviceID := util.Deref(service.ServiceID)
+			serviceID := service.ServiceID
 
 			cmd.PrintErrf("✅ Service creation request accepted!\n")
 			cmd.PrintErrf("📋 Service ID: %s\n", serviceID)

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -186,7 +186,7 @@ Examples:
 				return fmt.Errorf("empty response from API")
 			}
 			forkedService := *forkResp.JSON202
-			forkedServiceID := util.DerefStr(forkedService.ServiceID)
+			forkedServiceID := forkedService.ServiceID
 
 			cmd.PrintErrf("✅ Fork request accepted!\n")
 			cmd.PrintErrf("📋 New Service ID: %s\n", forkedServiceID)

--- a/internal/cmd/service_list.go
+++ b/internal/cmd/service_list.go
@@ -110,22 +110,14 @@ func outputServicesTable(services []OutputService, output io.Writer) error {
 
 	for _, service := range services {
 		table.Append(
-			util.Deref(service.ServiceID),
-			util.Deref(service.Name),
-			util.DerefStr(service.Status),
-			util.DerefStr(service.ServiceType),
-			util.Deref(service.RegionCode),
-			formatTimePtr(service.Created),
+			service.ServiceID,
+			service.Name,
+			string(service.Status),
+			string(service.ServiceType),
+			service.RegionCode,
+			service.Created.Format("2006-01-02 15:04"),
 		)
 	}
 
 	return table.Render()
-}
-
-// formatTimePtr formats a time pointer, returning empty string if nil
-func formatTimePtr(t *time.Time) string {
-	if t == nil {
-		return ""
-	}
-	return t.Format("2006-01-02 15:04")
 }

--- a/internal/cmd/service_list_test.go
+++ b/internal/cmd/service_list_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -183,13 +182,13 @@ func TestSanitizeServicesForOutput(t *testing.T) {
 
 	services := []api.Service{
 		{
-			ServiceID:       &serviceID1,
-			Name:            &serviceName1,
+			ServiceID:       serviceID1,
+			Name:            serviceName1,
 			InitialPassword: &initialPassword1,
 		},
 		{
-			ServiceID:       &serviceID2,
-			Name:            &serviceName2,
+			ServiceID:       serviceID2,
+			Name:            serviceName2,
 			InitialPassword: &initialPassword2,
 		},
 	}
@@ -212,21 +211,11 @@ func TestSanitizeServicesForOutput(t *testing.T) {
 		}
 
 		// Verify that other fields are preserved
-		if service.ServiceID == nil {
+		if service.ServiceID == "" {
 			t.Errorf("Expected ServiceID to be preserved in sanitized service %d", i)
 		}
-		if service.Name == nil {
+		if service.Name == "" {
 			t.Errorf("Expected Name to be preserved in sanitized service %d", i)
 		}
-	}
-}
-
-func TestFormatTimePtr(t *testing.T) {
-	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	if formatTimePtr(&testTime) == "" {
-		t.Error("formatTimePtr should return formatted time string")
-	}
-	if formatTimePtr(nil) != "" {
-		t.Error("formatTimePtr should return empty string for nil")
 	}
 }

--- a/internal/cmd/service_metrics.go
+++ b/internal/cmd/service_metrics.go
@@ -7,8 +7,8 @@ import (
 )
 
 // buildServiceMetricsCmd creates the metrics subcommand group. The metrics
-// surface targets gateway endpoints marked `x-preview: true` in the OpenAPI
-// spec — their request/response contract is still in flux. Registration is
+// surface targets gateway endpoints marked `x-tigerdata-preview: true` in the
+// OpenAPI spec — their request/response contract is still in flux. Registration is
 // gated on TIGER_EXPERIMENTAL in buildServiceCmd, so this builder is only
 // called when the env var is set; the tree doesn't include `metrics` at all
 // otherwise.

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -83,20 +83,20 @@ func createTestServices() []api.Service {
 
 	return []api.Service{
 		{
-			ServiceID:   &testServiceID1,
-			Name:        &name1,
-			RegionCode:  &region1,
-			Status:      &status1,
-			ServiceType: &serviceType1,
-			Created:     &created1,
+			ServiceID:   testServiceID1,
+			Name:        name1,
+			RegionCode:  region1,
+			Status:      status1,
+			ServiceType: serviceType1,
+			Created:     created1,
 		},
 		{
-			ServiceID:   &testServiceID2,
-			Name:        &name2,
-			RegionCode:  &region2,
-			Status:      &status2,
-			ServiceType: &serviceType2,
-			Created:     &created2,
+			ServiceID:   testServiceID2,
+			Name:        name2,
+			RegionCode:  region2,
+			Status:      status2,
+			ServiceType: serviceType2,
+			Created:     created2,
 		},
 	}
 }
@@ -173,12 +173,12 @@ func TestOutputService_JSON(t *testing.T) {
 	initialPassword := "secret-password-123"
 
 	service := api.Service{
-		ServiceID:       &serviceID,
-		Name:            &serviceName,
-		ServiceType:     &serviceType,
-		RegionCode:      &regionCode,
-		Status:          &status,
-		Created:         &created,
+		ServiceID:       serviceID,
+		Name:            serviceName,
+		ServiceType:     serviceType,
+		RegionCode:      regionCode,
+		Status:          status,
+		Created:         created,
 		InitialPassword: &initialPassword,
 	}
 
@@ -242,12 +242,12 @@ func TestOutputService_YAML(t *testing.T) {
 	initialPassword := "secret-password-123"
 
 	service := api.Service{
-		ServiceID:       &serviceID,
-		Name:            &serviceName,
-		ServiceType:     &serviceType,
-		RegionCode:      &regionCode,
-		Status:          &status,
-		Created:         &created,
+		ServiceID:       serviceID,
+		Name:            serviceName,
+		ServiceType:     serviceType,
+		RegionCode:      regionCode,
+		Status:          status,
+		Created:         created,
 		InitialPassword: &initialPassword,
 	}
 
@@ -316,27 +316,16 @@ func TestOutputService_Table(t *testing.T) {
 	initialPassword := "secret-password-123"
 
 	service := api.Service{
-		ServiceID:       &serviceID,
-		Name:            &serviceName,
-		ServiceType:     &serviceType,
-		RegionCode:      &regionCode,
-		Status:          &status,
-		Created:         &created,
+		ServiceID:       serviceID,
+		Name:            serviceName,
+		ServiceType:     serviceType,
+		RegionCode:      regionCode,
+		Status:          status,
+		Created:         created,
 		InitialPassword: &initialPassword,
-		Resources: &[]struct {
-			ID   *string `json:"id,omitempty"`
-			Spec *struct {
-				CPUMillis  *int    `json:"cpu_millis,omitempty"`
-				MemoryGbs  *int    `json:"memory_gbs,omitempty"`
-				VolumeType *string `json:"volume_type,omitempty"`
-			} `json:"spec,omitempty"`
-		}{
+		Resources: []api.Resource{
 			{
-				Spec: &struct {
-					CPUMillis  *int    `json:"cpu_millis,omitempty"`
-					MemoryGbs  *int    `json:"memory_gbs,omitempty"`
-					VolumeType *string `json:"volume_type,omitempty"`
-				}{
+				Spec: &api.ResourceSpec{
 					CPUMillis: &cpuMillis,
 					MemoryGbs: &memoryGbs,
 				},
@@ -401,26 +390,15 @@ func TestOutputService_FreeTier(t *testing.T) {
 	port := 5432
 
 	service := api.Service{
-		ServiceID:   &serviceID,
-		Name:        &serviceName,
-		ServiceType: &serviceType,
-		RegionCode:  &regionCode,
-		Status:      &status,
-		Created:     &created,
-		Resources: &[]struct {
-			ID   *string `json:"id,omitempty"`
-			Spec *struct {
-				CPUMillis  *int    `json:"cpu_millis,omitempty"`
-				MemoryGbs  *int    `json:"memory_gbs,omitempty"`
-				VolumeType *string `json:"volume_type,omitempty"`
-			} `json:"spec,omitempty"`
-		}{
+		ServiceID:   serviceID,
+		Name:        serviceName,
+		ServiceType: serviceType,
+		RegionCode:  regionCode,
+		Status:      status,
+		Created:     created,
+		Resources: []api.Resource{
 			{
-				Spec: &struct {
-					CPUMillis  *int    `json:"cpu_millis,omitempty"`
-					MemoryGbs  *int    `json:"memory_gbs,omitempty"`
-					VolumeType *string `json:"volume_type,omitempty"`
-				}{
+				Spec: &api.ResourceSpec{
 					// CPU and Memory are nil for free tier services
 					CPUMillis: nil,
 					MemoryGbs: nil,
@@ -475,8 +453,8 @@ func TestPrepareServiceForOutput_WithoutPassword(t *testing.T) {
 	initialPassword := "secret-password-123"
 
 	service := api.Service{
-		ServiceID:       &serviceID,
-		Name:            &serviceName,
+		ServiceID:       serviceID,
+		Name:            serviceName,
 		InitialPassword: &initialPassword,
 	}
 
@@ -498,10 +476,10 @@ func TestPrepareServiceForOutput_WithoutPassword(t *testing.T) {
 	}
 
 	// Verify that other fields are preserved
-	if outputSvc.ServiceID == nil || *outputSvc.ServiceID != serviceID {
+	if outputSvc.ServiceID != serviceID {
 		t.Error("Expected service_id to be preserved")
 	}
-	if outputSvc.Name == nil || *outputSvc.Name != serviceName {
+	if outputSvc.Name != serviceName {
 		t.Error("Expected name to be preserved")
 	}
 }
@@ -515,8 +493,8 @@ func TestPrepareServiceForOutput_WithPassword(t *testing.T) {
 	servicePort := 5432
 
 	service := api.Service{
-		ServiceID:       &serviceID,
-		Name:            &serviceName,
+		ServiceID:       serviceID,
+		Name:            serviceName,
 		InitialPassword: &initialPassword,
 		Endpoint: &api.Endpoint{
 			Host: &serviceHost,
@@ -542,10 +520,10 @@ func TestPrepareServiceForOutput_WithPassword(t *testing.T) {
 	}
 
 	// Verify that other fields are preserved
-	if outputSvc.ServiceID == nil || *outputSvc.ServiceID != serviceID {
+	if outputSvc.ServiceID != serviceID {
 		t.Error("Expected service_id to be preserved")
 	}
-	if outputSvc.Name == nil || *outputSvc.Name != serviceName {
+	if outputSvc.Name != serviceName {
 		t.Error("Expected name to be preserved")
 	}
 }

--- a/internal/cmd/service_update_password_test.go
+++ b/internal/cmd/service_update_password_test.go
@@ -73,8 +73,8 @@ func TestServiceUpdatePassword_ReadReplicaRejected(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.Service{
-			ServiceID:  util.Ptr("rep1234567"),
-			ProjectID:  util.Ptr("test-project-123"),
+			ServiceID:  "rep1234567",
+			ProjectID:  "test-project-123",
 			ForkedFrom: &api.ForkSpec{IsStandby: util.Ptr(true), ServiceID: util.Ptr("svcprimary")},
 		})
 	}))

--- a/internal/common/client_test.go
+++ b/internal/common/client_test.go
@@ -74,7 +74,7 @@ func TestValidateAPIKey(t *testing.T) {
 						w.WriteHeader(http.StatusOK)
 						w.Write([]byte(`{
 							"type": "apiKey",
-							"apiKey": {
+							"api_key": {
 								"public_key": "test-access-key",
 								"name": "Test Credentials",
 								"created": "2025-01-01T00:00:00Z",

--- a/internal/common/connection.go
+++ b/internal/common/connection.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/config"
-	"github.com/timescale/tiger-cli/internal/util"
 )
 
 // hasPooler reports whether a connection pooler exposes an endpoint.
@@ -24,7 +23,7 @@ func ReplicaPoolerWarning(target *ConnectionTarget, pooled bool) string {
 	if !target.IsReplica || !pooled || hasPooler(target.ConnectionService.ConnectionPooler) {
 		return ""
 	}
-	return fmt.Sprintf("read replica %q has no connection pooler; connecting directly instead", util.DerefStr(target.ConnectionService.Name))
+	return fmt.Sprintf("read replica %q has no connection pooler; connecting directly instead", target.ConnectionService.Name)
 }
 
 // ConnectionDetailsOptions configures how the connection string is built

--- a/internal/common/connection_test.go
+++ b/internal/common/connection_test.go
@@ -218,8 +218,8 @@ func TestBuildConnectionString_WithPassword_KeyringStorage(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -267,8 +267,8 @@ func TestBuildConnectionString_WithPassword_PgpassStorage(t *testing.T) {
 	host := "test-pgpass-host.com"
 	port := 5432
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -340,8 +340,8 @@ func TestBuildConnectionString_WithPassword_NoStorage(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -379,8 +379,8 @@ func TestBuildConnectionString_WithPassword_NoPasswordAvailable(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -416,8 +416,8 @@ func TestBuildConnectionString_ReadOnly_WithPassword(t *testing.T) {
 	host := "test-host.com"
 	port := 5432
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint: &api.Endpoint{
 			Host: &host,
 			Port: &port,
@@ -460,8 +460,8 @@ func TestBuildConnectionString_WithPassword_InvalidServiceEndpoint(t *testing.T)
 	serviceID := "test-invalid-service"
 	projectID := "test-invalid-project"
 	service := api.Service{
-		ServiceID: &serviceID,
-		ProjectID: &projectID,
+		ServiceID: serviceID,
+		ProjectID: projectID,
 		Endpoint:  nil, // Invalid - no endpoint
 	}
 
@@ -491,8 +491,8 @@ func TestGetConnectionDetailsFor(t *testing.T) {
 	// credService supplies credentials only; endpoint selection is driven by
 	// connService. WithPassword is off here, so credService is not exercised.
 	primary := api.Service{
-		ServiceID: util.Ptr("svc-primary"),
-		ProjectID: util.Ptr("proj-1"),
+		ServiceID: "svc-primary",
+		ProjectID: "proj-1",
 		Endpoint: &api.Endpoint{
 			Host: &primaryHost,
 			Port: &port,
@@ -501,8 +501,8 @@ func TestGetConnectionDetailsFor(t *testing.T) {
 
 	t.Run("direct endpoint", func(t *testing.T) {
 		conn := api.Service{
-			ServiceID: util.Ptr("rep-1"),
-			Name:      util.Ptr("my-replica"),
+			ServiceID: "rep-1",
+			Name:      "my-replica",
 			Endpoint:  &api.Endpoint{Host: &replicaHost, Port: &port},
 		}
 
@@ -526,8 +526,8 @@ func TestGetConnectionDetailsFor(t *testing.T) {
 
 	t.Run("pooled endpoint when available", func(t *testing.T) {
 		conn := api.Service{
-			ServiceID: util.Ptr("rep-1"),
-			Name:      util.Ptr("my-replica"),
+			ServiceID: "rep-1",
+			Name:      "my-replica",
 			Endpoint:  &api.Endpoint{Host: &replicaHost, Port: &port},
 			ConnectionPooler: &api.ConnectionPooler{
 				Endpoint: &api.Endpoint{Host: &poolerHost, Port: &poolerPort},
@@ -548,7 +548,7 @@ func TestGetConnectionDetailsFor(t *testing.T) {
 
 	t.Run("falls back to direct when pooler requested but unavailable", func(t *testing.T) {
 		conn := api.Service{
-			ServiceID: util.Ptr("rep-1"),
+			ServiceID: "rep-1",
 			Endpoint:  &api.Endpoint{Host: &replicaHost, Port: &port},
 		}
 
@@ -565,7 +565,7 @@ func TestGetConnectionDetailsFor(t *testing.T) {
 	})
 
 	t.Run("error when endpoint missing", func(t *testing.T) {
-		conn := api.Service{ServiceID: util.Ptr("rep-1")}
+		conn := api.Service{ServiceID: "rep-1"}
 		if _, err := GetConnectionDetailsFor(testConfig(""), conn, primary, ConnectionDetailsOptions{Role: "tsdbadmin"}); err == nil {
 			t.Fatal("expected error for missing connection endpoint")
 		}

--- a/internal/common/password_storage.go
+++ b/internal/common/password_storage.go
@@ -20,17 +20,17 @@ func getPasswordServiceName() string {
 
 // buildPasswordKeyringUsername creates a unique keyring username for service passwords
 func buildPasswordKeyringUsername(service api.Service, role string) (string, error) {
-	if service.ServiceID == nil {
+	if service.ServiceID == "" {
 		return "", fmt.Errorf("service ID is required")
 	}
-	if service.ProjectID == nil {
+	if service.ProjectID == "" {
 		return "", fmt.Errorf("project ID is required")
 	}
 	if role == "" {
 		return "", fmt.Errorf("role is required")
 	}
 
-	return fmt.Sprintf("password-%s-%s-%s", *service.ProjectID, *service.ServiceID, role), nil
+	return fmt.Sprintf("password-%s-%s-%s", service.ProjectID, service.ServiceID, role), nil
 }
 
 // sanitizeErrorMessage removes sensitive information from error messages

--- a/internal/common/password_storage_test.go
+++ b/internal/common/password_storage_test.go
@@ -16,8 +16,8 @@ import (
 func createTestService(serviceID string) api.Service {
 	projectID := "test-project-123"
 	return api.Service{
-		ProjectID: &projectID,
-		ServiceID: &serviceID,
+		ProjectID: projectID,
+		ServiceID: serviceID,
 		Endpoint: &api.Endpoint{
 			Host: util.Ptr("test-host.tigerdata.com"),
 			Port: util.Ptr(5432),
@@ -78,7 +78,7 @@ func TestKeyringStorage_Save_NoProjectId(t *testing.T) {
 	storage := &KeyringStorage{}
 	serviceID := "test-service-123"
 	service := api.Service{
-		ServiceID: &serviceID,
+		ServiceID: serviceID,
 		// No ProjectID
 	}
 
@@ -124,7 +124,7 @@ func TestKeyringStorage_Get_NoProjectId(t *testing.T) {
 	storage := &KeyringStorage{}
 	serviceID := "test-service-123"
 	service := api.Service{
-		ServiceID: &serviceID,
+		ServiceID: serviceID,
 		// No ProjectID
 	}
 
@@ -173,7 +173,7 @@ func TestKeyringStorage_Remove_NoProjectId(t *testing.T) {
 	storage := &KeyringStorage{}
 	serviceID := "test-service-123"
 	service := api.Service{
-		ServiceID: &serviceID,
+		ServiceID: serviceID,
 		// No ProjectID
 	}
 
@@ -202,7 +202,7 @@ func TestKeyringStorage_Remove_NoRole(t *testing.T) {
 func TestPgpassStorage_Remove_NoEndpoint(t *testing.T) {
 	storage := &PgpassStorage{}
 	service := api.Service{
-		ServiceID: util.Ptr("test-service-123"),
+		ServiceID: "test-service-123",
 		// No Endpoint
 	}
 
@@ -231,7 +231,7 @@ func TestPgpassStorage_Remove_NoRole(t *testing.T) {
 func TestPgpassStorage_Get_NoEndpoint(t *testing.T) {
 	storage := &PgpassStorage{}
 	service := api.Service{
-		ServiceID: util.Ptr("test-service-123"),
+		ServiceID: "test-service-123",
 		// No Endpoint
 	}
 
@@ -702,8 +702,8 @@ func TestBuildPasswordKeyringUsername(t *testing.T) {
 		{
 			name: "valid service with both IDs and tsdbadmin role",
 			service: api.Service{
-				ProjectID: util.Ptr("project-123"),
-				ServiceID: util.Ptr("service-456"),
+				ProjectID: "project-123",
+				ServiceID: "service-456",
 			},
 			role:        "tsdbadmin",
 			expected:    "password-project-123-service-456-tsdbadmin",
@@ -712,8 +712,8 @@ func TestBuildPasswordKeyringUsername(t *testing.T) {
 		{
 			name: "valid service with both IDs and readonly role",
 			service: api.Service{
-				ProjectID: util.Ptr("project-123"),
-				ServiceID: util.Ptr("service-456"),
+				ProjectID: "project-123",
+				ServiceID: "service-456",
 			},
 			role:        "readonly",
 			expected:    "password-project-123-service-456-readonly",
@@ -722,8 +722,8 @@ func TestBuildPasswordKeyringUsername(t *testing.T) {
 		{
 			name: "valid service with both IDs and mixed-case role",
 			service: api.Service{
-				ProjectID: util.Ptr("project-123"),
-				ServiceID: util.Ptr("service-456"),
+				ProjectID: "project-123",
+				ServiceID: "service-456",
 			},
 			role:        "MyAppUser",
 			expected:    "password-project-123-service-456-MyAppUser",
@@ -732,7 +732,7 @@ func TestBuildPasswordKeyringUsername(t *testing.T) {
 		{
 			name: "missing service ID",
 			service: api.Service{
-				ProjectID: util.Ptr("project-123"),
+				ProjectID: "project-123",
 			},
 			role:        "tsdbadmin",
 			expected:    "",
@@ -741,7 +741,7 @@ func TestBuildPasswordKeyringUsername(t *testing.T) {
 		{
 			name: "missing project ID",
 			service: api.Service{
-				ServiceID: util.Ptr("service-456"),
+				ServiceID: "service-456",
 			},
 			role:        "tsdbadmin",
 			expected:    "",
@@ -757,8 +757,8 @@ func TestBuildPasswordKeyringUsername(t *testing.T) {
 		{
 			name: "missing role",
 			service: api.Service{
-				ProjectID: util.Ptr("project-123"),
-				ServiceID: util.Ptr("service-456"),
+				ProjectID: "project-123",
+				ServiceID: "service-456",
 			},
 			role:        "",
 			expected:    "",

--- a/internal/common/ready.go
+++ b/internal/common/ready.go
@@ -18,10 +18,7 @@ var (
 // CheckServiceReady returns nil only when the service is READY, ErrPaused for
 // PAUSED/PAUSING, and ErrNotReady for every other (or unknown) status.
 func CheckServiceReady(service api.Service) error {
-	if service.Status == nil {
-		return ErrNotReady
-	}
-	switch *service.Status {
+	switch service.Status {
 	case api.DeployStatusREADY:
 		return nil
 	case api.DeployStatusPAUSED, api.DeployStatusPAUSING:

--- a/internal/common/ready_test.go
+++ b/internal/common/ready_test.go
@@ -5,28 +5,27 @@ import (
 	"testing"
 
 	"github.com/timescale/tiger-cli/internal/api"
-	"github.com/timescale/tiger-cli/internal/util"
 )
 
 func TestCheckServiceReady(t *testing.T) {
 	tests := []struct {
 		name    string
-		status  *api.DeployStatus
+		status  api.DeployStatus
 		wantErr error
 	}{
-		{name: "ready", status: util.Ptr(api.DeployStatusREADY), wantErr: nil},
-		{name: "paused", status: util.Ptr(api.DeployStatusPAUSED), wantErr: ErrPaused},
-		{name: "pausing", status: util.Ptr(api.DeployStatusPAUSING), wantErr: ErrPaused},
-		{name: "queued", status: util.Ptr(api.DeployStatusQUEUED), wantErr: ErrNotReady},
-		{name: "configuring", status: util.Ptr(api.DeployStatusCONFIGURING), wantErr: ErrNotReady},
-		{name: "resuming", status: util.Ptr(api.DeployStatusRESUMING), wantErr: ErrNotReady},
-		{name: "upgrading", status: util.Ptr(api.DeployStatusUPGRADING), wantErr: ErrNotReady},
-		{name: "optimizing", status: util.Ptr(api.DeployStatusOPTIMIZING), wantErr: ErrNotReady},
-		{name: "unstable", status: util.Ptr(api.DeployStatusUNSTABLE), wantErr: ErrNotReady},
-		{name: "deleting", status: util.Ptr(api.DeployStatusDELETING), wantErr: ErrNotReady},
-		{name: "deleted", status: util.Ptr(api.DeployStatusDELETED), wantErr: ErrNotReady},
-		{name: "unknown status", status: util.Ptr(api.DeployStatus("SOMETHING_NEW")), wantErr: ErrNotReady},
-		{name: "nil status", status: nil, wantErr: ErrNotReady},
+		{name: "ready", status: api.DeployStatusREADY, wantErr: nil},
+		{name: "paused", status: api.DeployStatusPAUSED, wantErr: ErrPaused},
+		{name: "pausing", status: api.DeployStatusPAUSING, wantErr: ErrPaused},
+		{name: "queued", status: api.DeployStatusQUEUED, wantErr: ErrNotReady},
+		{name: "configuring", status: api.DeployStatusCONFIGURING, wantErr: ErrNotReady},
+		{name: "resuming", status: api.DeployStatusRESUMING, wantErr: ErrNotReady},
+		{name: "upgrading", status: api.DeployStatusUPGRADING, wantErr: ErrNotReady},
+		{name: "optimizing", status: api.DeployStatusOPTIMIZING, wantErr: ErrNotReady},
+		{name: "unstable", status: api.DeployStatusUNSTABLE, wantErr: ErrNotReady},
+		{name: "deleting", status: api.DeployStatusDELETING, wantErr: ErrNotReady},
+		{name: "deleted", status: api.DeployStatusDELETED, wantErr: ErrNotReady},
+		{name: "unknown status", status: api.DeployStatus("SOMETHING_NEW"), wantErr: ErrNotReady},
+		{name: "empty status", status: "", wantErr: ErrNotReady},
 	}
 
 	for _, tt := range tests {

--- a/internal/common/replica_test.go
+++ b/internal/common/replica_test.go
@@ -43,9 +43,9 @@ func primaryService() api.Service {
 	host := "svcprimary.example.com"
 	port := 5432
 	return api.Service{
-		ServiceID: util.Ptr("svcprimary"),
-		ProjectID: util.Ptr("proj1"),
-		Name:      util.Ptr("my-db"),
+		ServiceID: "svcprimary",
+		ProjectID: "proj1",
+		Name:      "my-db",
 		Endpoint:  &api.Endpoint{Host: &host, Port: &port},
 	}
 }
@@ -54,9 +54,9 @@ func replicaService() api.Service {
 	host := "replica.example.com"
 	port := 5432
 	return api.Service{
-		ServiceID: util.Ptr("rep1234567"),
-		ProjectID: util.Ptr("proj1"),
-		Name:      util.Ptr("reporting-replica"),
+		ServiceID: "rep1234567",
+		ProjectID: "proj1",
+		Name:      "reporting-replica",
 		Endpoint:  &api.Endpoint{Host: &host, Port: &port},
 		ForkedFrom: &api.ForkSpec{
 			IsStandby: util.Ptr(true),
@@ -77,7 +77,7 @@ func TestResolveConnectionTarget_Primary(t *testing.T) {
 	if target.IsReplica {
 		t.Fatal("expected a primary target")
 	}
-	if util.DerefStr(target.ConnectionService.ServiceID) != "svcprimary" || util.DerefStr(target.CredentialService.ServiceID) != "svcprimary" {
+	if target.ConnectionService.ServiceID != "svcprimary" || target.CredentialService.ServiceID != "svcprimary" {
 		t.Errorf("expected connect and credential to be the primary, got %+v", target)
 	}
 }
@@ -95,12 +95,12 @@ func TestResolveConnectionTarget_Replica(t *testing.T) {
 		t.Fatal("expected a replica target")
 	}
 	// Connect to the replica's own endpoint.
-	if util.DerefStr(target.ConnectionService.ServiceID) != "rep1234567" {
-		t.Errorf("expected connect service rep1234567, got %q", util.DerefStr(target.ConnectionService.ServiceID))
+	if target.ConnectionService.ServiceID != "rep1234567" {
+		t.Errorf("expected connect service rep1234567, got %q", target.ConnectionService.ServiceID)
 	}
 	// Credentials resolve against the parent primary (fetched via GetService).
-	if util.DerefStr(target.CredentialService.ServiceID) != "svcprimary" {
-		t.Errorf("expected credential service svcprimary, got %q", util.DerefStr(target.CredentialService.ServiceID))
+	if target.CredentialService.ServiceID != "svcprimary" {
+		t.Errorf("expected credential service svcprimary, got %q", target.CredentialService.ServiceID)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestResolveConnectionTargetByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !target.IsReplica || util.DerefStr(target.CredentialService.ServiceID) != "svcprimary" {
+	if !target.IsReplica || target.CredentialService.ServiceID != "svcprimary" {
 		t.Errorf("expected replica target with parent credentials, got %+v", target)
 	}
 
@@ -148,8 +148,8 @@ func TestNewReplicaConnectionTarget(t *testing.T) {
 	host := "menu-replica.example.com"
 	port := 5432
 	replica := api.ReadReplicaSet{
-		ID:       util.Ptr("rep7654321"),
-		Name:     util.Ptr("menu-replica"),
+		ID:       "rep7654321",
+		Name:     "menu-replica",
 		Endpoint: &api.Endpoint{Host: &host, Port: &port},
 	}
 
@@ -157,11 +157,11 @@ func TestNewReplicaConnectionTarget(t *testing.T) {
 	if !target.IsReplica {
 		t.Error("expected a replica target")
 	}
-	if util.DerefStr(target.ConnectionService.ServiceID) != "rep7654321" || util.DerefStr(target.ConnectionService.Endpoint.Host) != host {
+	if target.ConnectionService.ServiceID != "rep7654321" || util.DerefStr(target.ConnectionService.Endpoint.Host) != host {
 		t.Errorf("expected connect to carry the replica endpoint, got %+v", target.ConnectionService)
 	}
-	if util.DerefStr(target.CredentialService.ServiceID) != "svcprimary" {
-		t.Errorf("expected credential to be the primary, got %q", util.DerefStr(target.CredentialService.ServiceID))
+	if target.CredentialService.ServiceID != "svcprimary" {
+		t.Errorf("expected credential to be the primary, got %q", target.CredentialService.ServiceID)
 	}
 }
 
@@ -169,10 +169,10 @@ func TestReplicaPoolerWarning(t *testing.T) {
 	host := "h"
 	port := 6432
 	withPooler := api.Service{
-		Name:             util.Ptr("rep-a"),
+		Name:             "rep-a",
 		ConnectionPooler: &api.ConnectionPooler{Endpoint: &api.Endpoint{Host: &host, Port: &port}},
 	}
-	noPooler := api.Service{Name: util.Ptr("rep-b")}
+	noPooler := api.Service{Name: "rep-b"}
 
 	replica := func(svc api.Service) *ConnectionTarget {
 		return &ConnectionTarget{ConnectionService: svc, CredentialService: primaryService(), IsReplica: true}

--- a/internal/common/schema_fetch.go
+++ b/internal/common/schema_fetch.go
@@ -6,7 +6,6 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/timescale/tiger-cli/internal/config"
-	"github.com/timescale/tiger-cli/internal/util"
 )
 
 // FetchServiceSchema opens a read-only connection to the target (a primary
@@ -34,8 +33,8 @@ func FetchServiceSchema(ctx context.Context, cfg *config.Config, target *Connect
 	defer conn.Close(context.Background())
 
 	ident := SchemaIdent{
-		ID:   util.DerefStr(target.ConnectionService.ServiceID),
-		Name: util.DerefStr(target.ConnectionService.Name),
+		ID:   target.ConnectionService.ServiceID,
+		Name: target.ConnectionService.Name,
 	}
 	return FetchSchemaFromConn(ctx, conn, ident, opts)
 }

--- a/internal/common/wait.go
+++ b/internal/common/wait.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/timescale/tiger-cli/internal/api"
-	"github.com/timescale/tiger-cli/internal/util"
 )
 
 type WaitHandler interface {
@@ -101,7 +100,7 @@ type StatusWaitHandler struct {
 }
 
 func (h *StatusWaitHandler) Message() string {
-	return fmt.Sprintf("Service status: %s", util.DerefStr(h.Service.Status))
+	return fmt.Sprintf("Service status: %s", h.Service.Status)
 }
 
 func (h *StatusWaitHandler) InitialCheck() (bool, error) {
@@ -134,7 +133,7 @@ func (h *StatusWaitHandler) Check(resp *api.GetServiceResponse) (bool, error) {
 }
 
 func (h *StatusWaitHandler) checkServiceStatus(service *api.Service) (bool, error) {
-	status := util.DerefStr(service.Status)
+	status := string(service.Status)
 	switch status {
 	case h.TargetStatus:
 		return true, nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -159,7 +159,7 @@ func (s *Server) registerServiceTools(readOnly, experimental bool) {
 	addTool(s, readOnly, newServiceResizeTool(), s.handleServiceResize)
 	addTool(s, readOnly, newServiceLogsTool(), s.handleServiceLogs)
 
-	// Metrics tools target gateway endpoints marked `x-preview: true`. They
+	// Metrics tools target gateway endpoints marked `x-tigerdata-preview: true`. They
 	// are registered only when the experimental gate is on at server startup;
 	// the user must restart the MCP server after toggling the gate. Handler
 	// bodies re-check the gate defensively in case config changes mid-session.

--- a/internal/mcp/service_create.go
+++ b/internal/mcp/service_create.go
@@ -161,7 +161,7 @@ func (s *Server) handleServiceCreate(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	service := *resp.JSON202
-	serviceID := util.Deref(service.ServiceID)
+	serviceID := service.ServiceID
 
 	// Set as default service if requested (defaults to true)
 	if input.SetDefault {

--- a/internal/mcp/service_fork.go
+++ b/internal/mcp/service_fork.go
@@ -173,7 +173,7 @@ func (s *Server) handleServiceFork(ctx context.Context, req *mcp.CallToolRequest
 	}
 
 	service := *resp.JSON202
-	serviceID := util.Deref(service.ServiceID)
+	serviceID := service.ServiceID
 
 	// Save password immediately after service fork, before any waiting
 	// This ensures the password is stored even if the wait fails or is interrupted

--- a/internal/mcp/service_list.go
+++ b/internal/mcp/service_list.go
@@ -106,21 +106,17 @@ func (s *Server) handleServiceList(ctx context.Context, req *mcp.CallToolRequest
 // convertToServiceInfo converts an API Service to MCP ServiceInfo
 func (s *Server) convertToServiceInfo(service api.Service) ServiceInfo {
 	info := ServiceInfo{
-		ServiceID: util.Deref(service.ServiceID),
-		Name:      util.Deref(service.Name),
-		Status:    util.DerefStr(service.Status),
-		Type:      util.DerefStr(service.ServiceType),
-		Region:    util.Deref(service.RegionCode),
-	}
-
-	// Add creation time if available
-	if service.Created != nil {
-		info.Created = service.Created.Format("2006-01-02T15:04:05Z")
+		ServiceID: service.ServiceID,
+		Name:      service.Name,
+		Status:    string(service.Status),
+		Type:      string(service.ServiceType),
+		Region:    service.RegionCode,
+		Created:   service.Created.Format("2006-01-02T15:04:05Z"),
 	}
 
 	// Add resource information if available
-	if service.Resources != nil && len(*service.Resources) > 0 {
-		resource := (*service.Resources)[0]
+	if len(service.Resources) > 0 {
+		resource := service.Resources[0]
 		if resource.Spec != nil {
 			info.Resources = &ResourceInfo{}
 

--- a/internal/mcp/service_start.go
+++ b/internal/mcp/service_start.go
@@ -119,7 +119,7 @@ func (s *Server) handleServiceStart(ctx context.Context, req *mcp.CallToolReques
 
 	// Return status and message (after wait so status is accurate)
 	output := ServiceStartOutput{
-		Status:  util.DerefStr(service.Status),
+		Status:  string(service.Status),
 		Message: message,
 	}
 

--- a/internal/mcp/service_stop.go
+++ b/internal/mcp/service_stop.go
@@ -119,7 +119,7 @@ func (s *Server) handleServiceStop(ctx context.Context, req *mcp.CallToolRequest
 
 	// Return status and message (after wait so status is accurate)
 	output := ServiceStopOutput{
-		Status:  util.DerefStr(service.Status),
+		Status:  string(service.Status),
 		Message: message,
 	}
 

--- a/internal/mcp/utils.go
+++ b/internal/mcp/utils.go
@@ -78,21 +78,17 @@ func (ServiceDetail) Schema() *jsonschema.Schema {
 // convertToServiceDetail converts an API Service to MCP ServiceDetail
 func (s *Server) convertToServiceDetail(cfg *config.Config, service api.Service, withPassword bool) ServiceDetail {
 	detail := ServiceDetail{
-		ServiceID: util.Deref(service.ServiceID),
-		Name:      util.Deref(service.Name),
-		Status:    util.DerefStr(service.Status),
-		Type:      util.DerefStr(service.ServiceType),
-		Region:    util.Deref(service.RegionCode),
-	}
-
-	// Add creation time if available
-	if service.Created != nil {
-		detail.Created = service.Created.Format("2006-01-02T15:04:05Z")
+		ServiceID: service.ServiceID,
+		Name:      service.Name,
+		Status:    string(service.Status),
+		Type:      string(service.ServiceType),
+		Region:    service.RegionCode,
+		Created:   service.Created.Format("2006-01-02T15:04:05Z"),
 	}
 
 	// Add resource information if available
-	if service.Resources != nil && len(*service.Resources) > 0 {
-		resource := (*service.Resources)[0]
+	if len(service.Resources) > 0 {
+		resource := service.Resources[0]
 		if resource.Spec != nil {
 			detail.Resources = &ResourceInfo{}
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,6 +3,13 @@ info:
   title: Tiger Cloud API
   description: |
     A RESTful API for Tiger Cloud platform.
+
+    Operations and schemas annotated with `x-tigerdata-preview: true` are experimental —
+    their shape may change without notice and they are excluded from
+    auto-generated SDKs. Stable entries have no `x-tigerdata-preview` marker. Schemas
+    used only by preview operations should be tagged so the SDK doesn't
+    inherit orphan model classes; schemas shared with stable operations stay
+    unmarked.
   version: 1.0.0
   license:
     name: Proprietary
@@ -12,39 +19,23 @@ info:
     url: https://www.tigerdata.com/contact
 servers:
   - url: https://console.cloud.tigerdata.com/public/api/v1
-    description: API server for Tiger Cloud
+    description: API server for Tiger Cloud.
 
 tags:
   - name: Auth
     description: Authentication and authorization information.
+  - name: Projects
+    description: Manage the projects that organize your Tiger Cloud resources.
   - name: VPCs
     description: Manage VPCs and their peering connections.
   - name: Services
-    description: Manage services, read replicas, and their associated actions.
+    description: Manage services and their associated actions.
+  - name: Read Replica Sets
+    description: Manage read replica sets and their associated actions.
   - name: Analytics
     description: Track analytics events.
 
 paths:
-  /auth/info:
-    get:
-      operationId: getAuthInfo
-      tags:
-        - Auth
-      summary: Get Authentication Info
-      description: |
-        Returns the authenticated caller's identity. The response shape depends
-        on the credential type: `apiKey` for PAT callers, `oauth` for OAuth user callers. 
-        Exactly one of `apiKey` or `oauth` is populated; `type` discriminates.
-      responses:
-        '200':
-          description: Authentication information retrieved successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuthInfo'
-        '4XX':
-          $ref: '#/components/responses/ClientError'
-
   /auth/logout:
     post:
       operationId: logout
@@ -53,9 +44,13 @@ paths:
       summary: Log out and revoke refresh token
       description: |
         Revokes the caller's refresh token server-side. For OAuth Bearer
-        callers, include the refresh token in the request body. Returns
-        204 on success. The caller is still responsible for dropping any
-        locally-cached credentials.
+        callers, include the refresh token in the request body — it is held
+        client-side and cannot be derived from the access token. Callers
+        without a refresh token to revoke may post an
+        empty body to clear server-side session state best-effort.
+
+        Returns 204 No Content on success. The caller is still responsible
+        for dropping any locally-cached credentials.
       requestBody:
         required: false
         content:
@@ -65,10 +60,30 @@ paths:
               properties:
                 refresh_token:
                   type: string
-                  description: The OAuth refresh token to revoke.
+                  description: The OAuth refresh token to revoke. Omit for sessions without a refresh token.
       responses:
         '204':
           description: Logout successful.
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+
+  /auth/info:
+    get:
+      operationId: getAuthInfo
+      tags:
+        - Auth
+      summary: Get Authentication Info
+      description: |
+        Returns the authenticated caller's identity. The response shape depends on the credential type: `apiKey` for PAT
+        callers, `oauth` for OAuth user callers. Exactly one of `api_key` or `oauth` is populated;
+        `type` discriminates.
+      responses:
+        '200':
+          description: Authentication information retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthInfo'
         '4XX':
           $ref: '#/components/responses/ClientError'
 
@@ -89,7 +104,7 @@ paths:
                 properties:
                   type: object
                   additionalProperties: true
-                  description: Optional map of arbitrary properties associated with the user
+                  description: Optional map of arbitrary properties associated with the user.
                   example:
                     email: "user@example.com"
                     name: "John Doe"
@@ -117,12 +132,12 @@ paths:
               properties:
                 event:
                   type: string
-                  description: The name of the event to track
+                  description: The name of the event to track.
                   example: service_created
                 properties:
                   type: object
                   additionalProperties: true
-                  description: Optional map of arbitrary properties associated with the event
+                  description: Optional map of arbitrary properties associated with the event.
                   example:
                     region: "us-east-1"
       responses:
@@ -249,11 +264,7 @@ paths:
               $ref: '#/components/schemas/VPCRename'
       responses:
         '200':
-          description: VPC renamed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VPC'
+          $ref: '#/components/responses/SuccessMessage'
         '4XX':
           $ref: '#/components/responses/ClientError'
 
@@ -457,6 +468,32 @@ paths:
         '4XX':
           $ref: '#/components/responses/ClientError'
 
+  /projects/{project_id}/services/{service_id}/rename:
+    post:
+      operationId: renameService
+      tags:
+        - Services
+      summary: Rename a Service
+      description: Updates the name of a specific service.
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceRename'
+      responses:
+        '200':
+          description: Service renamed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+
   /projects/{project_id}/services/{service_id}/attachToVPC:
     post:
       operationId: attachServiceToVPC
@@ -636,8 +673,12 @@ paths:
         - Services
       summary: Get service logs
       description: |
-        Fetch logs for a specific service. Returns up to 500 log entries from
-        available logs. Supports pagination.
+        Fetch logs for a specific service. Returns up to 500 log entries in reverse
+        chronological order. Supports cursor-based pagination via the `cursor` parameter
+        and the `last_cursor` field in the response.
+
+        Use the returned `last_cursor` value as the `cursor` parameter on subsequent
+        requests to page through all available logs.
       parameters:
         - $ref: '#/components/parameters/ProjectId'
         - $ref: '#/components/parameters/ServiceId'
@@ -646,37 +687,62 @@ paths:
           required: false
           schema:
             type: integer
-          description: Specific service node to fetch logs from (for multi-node services)
-        - name: page
+            minimum: 0
+          description: Specific service node to fetch logs from (for multi-node services).
+        - name: cursor
           in: query
           required: false
-          deprecated: true
           schema:
-            type: integer
-          description: Page number for pagination (0-based)
+            type: string
+          description: |
+            Opaque pagination cursor returned as `last_cursor` in a previous response.
+            When provided, returns the next page of logs older than the cursor position.
         - name: until
           in: query
           required: false
           schema:
             type: string
             format: date-time
-          description: Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)
+          description: Upper bound timestamp — fetch logs before this time (RFC3339 format, e.g., 2024-01-15T10:00:00Z).
         - name: since
           in: query
           required: false
           schema:
             type: string
             format: date-time
-          description: Fetch logs after this timestamp (RFC3339 format, e.g., 2024-01-15T09:00:00Z).
-        - name: cursor
+          description: |
+            Lower bound timestamp — fetch logs after this time (RFC3339 format).
+        - name: search
           in: query
           required: false
           schema:
-            type: string
-          description: Opaque pagination cursor returned as lastCursor in a previous response. When provided, returns the next page of logs older than the cursor position.
+            type: array
+            items:
+              type: string
+              minLength: 1
+              pattern: "\\S"
+          style: form
+          explode: true
+          description: |
+            Full-text search terms to filter log lines. Repeat the parameter for multiple values
+            (e.g. `?search=slow+query&search=ERROR`).
+        - name: severities
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              minLength: 1
+              pattern: "\\S"
+          style: form
+          explode: true
+          description: |
+            Severity levels to filter results. Repeat the parameter for multiple values
+            (e.g. `?severities=ERROR&severities=WARNING`).
       responses:
         '200':
-          description: Service logs retrieved successfully
+          description: Service logs retrieved successfully.
           content:
             application/json:
               schema:
@@ -687,7 +753,7 @@ paths:
   /projects/{project_id}/services/{service_id}/metrics/available-series:
     get:
       operationId: getServiceMetricsAvailableSeries
-      x-preview: true
+      x-tigerdata-preview: true
       tags:
         - Services
       summary: List available metric series
@@ -713,7 +779,7 @@ paths:
   /projects/{project_id}/services/{service_id}/metrics/series:
     post:
       operationId: getServiceMetricsSeries
-      x-preview: true
+      x-tigerdata-preview: true
       tags:
         - Services
       summary: Get a metric series
@@ -766,7 +832,7 @@ paths:
               $ref: '#/components/schemas/SetHAReplicaInput'
       responses:
         '202':
-          description: HA replica configuration updated
+          description: HA replica configuration updated.
           content:
             application/json:
               schema:
@@ -856,7 +922,7 @@ paths:
               $ref: '#/components/schemas/ResizeInput'
       responses:
         '202':
-          description: Resize request has been accepted and is in progress.
+          $ref: '#/components/responses/SuccessMessage'
         '4XX':
           $ref: '#/components/responses/ClientError'
 
@@ -942,6 +1008,7 @@ components:
       description: The unique identifier of the read replica set.
       schema:
         type: string
+        minLength: 3
         example: "alb8jicdpr"
     VPCId:
       name: vpc_id
@@ -950,6 +1017,7 @@ components:
       description: The unique identifier of the VPC.
       schema:
         type: string
+        pattern: "^[0-9]+$"
         example: "1234567890"
     PeeringId:
       name: peering_id
@@ -958,6 +1026,7 @@ components:
       description: The unique identifier of the VPC peering connection.
       schema:
         type: string
+        pattern: "^[0-9]+$"
         example: "1234567890"
 
   schemas:
@@ -965,125 +1034,155 @@ components:
       type: object
       description: |
         Information about the authentication credentials being used. Exactly one
-        of `apiKey` or `oauth` is populated; the `type` field discriminates.
+        of `api_key` or `oauth` is populated; the `type` field discriminates.
       required:
         - type
       properties:
         type:
           type: string
           description: |
-            Discriminator for the credential shape. `apiKey` for PAT callers;
-            `oauth` for OAuth user callers.
+            Discriminator for the credential shape. `apiKey` for PAT callers; `oauth` for OAuth
+            user callers.
           enum: ["apiKey", "oauth"]
           example: "apiKey"
+        api_key:
+          $ref: '#/components/schemas/AuthInfoApiKey'
         apiKey:
-          type: object
-          description: Information about the API key credentials
-          required:
-            - public_key
-            - name
-            - created
-            - project
-            - issuing_user
-          properties:
-            public_key:
-              type: string
-              description: The public key of the client credentials
-              example: "tskey_abc123"
-            name:
-              type: string
-              description: The name of the credential
-              example: "my-production-token"
-            created:
-              type: string
-              format: date-time
-              description: When the client credentials were created
-              example: "2024-01-15T10:30:00Z"
-            project:
-              type: object
-              description: Information about the project
-              required:
-                - id
-                - name
-                - plan_type
-              properties:
-                id:
-                  type: string
-                  description: The project ID
-                  example: "rp1pz7uyae"
-                name:
-                  type: string
-                  description: The name of the project
-                  example: "My Production Project"
-                plan_type:
-                  type: string
-                  description: The plan type for the project
-                  example: "FREE"
-            issuing_user:
-              type: object
-              description: Information about the user who created the credentials
-              required:
-                - id
-                - name
-                - email
-              properties:
-                id:
-                  type: string
-                  description: The user ID
-                  example: "user123"
-                name:
-                  type: string
-                  description: The user's name
-                  example: "John Doe"
-                email:
-                  type: string
-                  format: email
-                  description: The user's email
-                  example: "john.doe@example.com"
+          deprecated: true
+          x-deprecated-reason: Use `api_key` instead.
+          x-go-name: ApiKeyDeprecated
+          description: Deprecated. Use `api_key` instead.
+          allOf:
+            - $ref: '#/components/schemas/AuthInfoApiKey'
         oauth:
-          type: object
-          description: OAuth user details. Present for OAuth user callers.
-          required:
-            - user
-          properties:
-            user:
-              type: object
-              required:
-                - id
-                - name
-                - email
-              properties:
-                id:
-                  type: string
-                  description: The numeric user ID
-                  example: "1234567"
-                name:
-                  type: string
-                  description: The user's name
-                  example: "John Doe"
-                email:
-                  type: string
-                  format: email
-                  description: The user's email
-                  example: "john.doe@example.com"
+          $ref: '#/components/schemas/AuthInfoOAuth'
+    AuthInfoApiKey:
+      type: object
+      description: Information about the API key credentials (PAT).
+      required:
+        - public_key
+        - name
+        - created
+        - project
+        - issuing_user
+      properties:
+        public_key:
+          type: string
+          description: The public key of the client credentials.
+          example: "tskey_abc123"
+        name:
+          type: string
+          description: The name of the credential.
+          example: "my-production-token"
+        created:
+          type: string
+          format: date-time
+          description: When the client credentials were created.
+          example: "2024-01-15T10:30:00Z"
+        project:
+          $ref: '#/components/schemas/AuthInfoProject'
+        issuing_user:
+          $ref: '#/components/schemas/AuthInfoIssuingUser'
+    AuthInfoProject:
+      type: object
+      description: Information about the project.
+      required:
+        - id
+        - name
+        - plan_type
+      properties:
+        id:
+          type: string
+          description: The project ID.
+          example: "rp1pz7uyae"
+        name:
+          type: string
+          description: The name of the project.
+          example: "My Production Project"
+        plan_type:
+          type: string
+          description: The plan type for the project.
+          example: "FREE"
+    AuthInfoIssuingUser:
+      type: object
+      description: Information about the user who created the credentials.
+      required:
+        - id
+        - name
+        - email
+      properties:
+        id:
+          type: string
+          description: The user ID.
+          example: "user123"
+        name:
+          type: string
+          description: The user's name.
+          example: "John Doe"
+        email:
+          type: string
+          format: email
+          description: The user's email.
+          example: "john.doe@example.com"
+    AuthInfoOAuth:
+      type: object
+      description: OAuth user details. Present for OAuth user callers.
+      required:
+        - user
+      properties:
+        user:
+          $ref: '#/components/schemas/AuthInfoUser'
+    AuthInfoUser:
+      type: object
+      description: The authenticated OAuth user.
+      required:
+        - id
+        - name
+        - email
+      properties:
+        id:
+          type: string
+          description: The numeric user ID.
+          example: "1234567"
+        name:
+          type: string
+          description: The user's name.
+          example: "John Doe"
+        email:
+          type: string
+          format: email
+          description: The user's email.
+          example: "john.doe@example.com"
     VPC:
       type: object
+      description: A virtual private cloud that services can be attached to.
+      required:
+        - id
+        - name
+        - cidr
+        - region_code
       properties:
         id:
           type: string
           readOnly: true
+          description: The unique identifier for the VPC.
           example: "1234567890"
         name:
           type: string
+          description: The name of the VPC.
           example: "my-production-vpc"
         cidr:
           type: string
+          format: cidr
+          description: The IPv4 CIDR block for the VPC, in address/prefix notation (e.g. 10.0.0.0/16).
           example: "10.0.0.0/16"
         region_code:
           type: string
+          description: The cloud region where the VPC is hosted.
           example: "us-east-1"
     VPCCreate:
       type: object
+      description: Parameters for creating a VPC.
       required:
         - name
         - cidr
@@ -1091,15 +1190,30 @@ components:
       properties:
         name:
           type: string
+          description: The name of the VPC.
           example: "my-production-vpc"
         cidr:
           type: string
+          format: cidr
+          description: The IPv4 CIDR block for the VPC, in address/prefix notation (e.g. 10.0.0.0/16).
           example: "10.0.0.0/16"
         region_code:
           type: string
+          description: The cloud region where the VPC will be created.
           example: "us-east-1"
+    ServiceRename:
+      type: object
+      description: Parameters for renaming a service.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The new name for the service.
+          example: "my-renamed-service"
     VPCRename:
       type: object
+      description: Parameters for renaming a VPC.
       required:
         - name
       properties:
@@ -1109,31 +1223,45 @@ components:
           example: "my-renamed-vpc"
     Peering:
       type: object
+      description: A VPC peering connection to an external cloud account.
+      required:
+        - id
+        - peer_account_id
+        - peer_region_code
+        - peer_vpc_id
       properties:
         id:
           type: string
           readOnly: true
+          description: The unique identifier for the peering connection.
           example: "1234567890"
         peer_account_id:
           type: string
+          description: The cloud account ID of the peer VPC.
           example: "acc-12345"
         peer_region_code:
           type: string
-          example: "aws-us-east-1"
+          description: The cloud region of the peer VPC.
+          example: "us-east-1"
         peer_vpc_id:
           type: string
+          description: The ID of the peer VPC.
           example: "1234567890"
         provisioned_id:
           type: string
+          description: The provider-assigned identifier for the provisioned peering.
           example: "1234567890"
         status:
           type: string
+          description: The current status of the peering connection.
           example: "active"
         error_message:
           type: string
+          description: A human-readable error message when the peering connection failed.
           example: "VPC not found"
     PeeringCreate:
       type: object
+      description: Parameters for creating a VPC peering connection.
       required:
         - peer_account_id
         - peer_region_code
@@ -1141,93 +1269,119 @@ components:
       properties:
         peer_account_id:
           type: string
+          description: The cloud account ID of the peer VPC.
           example: "acc-12345"
         peer_region_code:
           type: string
-          example: "aws-us-east-1"
+          description: The cloud region of the peer VPC.
+          example: "us-east-1"
         peer_vpc_id:
           type: string
+          description: The ID of the peer VPC.
           example: "1234567890"
     Endpoint:
       type: object
+      description: A network endpoint for connecting to a service.
       properties:
         host:
           type: string
-          example: "my-service.com"
+          description: The hostname of the endpoint.
+          example: "i4wmp4crev.oec7sxsza2.tsdb.cloud.timescale.com"
         port:
           type: integer
-          example: 8080
+          description: The port of the endpoint.
+          example: 32625
+    VPCEndpoint:
+      type: object
+      description: VPC endpoint configuration for connecting to a service over VPC peering.
+      properties:
+        host:
+          type: string
+          description: The hostname for connecting to the service over VPC peering.
+          example: "i4wmp4crev.oec7sxsza2.tsdb.cloud.timescale.com"
+        port:
+          type: integer
+          description: The port for connecting to the service over VPC peering.
+          example: 5432
+        vpc_id:
+          type: string
+          description: The ID of the VPC the endpoint is associated with.
+          example: "1337"
     ConnectionPooler:
       type: object
+      description: Connection pooler configuration for a service.
       properties:
         endpoint:
           $ref: '#/components/schemas/Endpoint'
     Service:
       type: object
+      description: A database service and its current configuration.
+      required:
+        - service_id
+        - project_id
+        - name
+        - region_code
+        - service_type
+        - created
+        - status
+        - resources
       properties:
         service_id:
           type: string
           description: The unique identifier for the service.
+          example: "kd9w2xp4mz"
         project_id:
           type: string
           description: The project this service belongs to.
+          example: "rp1pz7uyae"
         name:
           type: string
           description: The name of the service.
+          example: "my-production-db"
         region_code:
           type: string
           description: The cloud region where the service is hosted.
           example: "us-east-1"
         service_type:
-          $ref: '#/components/schemas/ServiceType'
+          allOf:
+            - $ref: '#/components/schemas/ServiceType'
           description: The type of the service.
         created:
           type: string
           format: date-time
-          description: Creation timestamp
+          description: Creation timestamp.
+          example: "2025-01-15T09:30:00Z"
         initial_password:
           type: string
           description: The initial password for the service.
           format: password
           example: "a-very-secure-initial-password"
         status:
-          $ref: '#/components/schemas/DeployStatus'
-          description: Current status of the service
+          allOf:
+            - $ref: '#/components/schemas/DeployStatus'
+          description: Current status of the service.
         resources:
           type: array
-          description: List of resources allocated to the service
+          description: List of resources allocated to the service.
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                description: Resource identifier
-              spec:
-                type: object
-                description: Resource specification
-                properties:
-                  cpu_millis:
-                    type: integer
-                    description: CPU allocation in millicores
-                  memory_gbs:
-                    type: integer
-                    description: Memory allocation in gigabytes
-                  volume_type:
-                    type: string
-                    description: Type of storage volume
+            $ref: '#/components/schemas/Resource'
+        metrics:
+          $ref: '#/components/schemas/ServiceMetrics'
         metadata:
-          type: object
-          description: Additional metadata for the service
-          properties:
-            environment:
-              type: string
-              description: Environment tag for the service
+          $ref: '#/components/schemas/ServiceMetadata'
         endpoint:
           $ref: '#/components/schemas/Endpoint'
+        vpc_endpoint:
+          description: VPC endpoint configuration if available.
+          allOf:
+            - $ref: '#/components/schemas/VPCEndpoint'
         vpcEndpoint:
-          type: object
-          nullable: true
-          description: VPC endpoint configuration if available
+          deprecated: true
+          x-deprecated-reason: Use `vpc_endpoint` instead.
+          x-go-name: VpcEndpointDeprecated
+          description: Deprecated. Use `vpc_endpoint` instead.
+          allOf:
+            - $ref: '#/components/schemas/VPCEndpoint'
         forked_from:
           $ref: '#/components/schemas/ForkSpec'
         ha_replicas:
@@ -1236,10 +1390,51 @@ components:
           $ref: '#/components/schemas/ConnectionPooler'
         read_replica_sets:
           type: array
+          description: The read replica sets attached to the service.
           items:
             $ref: '#/components/schemas/ReadReplicaSet'
+    Resource:
+      type: object
+      description: A resource allocated to the service.
+      properties:
+        id:
+          type: string
+          description: Resource identifier.
+          example: "n4ph2tqz8r"
+        spec:
+          $ref: '#/components/schemas/ResourceSpec'
+    ResourceSpec:
+      type: object
+      description: Resource specification.
+      properties:
+        cpu_millis:
+          type: integer
+          description: CPU allocation in millicores.
+          example: 1000
+        memory_gbs:
+          type: integer
+          description: Memory allocation in gigabytes.
+          example: 4
+        volume_type:
+          type: string
+          description: Type of storage volume.
+          example: "gp3"
+    ServiceMetadata:
+      type: object
+      description: Additional metadata for the service.
+      properties:
+        environment:
+          type: string
+          description: Environment tag for the service.
+          example: "PROD"
     ServiceType:
       type: string
+      description: |
+        The type of the service:
+        - TIMESCALEDB: a TimescaleDB service (PostgreSQL with the TimescaleDB extension)
+        - POSTGRES: a standard PostgreSQL service
+
+        VECTOR is deprecated and should not be used.
       enum:
       - TIMESCALEDB
       - POSTGRES
@@ -1249,7 +1444,10 @@ components:
         enum:
         - DEV
         - PROD
-        description: The environment tag for the service.
+        description: |
+          The environment tag for the service:
+          - DEV: a development environment
+          - PROD: a production environment
     ForkStrategy:
       type: string
       enum:
@@ -1263,6 +1461,20 @@ components:
         - PITR: Point-in-time recovery using target_time
     DeployStatus:
       type: string
+      description: |
+        The current deployment status of the service:
+        - QUEUED: the create request has been submitted and is queued
+        - DELETING: the service is being deleted
+        - CONFIGURING: the service is up but still completing configuration
+        - READY: fully configured and serving traffic
+        - DELETED: the service has been deleted
+        - UNSTABLE: the service was ready but is not currently reachable
+        - PAUSING: the service is being paused
+        - PAUSED: the service is paused (temporarily shut down)
+        - RESUMING: the service is resuming after being paused
+        - UPGRADING: the service is being updated
+
+        OPTIMIZING is deprecated and should not be used.
       enum:
       - QUEUED
       - DELETING
@@ -1277,27 +1489,48 @@ components:
       - OPTIMIZING
     ForkSpec:
       type: object
+      description: The service this service was forked from.
       properties:
         project_id:
           type: string
-          example: "asda1b2c3"
+          description: The project of the parent service.
+          example: "rp1pz7uyae"
         service_id:
           type: string
-          example: "bbss422fg"
+          description: The ID of the parent service.
+          example: "kd9w2xp4mz"
         is_standby:
           type: boolean
+          description: Whether this service is a standby of the parent service.
           example: false
     ReadReplicaSet:
       type: object
+      description: A set of read replicas for a service.
+      required:
+        - id
+        - name
+        - status
+        - nodes
+        - cpu_millis
+        - memory_gbs
       properties:
         id:
           type: string
+          description: The unique identifier for the read replica set.
           example: "alb8jicdpr"
         name:
           type: string
+          description: The name of the read replica set.
           example: "reporting-replica-1"
         status:
           type: string
+          description: |
+            The current status of the read replica set:
+            - creating: the replica set is being provisioned
+            - active: the replica set is provisioned and serving traffic
+            - resizing: the replica set is being resized
+            - deleting: the replica set is being deleted
+            - error: the replica set is in an error state
           enum: [creating, active, resizing, deleting, error]
           example: "active"
         nodes:
@@ -1313,23 +1546,29 @@ components:
           description: Memory allocation in gigabytes.
           example: 1
         metadata:
-          type: object
-          description: Additional metadata for the read replica set
-          properties:
-            environment:
-              type: string
-              description: Environment tag for the read replica set
+          $ref: '#/components/schemas/ReplicaSetMetadata'
         endpoint:
           $ref: '#/components/schemas/Endpoint'
         connection_pooler:
           $ref: '#/components/schemas/ConnectionPooler'
+    ReplicaSetMetadata:
+      type: object
+      description: Additional metadata for the read replica set.
+      properties:
+        environment:
+          type: string
+          description: Environment tag for the read replica set.
+          example: "PROD"
     ServiceCreate:
       type: object
+      description: Parameters for creating a service.
       required:
         - name
       properties:
         name:
           type: string
+          minLength: 1
+          maxLength: 128
           description: A human-readable name for the service.
           example: "my-production-db"
         addons:
@@ -1345,6 +1584,7 @@ components:
           example: "us-east-1"
         replica_count:
           type: integer
+          minimum: 0
           description: Number of high-availability replicas to create (all replicas are asynchronous by default).
           example: 2
         cpu_millis:
@@ -1356,8 +1596,9 @@ components:
           description: The initial memory allocation in gigabytes, or 'shared' for a shared-resource service.
           example: "4"
         environment_tag:
-          $ref: '#/components/schemas/EnvironmentTag'
-          description: The environment tag for the service, 'DEV' by default.
+          allOf:
+            - $ref: '#/components/schemas/EnvironmentTag'
+          description: The environment tag for the service.
           default: DEV
     ForkServiceCreate:
       type: object
@@ -1366,6 +1607,8 @@ components:
       properties:
         name:
           type: string
+          minLength: 1
+          maxLength: 128
           description: A human-readable name for the forked service. If not provided, will use parent service name with "-fork" suffix.
           example: "my-production-db-fork"
         cpu_millis:
@@ -1378,21 +1621,22 @@ components:
           example: "4"
         fork_strategy:
           $ref: '#/components/schemas/ForkStrategy'
-          description: Strategy for creating the fork. This field is required.
         target_time:
           type: string
           format: date-time
           description: Target time for point-in-time recovery. Required when fork_strategy is PITR.
           example: "2024-01-01T00:00:00Z"
         environment_tag:
-          $ref: '#/components/schemas/EnvironmentTag'
-          description: The environment tag for the forked service, 'DEV' by default.
+          allOf:
+            - $ref: '#/components/schemas/EnvironmentTag'
+          description: The environment tag for the forked service.
           default: DEV
       description: |
         Create a fork of an existing service. Service type, region code, and storage are always inherited from the parent service.
         HA replica count is always set to 0 for forked services.
     HAReplica:
       type: object
+      description: High-availability replica configuration for a service.
       properties:
         sync_replica_count:
           type: integer
@@ -1402,20 +1646,43 @@ components:
           type: integer
           description: Number of high-availability replicas (all replicas are asynchronous by default).
           example: 1
+    ServiceMetrics:
+      type: object
+      nullable: true
+      description: Resource usage metrics for the service.
+      properties:
+        memory_mb:
+          type: integer
+          nullable: true
+          description: Memory usage in megabytes.
+          example: 512
+        storage_mb:
+          type: integer
+          nullable: true
+          description: Storage usage in megabytes.
+          example: 1024
+        milli_cpu:
+          type: integer
+          nullable: true
+          description: CPU usage in millicores.
+          example: 250
     SetHAReplicaInput:
       type: object
       properties:
         sync_replica_count:
           type: integer
+          minimum: 0
           description: Number of synchronous high-availability replicas.
           example: 1
         replica_count:
           type: integer
+          minimum: 0
           description: Number of high-availability replicas (all replicas are asynchronous by default).
           example: 1
       description: At least one of sync_replica_count or replica_count must be provided.
     ReadReplicaSetCreate:
       type: object
+      description: Parameters for creating a read replica set.
       required:
         - name
         - nodes
@@ -1424,36 +1691,45 @@ components:
       properties:
         name:
           type: string
+          minLength: 1
+          maxLength: 128
           description: A human-readable name for the read replica.
           example: "my-reporting-replica"
         nodes:
           type: integer
+          minimum: 1
           description: Number of nodes to create in the replica set.
           example: 2
         cpu_millis:
           type: integer
+          minimum: 1
           description: The initial CPU allocation in milli-cores.
           example: 250
         memory_gbs:
           type: integer
+          minimum: 1
           description: The initial memory allocation in gigabytes.
           example: 1
     ResizeInput:
       type: object
+      description: Parameters for resizing a service.
       required:
         - cpu_millis
         - memory_gbs
       properties:
         cpu_millis:
           type: string
+          pattern: "^[0-9]+$"
           description: The new CPU allocation in milli-cores.
           example: "1000"
         memory_gbs:
           type: string
+          pattern: "^[0-9]+$"
           description: The new memory allocation in gigabytes.
           example: "4"
     UpdatePasswordInput:
       type: object
+      description: Parameters for updating a service's password.
       required:
         - password
       properties:
@@ -1464,26 +1740,33 @@ components:
           example: "a-very-secure-new-password"
     SetEnvironmentInput:
       type: object
+      description: Parameters for setting a service's environment.
       required:
         - environment
       properties:
         environment:
           type: string
-          description: The target environment for the service.
+          description: |
+            The target environment for the service:
+            - PROD: a production environment
+            - DEV: a development environment
           enum: [PROD, DEV]
       example:
         environment: "PROD"
     ServiceVPCInput:
       type: object
+      description: Parameters for attaching a service to a VPC.
       required:
         - vpc_id
       properties:
         vpc_id:
           type: string
+          pattern: "^[0-9]+$"
           description: The ID of the VPC to attach the service to.
           example: "1234567890"
     ServiceLogEntry:
       type: object
+      description: A single structured log entry from a service.
       required:
         - timestamp
         - message
@@ -1492,19 +1775,25 @@ components:
         timestamp:
           type: string
           format: date-time
-          description: Timestamp of the log entry (RFC3339 format)
+          description: Timestamp of the log entry (RFC3339 format).
+          example: "2025-01-15T09:30:00Z"
         message:
           type: string
-          description: Log message text
+          description: Log message text.
+          example: "database system is ready to accept connections"
         severity:
           type: string
-          description: PostgreSQL severity level (e.g. LOG, WARNING, ERROR, FATAL)
+          description: PostgreSQL severity level (e.g. LOG, WARNING, ERROR, FATAL).
+          example: "LOG"
     ServiceLogs:
       type: object
+      description: The logs for a service.
       required:
         - logs
       properties:
         logs:
+          deprecated: true
+          x-deprecated-reason: Use `entries` instead.
           type: array
           items:
             type: string
@@ -1513,14 +1802,58 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ServiceLogEntry'
-          description: Structured log entries with timestamp and severity metadata. Only present on the cursor-based path.
+          description: |
+            Structured log entries with timestamp and severity metadata.
+            Entries are in the same order as logs and can be used in place of it
+            by callers that need structured data.
+        last_cursor:
+          type: string
+          description: |
+            Opaque cursor for the next page of results. Present when more log entries
+            exist older than the last entry in this response. Pass this value as the
+            `cursor` query parameter to retrieve the next page. Absent when there are
+            no further results.
+          example: "eyJ0cyI6IjIwMjUtMDEtMTVUMDk6MzA6MDBaIn0="
         lastCursor:
           type: string
-          description: Opaque cursor for the next page of results. Present when more log entries exist older than the last entry in this response. Absent when there are no further results.
+          deprecated: true
+          x-deprecated-reason: Use `last_cursor` instead.
+          x-go-name: LastCursorDeprecated
+          description: Deprecated. Use `last_cursor` instead.
+          example: "eyJ0cyI6IjIwMjUtMDEtMTVUMDk6MzA6MDBaIn0="
+    Project:
+      type: object
+      description: A project that organizes your Tiger Cloud resources, such as services and VPCs.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: The unique identifier for the project.
+          example: "rp1pz7uyae"
+        name:
+          type: string
+          description: The name of the project.
+          example: "My Production Project"
+
+    Error:
+      type: object
+      description: An error returned when a request cannot be completed.
+      properties:
+        code:
+          type: string
+          description: A machine-readable error code.
+          example: "NOT_FOUND"
+        message:
+          type: string
+          description: A human-readable error message.
+          example: "The requested service could not be found."
 
     MetricsSeriesRequest:
-      x-preview: true
+      x-tigerdata-preview: true
       type: object
+      additionalProperties: false
       description: |
         Parameters for a single getServiceMetricsSeries query. Sent as a JSON
         body so callers can pass an unbounded filter set without query-string
@@ -1570,8 +1903,10 @@ components:
             - P99
             - LAST
           description: |
-            Aggregation function applied per bucket. Optional: when omitted,
-            the server picks the default for the metric (currently `LAST`).
+            Aggregation function applied to raw/pre-aggregated samples when
+            collapsing them into one value per output bucket. Optional: when
+            omitted the server picks the default for the metric (currently
+            `LAST`).
 
             Not accepted on the following metrics — requests are rejected
             with `INVALID_REQUEST`:
@@ -1590,6 +1925,18 @@ components:
               - `timescale_cloud_database_num_connections`
               - `timescale_cloud_database_job_duration_usecs`
               - `timescale_cloud_database_job_success`
+
+            Values:
+              - `RATE`: counter-reset-aware per-second rate of change.
+              - `INCREASE`: counter-reset-aware total increase over the bucket.
+              - `SUM`: sum of samples in the bucket.
+              - `AVG`: mean of samples in the bucket.
+              - `MIN`: minimum sample in the bucket.
+              - `MAX`: maximum sample in the bucket.
+              - `COUNT`: number of samples in the bucket.
+              - `P50` / `P90` / `P99`: percentile approximations (only valid
+                for metrics stored as sketches).
+              - `LAST`: the most recent sample in the bucket (default).
           example: "RATE"
         filters:
           type: array
@@ -1604,7 +1951,7 @@ components:
             $ref: '#/components/schemas/MetricLabelFilter'
 
     MetricLabelFilter:
-      x-preview: true
+      x-tigerdata-preview: true
       type: object
       description: A single key/value label match applied to a metric series query.
       required:
@@ -1613,15 +1960,17 @@ components:
       properties:
         key:
           type: string
+          minLength: 1
           description: Label key to match against, e.g. `role` or `job_id`.
           example: "role"
         value:
           type: string
+          minLength: 1
           description: Label value to match. Case sensitivity follows the underlying metric's storage convention.
           example: "primary"
 
     MetricSeries:
-      x-preview: true
+      x-tigerdata-preview: true
       type: object
       description: One labeled time series — the label set plus its per-bucket data points.
       required:
@@ -1642,7 +1991,7 @@ components:
             $ref: '#/components/schemas/MetricDataPoint'
 
     MetricDataPoint:
-      x-preview: true
+      x-tigerdata-preview: true
       type: object
       description: A single time/value pair within a MetricSeries.
       required:
@@ -1656,39 +2005,13 @@ components:
         value:
           type: number
           format: double
+          nullable: true
+          x-omitempty: false
           description: |
-            The aggregated value at this bucket. Buckets without collected
-            data are omitted from the parent series' `data` array; the API
-            does not currently emit null values.
+            The aggregated value at this bucket, or null for a gap bucket with
+            no collected data. Gap buckets are still emitted (one entry per
+            bucket in the window), so this is null rather than omitted.
           example: 247.5
-
-    Project:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          example: "rp1pz7uyae"
-        name:
-          type: string
-          example: "My Production Project"
-
-    Error:
-      type: object
-      properties:
-        code:
-          type: string
-        message:
-          type: string
-        details:
-          type: string
-          description: |
-            Additional context about the failure. Often the actionable part
-            of the error (e.g. "bearer auth is not enabled on this server"
-            for a generic UNAUTHORIZED). Optional; absent on errors with no
-            extra detail.
 
   responses:
     AnalyticsResponse:
@@ -1700,7 +2023,7 @@ components:
             properties:
               status:
                 type: string
-                description: Status of the analytics operation
+                description: Status of the analytics operation.
                 example: "success"
     SuccessMessage:
       description: The action was completed successfully.
@@ -1718,3 +2041,24 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: |
+        HTTP Basic auth with a Tiger Cloud PAT: `Authorization: Basic
+        base64(<public_key>:<secret_key>)`. The original auth scheme.
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        Bearer token: `Authorization: Bearer <jwt>`. Accepts FusionAuth JWTs
+        minted via the PKCE flow (user tokens) as well as JWTs minted via the
+        client-credentials exchange for a PAT. The two are distinguished by the
+        presence of the `timescale_pat_token_id` claim.
+
+security:
+  - basicAuth: []
+  - bearerAuth: []


### PR DESCRIPTION
Update the spec to get the latest changes. There shouldn't be behavioral changes.

- update the spec and regenerate the API client
- some service fields are now required, changed related Go code from pointers to plain values
- fixed a wrong path in the generate command
- kept the error "details" field by hand, the API still sends it