### PR TITLE
Set SilenceUsage: true on every leaf command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,32 +569,35 @@ The `internal/` directory follows Go conventions to prevent external imports of 
 
 ## Cobra Usage Display Pattern
 
-When implementing Cobra commands, use this pattern to control when usage information is displayed on errors:
+Every leaf command (one with a `RunE`) sets `SilenceUsage: true` as a literal
+field on its `cobra.Command` struct, unconditionally. A bad flag or a bad
+argument count therefore prints only the error, not the full help text:
 
 ```go
-RunE: func(cmd *cobra.Command, args []string) error {
-    // 1. Do argument validation first - errors here show usage
-    if len(args) < 1 {
-        return fmt.Errorf("service ID is required")
-    }
-
-    // 2. Set SilenceUsage = true after argument validation
-    cmd.SilenceUsage = true
-
-    // 3. Proceed with business logic - errors here don't show usage
-    if err := someAPICall(); err != nil {
-        return fmt.Errorf("operation failed: %w", err)
-    }
-
-    return nil
-},
+cmd := &cobra.Command{
+    Use:               "get [service-id]",
+    Args:              cobra.MaximumNArgs(1),
+    ValidArgsFunction: serviceIDCompletion(app),
+    SilenceUsage:      true,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        // ...
+    },
+}
 ```
 
-**Philosophy**:
-- Early argument/syntax errors → show usage (helps users learn command syntax)
-- Operational errors after arguments are validated → don't show usage (avoids cluttering output with irrelevant usage info)
+**Philosophy**: usage output is only useful the first time someone learns a
+command's syntax, and by then `--help` (or the docs) has already shown it. A
+wrong flag or a failed API call both just need the one-line error; burying it
+under a wall of flag descriptions makes it harder to read, not easier.
 
-This provides fine-grained control over when usage is displayed, improving user experience by showing help when it's relevant and hiding it when it's not.
+Because `SilenceUsage` lives on the struct literal, it's already `true` before
+`RunE` ever runs — including for a flag-parsing error, which cobra reports
+before calling `RunE` at all. There's nothing to set inside the handler.
+
+Parent/group commands (`tiger service`, `tiger mcp`) have no `RunE` and don't
+set it — cobra's own "unknown command" error for a bad subcommand name still
+shows that command's usage, which is the one case where seeing the available
+subcommands actually helps.
 
 `SilenceErrors` is a separate setting and is rarely needed: set it only on a
 command that already reports its own errors, so cobra doesn't print them a second
@@ -762,14 +765,13 @@ func buildMyFlaggedCmd(app *common.App) *cobra.Command {
     var retryCount int
 
     cmd := &cobra.Command{
-        Use:   "my-command",
-        Short: "Command with local flags",
+        Use:          "my-command",
+        Short:        "Command with local flags",
+        SilenceUsage: true,
         RunE: func(cmd *cobra.Command, args []string) error {
             if len(args) < 1 {
                 return fmt.Errorf("argument required")
             }
-
-            cmd.SilenceUsage = true
 
             // Use flag variables (they're in scope)
             fmt.Printf("Flag: %s, Feature: %t, Retries: %d\n",
@@ -803,10 +805,10 @@ that bug. Flag types that validate at parse time (`outputFlag` and friends in
 ```go
 func buildMyConfigurableFlagCmd(app *common.App) *cobra.Command {
     cmd := &cobra.Command{
-        Use:   "my-command",
-        Short: "Command with configurable flag",
+        Use:          "my-command",
+        Short:        "Command with configurable flag",
+        SilenceUsage: true,
         RunE: func(cmd *cobra.Command, args []string) error {
-            cmd.SilenceUsage = true
             cfg := app.GetConfig()
             // ... use cfg.Output which respects: flag > env > config > default
         },

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -85,9 +85,8 @@ Examples:
   tiger auth login`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			var err error

--- a/internal/cmd/auth_logout.go
+++ b/internal/cmd/auth_logout.go
@@ -19,9 +19,8 @@ func buildLogoutCmd(app *common.App) *cobra.Command {
 		Long:              `Remove stored credentials. For OAuth logins, also revokes the refresh token server-side.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			revokeOAuthSession(cmd, app, cfg)

--- a/internal/cmd/auth_status.go
+++ b/internal/cmd/auth_status.go
@@ -28,9 +28,8 @@ func buildStatusCmd(app *common.App) *cobra.Command {
 		Long:              "Displays whether you are logged in and shows your currently configured project ID.",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg, client, _, err := app.GetAll()
 			if err != nil {
 				if errors.Is(err, config.ErrNotLoggedIn) {

--- a/internal/cmd/config_reset.go
+++ b/internal/cmd/config_reset.go
@@ -16,9 +16,8 @@ func buildConfigResetCmd(app *common.App) *cobra.Command {
 		Long:              `Reset all configuration settings to their default values`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			if err := cfg.Reset(); err != nil {

--- a/internal/cmd/config_set.go
+++ b/internal/cmd/config_set.go
@@ -15,9 +15,8 @@ func buildConfigSetCmd(app *common.App) *cobra.Command {
 		Long:              `Set a configuration value and save it to ~/.config/tiger/config.yaml`,
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: configOptionCompletion,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			key, value := args[0], args[1]

--- a/internal/cmd/config_show.go
+++ b/internal/cmd/config_show.go
@@ -23,9 +23,8 @@ func buildConfigShowCmd(app *common.App) *cobra.Command {
 		Long:              `Display the current CLI configuration settings`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			// Values are re-read free of env and CLI flags (unless --with-env

--- a/internal/cmd/config_unset.go
+++ b/internal/cmd/config_unset.go
@@ -16,9 +16,8 @@ func buildConfigUnsetCmd(app *common.App) *cobra.Command {
 		Long:              `Remove a configuration value and save changes to ~/.config/tiger/config.yaml`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: configOptionCompletion,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			key := args[0]

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -80,8 +80,6 @@ func getServiceDetails(cmd *cobra.Command, app *common.App, args []string) (api.
 		return api.Service{}, err
 	}
 
-	cmd.SilenceUsage = true
-
 	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -88,9 +88,8 @@ Examples:
   tiger db psql svc-12345 -- -c "SELECT version();" --no-psqlrc`,
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg, _, _, err := app.GetAll()
 			if err != nil {
 				return err

--- a/internal/cmd/db_connection_string.go
+++ b/internal/cmd/db_connection_string.go
@@ -55,10 +55,10 @@ Examples:
   tiger db connection-string svc-12345 --with-password`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _, _, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 

--- a/internal/cmd/db_create_role.go
+++ b/internal/cmd/db_create_role.go
@@ -84,6 +84,7 @@ PostgreSQL Configuration Parameters That May Be Set:
     (kills queries that exceed the specified duration, in milliseconds)`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate arguments
 			if roleName == "" {
@@ -92,7 +93,6 @@ PostgreSQL Configuration Parameters That May Be Set:
 
 			cfg, _, _, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 

--- a/internal/cmd/db_save_password.go
+++ b/internal/cmd/db_save_password.go
@@ -46,10 +46,10 @@ Examples:
   tiger db save-password svc-12345 --password=your-password --password-storage pgpass`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _, _, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 

--- a/internal/cmd/db_schema.go
+++ b/internal/cmd/db_schema.go
@@ -48,10 +48,10 @@ Examples:
   tiger db schema svc-12345 --internal`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _, _, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 

--- a/internal/cmd/db_test_connection.go
+++ b/internal/cmd/db_test_connection.go
@@ -53,9 +53,8 @@ Examples:
   tiger db test-connection svc-12345 --timeout 0`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg, _, _, err := app.GetAll()
 			if err != nil {
 				return common.ExitWithCode(common.ExitInvalidParameters, err)

--- a/internal/cmd/mcp_get.go
+++ b/internal/cmd/mcp_get.go
@@ -38,10 +38,9 @@ Examples:
   tiger mcp get service_create -o yaml`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: mcpGetCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			capabilityName := args[0]
-
-			cmd.SilenceUsage = true
 
 			cfg := app.GetConfig()
 

--- a/internal/cmd/mcp_install.go
+++ b/internal/cmd/mcp_install.go
@@ -61,11 +61,10 @@ Examples:
 
   # Use custom configuration file path
   tiger mcp install claude-code --config-path ~/custom/config.json`, generateSupportedEditorsHelp()),
-		Args:      cobra.MaximumNArgs(1),
-		ValidArgs: getValidEditorNames(),
+		Args:         cobra.MaximumNArgs(1),
+		ValidArgs:    getValidEditorNames(),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			var clientName string
 			if len(args) == 0 {
 				// No client specified, prompt user to select one

--- a/internal/cmd/mcp_list.go
+++ b/internal/cmd/mcp_list.go
@@ -34,9 +34,8 @@ Examples:
   tiger mcp list -o yaml`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			// Create MCP server

--- a/internal/cmd/mcp_start.go
+++ b/internal/cmd/mcp_start.go
@@ -32,9 +32,9 @@ Examples:
   tiger mcp start http`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Default behavior when no subcommand is specified - use stdio
-			cmd.SilenceUsage = true
 			return startStdioServer(cmd, app)
 		},
 	}

--- a/internal/cmd/mcp_start_http.go
+++ b/internal/cmd/mcp_start_http.go
@@ -40,9 +40,9 @@ Examples:
   tiger mcp start http --host 192.168.1.100 --port 9000`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		SilenceErrors:     true, // HTTP server uses slog for all output, including errors
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
 			return startHTTPServer(cmd, app, httpHost, httpPort)
 		},
 	}

--- a/internal/cmd/mcp_start_stdio.go
+++ b/internal/cmd/mcp_start_stdio.go
@@ -18,8 +18,8 @@ Examples:
   tiger mcp start stdio`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
 			return startStdioServer(cmd, app)
 		},
 	}

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -81,6 +81,7 @@ Allowed CPU/Memory Configurations:
 Note: You can specify both CPU and memory together, or specify only one (the other will be automatically configured).`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Auto-generate service name if not provided
 			if createServiceName == "" {
@@ -112,8 +113,6 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			if createWaitTimeout <= 0 {
 				return fmt.Errorf("wait timeout must be positive, got %v", createWaitTimeout)
 			}
-
-			cmd.SilenceUsage = true
 
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {

--- a/internal/cmd/service_delete.go
+++ b/internal/cmd/service_delete.go
@@ -43,14 +43,13 @@ Examples:
   tiger service delete svc-12345 --wait-timeout 15m`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Require explicit service ID for safety
 			if len(args) < 1 {
 				return fmt.Errorf("service ID is required")
 			}
 			serviceID := args[0]
-
-			cmd.SilenceUsage = true
 
 			// Check read-only mode before the confirmation prompt, so it refuses
 			// without asking the user to type the service ID.

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -71,6 +71,7 @@ Examples:
   tiger service fork svc-12345 --now --wait-timeout 45m`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate timing flags first - exactly one must be specified
 			timingFlagsSet := 0
@@ -100,12 +101,10 @@ Examples:
 
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
 			if err := common.CheckReadOnly(cfg); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -114,8 +113,6 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()

--- a/internal/cmd/service_get.go
+++ b/internal/cmd/service_get.go
@@ -39,10 +39,10 @@ Examples:
   tiger service get svc-12345 --output yaml`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -51,8 +51,6 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			// Make API call to get service details
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)

--- a/internal/cmd/service_list.go
+++ b/internal/cmd/service_list.go
@@ -27,9 +27,8 @@ func buildServiceListCmd(app *common.App) *cobra.Command {
 		Long:              `List all database services in the current project.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
 				return err

--- a/internal/cmd/service_logs.go
+++ b/internal/cmd/service_logs.go
@@ -51,10 +51,10 @@ Examples:
   tiger service logs --tail 1000`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -63,8 +63,6 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			// Prepare parameters
 			var sincePtr *time.Time

--- a/internal/cmd/service_metrics_available_series.go
+++ b/internal/cmd/service_metrics_available_series.go
@@ -17,14 +17,14 @@ import (
 func buildServiceMetricsAvailableSeriesCmd(app *common.App) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:   "available-series [service-id]",
-		Short: "List available metric series",
-		Long:  `List the names of all metric series available for a service.`,
-		Args:  cobra.MaximumNArgs(1),
+		Use:          "available-series [service-id]",
+		Short:        "List available metric series",
+		Long:         `List the names of all metric series available for a service.`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -32,8 +32,6 @@ func buildServiceMetricsAvailableSeriesCmd(app *common.App) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()

--- a/internal/cmd/service_metrics_series.go
+++ b/internal/cmd/service_metrics_series.go
@@ -53,7 +53,8 @@ Examples:
   tiger service metrics series --metric some_metric_name \
     --from 2026-05-13T00:00:00Z --to 2026-05-13T01:00:00Z \
     --filter ordinal=0`,
-		Args: cobra.MaximumNArgs(1),
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fromTime, err := time.Parse(time.RFC3339, from)
 			if err != nil {
@@ -71,7 +72,6 @@ Examples:
 
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -79,8 +79,6 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			body := api.MetricsSeriesRequest{
 				Name: metric,

--- a/internal/cmd/service_resize.go
+++ b/internal/cmd/service_resize.go
@@ -58,15 +58,14 @@ Allowed CPU/Memory Configurations:
 Note: You can specify both CPU and memory together, or specify only one (the other will be automatically configured).`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
 			if err := common.CheckReadOnly(cfg); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -86,8 +85,6 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			if cpuMemoryCfg == nil {
 				return fmt.Errorf("must specify at least one of --cpu or --memory")
 			}
-
-			cmd.SilenceUsage = true
 
 			// Display resize information
 			cmd.PrintErrf("📐 Resizing service '%s' to %s...\n", serviceID, cpuMemoryCfg)

--- a/internal/cmd/service_start.go
+++ b/internal/cmd/service_start.go
@@ -36,15 +36,14 @@ Examples:
   tiger service start svc-12345 --wait-timeout 10m`,
 		ValidArgsFunction: serviceIDCompletion(app),
 		Args:              cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
 			if err := common.CheckReadOnly(cfg); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -53,8 +52,6 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			// Make the start request
 			resp, err := client.StartServiceWithResponse(

--- a/internal/cmd/service_stop.go
+++ b/internal/cmd/service_stop.go
@@ -36,15 +36,14 @@ Examples:
   tiger service stop svc-12345 --wait-timeout 10m`,
 		ValidArgsFunction: serviceIDCompletion(app),
 		Args:              cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
 			if err := common.CheckReadOnly(cfg); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -53,8 +52,6 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			cmd.SilenceUsage = true
 
 			// Make the stop request
 			resp, err := client.StopServiceWithResponse(

--- a/internal/cmd/service_update_password.go
+++ b/internal/cmd/service_update_password.go
@@ -54,15 +54,14 @@ Examples:
   tiger service update-password --auto-generate`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
 			if err := common.CheckReadOnly(cfg); err != nil {
-				cmd.SilenceUsage = true
 				return err
 			}
 
@@ -80,8 +79,6 @@ Examples:
 			if autoGenerate && password != "" {
 				return fmt.Errorf("cannot use --auto-generate and --new-password together")
 			}
-
-			cmd.SilenceUsage = true
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -32,9 +32,8 @@ func buildVersionCmd(app *common.App) *cobra.Command {
 		Long:              `Display version, build time, and git commit information for the Tiger CLI`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-
 			cfg := app.GetConfig()
 
 			versionOutput := VersionOutput{


### PR DESCRIPTION
## Summary
- Every command with a `RunE` now sets `SilenceUsage: true` as a literal field on its `cobra.Command`, instead of setting `cmd.SilenceUsage = true` inline after argument validation.
- A bad flag or invalid argument now prints just the error, instead of the error followed by the full help/usage text — the error used to get buried at the top of a long usage dump (most of which is not actually relevant to the user's command), making it hard to spot.
- Updated the "Cobra Usage Display Pattern" section in CLAUDE.md to describe the new, simpler rule.