### PR TITLE
Extend read_only config into all/prod/off modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,9 @@ func processData(cfg *config.Config) {
 Config-derived state lives on the `Config` too: credential storage is a set of
 methods on it (`cfg.StoreCredentials`, `cfg.GetStoredCredentials`,
 `cfg.RemoveCredentials`), keyed off `cfg.ConfigDir`, and `cfg.Set`/`Unset`/`Reset`
-write the config file and then reload the struct **in place**. Reloading in place
+write the config file and then reload the struct **in place**. `Set` also returns
+the value as stored, which isn't always its argument — `read_only` normalizes its
+legacy spellings — so echo the return value to the user rather than the input. Reloading in place
 is what lets a command change the config mid-run and have the App's readers see
 it — that's how `tiger config set analytics false` suppresses its own analytics
 event, and how `version_check false` suppresses the update notice.
@@ -397,7 +399,7 @@ pattern: `strconv.ParseBool(os.Getenv("TIGER_EXPERIMENTAL"))` is read once in
 and the MCP server read at registration time.
 
 - CLI: `buildServiceCmd` guards `cmd.AddCommand(buildServiceMetricsCmd(app))` with `if app.Experimental { … }`. When the env var is unset, the `metrics` subtree isn't added to the command tree at all — the command literally does not exist (no help entry, no tab completion, `unknown command` error like any typo).
-- MCP: `NewServer` passes `app.Experimental` to `registerServiceTools(readOnly, experimental bool)`, which guards the metrics tool `addTool` calls the same way, so the tools aren't advertised to MCP clients when the env var is off. Restart the MCP server after toggling.
+- MCP: `NewServer` passes `app.Experimental` to `registerServiceTools(mode config.ReadOnlyMode, experimental bool)`, which guards the metrics tool `addTool` calls the same way, so the tools aren't advertised to MCP clients when the env var is off. Restart the MCP server after toggling.
 
 **Do not mention `TIGER_EXPERIMENTAL` in user-facing docs, command help, spec
 files, or error messages.** When a feature graduates, remove the
@@ -443,7 +445,55 @@ helpers and API-to-output conversion live in `utils.go`.
 
 **Read-Only Mode Gate:**
 
-Write/destructive MCP tool handlers and CLI command `RunE` functions must call `common.CheckReadOnly(cfg)` (defined in `internal/common/errors.go`) immediately after reading the config from the App. When `cfg.ReadOnly` is `true`, the call returns `common.ErrReadOnly` and the API client is never invoked. The gated CLI commands today are `service create`, `service fork`, `service start`, `service stop`, `service resize`, `service update-password`, and `service delete`.
+`cfg.ReadOnly` is a `config.ReadOnlyMode` — `all`, `prod`, or `off`. The legacy
+booleans are still accepted: `config.Load` runs whatever the source held through
+`parseReadOnlyMode`, which takes the mode names plus every boolean spelling
+viper's weak typing can produce, so nothing downstream sees an unnormalized
+value. Since `prod` protects only services tagged `PROD`, every gate needs its
+target's environment tag, so the two checks in `internal/common/read_only.go`
+split the way `ResolveConnectionTarget`/`...ByID` does:
+
+- **`common.CheckReadOnly(cfg, tag)`** — the verdict, for a caller that has the
+  tag: from a fetched service via `common.ServiceEnvironmentTag(service)`
+  (responses carry it under `metadata`, not as the enum the requests take), or
+  from the tag about to be requested — `--environment` for `service
+  create`/`fork`, and a hardcoded `api.EnvironmentTagDEV` for the MCP versions,
+  which take no such input.
+- **`common.CheckReadOnlyByServiceID(ctx, cfg, client, projectID, serviceID)`** —
+  the same verdict from an ID, fetching the service to read its tag. Costs one
+  API call, and only under `prod`; `all` refuses and `off` allows without one. A
+  failed fetch is a refusal.
+
+Every write/destructive CLI `RunE` and MCP handler calls one of them: `service
+create`, `fork`, `start`, `stop`, `resize`, `update-password`, `delete` and `db
+create role` on the CLI side, and the six `service_*` write tools listed in
+`readOnlyGatedTools` on the MCP side.
+
+Four things to know before adding a surface:
+
+- **A replica set is judged on its own tag, not its primary's**, on both planes.
+  The API tags replica sets individually, so nothing is inherited — a replica of
+  a `PROD` primary is protected only if that replica set is itself tagged `PROD`.
+- **`prod` refuses creating a `PROD` service, not just modifying one.** No
+  existing service is at risk there, so it looks like over-reach — but allowing
+  it would let a caller create a service the same mode then refuses to stop,
+  resize or delete, recoverable only through the console. `service create`/`fork`
+  therefore gate on the tag they are about to request.
+- **MCP registration can't express `prod`.** `addTool` skips `readOnlyGatedTools`
+  only under `all`; under `prod` the write tools stay registered (they work on
+  `DEV` services) and refuse per call instead. `buildServerInstructions` has a
+  `prod` variant explaining that to the model, so a refusal doesn't read as a bug.
+- **Database sessions reach the same verdict**, through the same two functions.
+  Where the verdict is wanted as a boolean, write `CheckReadOnly(…) != nil` rather
+  than adding a wrapper, so grepping one name still finds every gate. For a
+  `ConnectionTarget`, pass `ConnectionService` — that's what judges a replica on
+  its own tag.
+
+`CheckReadOnly` needs a tag, so it can't accidentally be called in a way that
+ignores `prod`. The one exception is refusing the blanket case *before* a fetch
+the command was making anyway: read the mode directly with
+`if cfg.ReadOnly.BlocksAll() { return common.ErrReadOnly }`, then still call
+`CheckReadOnly` once the service arrives. `service update-password` does both.
 
 **Tool Definition Pattern:**
 
@@ -1072,6 +1122,10 @@ answer, stderr so they can see what they're being asked. A prompt nobody can see
 reads as a hang, and can be answered by accident — a stray Enter at `service
 update-password` rotates the password. Confirmations, password prompts, and
 BubbleTea programs all follow this rule.
+
+A prompt that merely *offers* something skips silently instead of erroring, since
+nothing is being refused — `offerProdProtection` in `auth_login.go` is the one
+example.
 
 The gate is about *prompts*, not about reading stdin as such. A read whose whole
 point is piped input — `util.ReadAll` on a here-doc or a `|` — must not be

--- a/README.md
+++ b/README.md
@@ -252,7 +252,13 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `mcp_max_rows` - Maximum number of rows the `db_execute_query` MCP tool returns per result set before truncating, to limit how much data lands in an AI agent's context. Only applies to the MCP tool, not CLI commands. Default: `100`
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
-- `read_only` - When `true`, mutating operations are refused: the `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` CLI commands return an error, and their MCP equivalents are not registered, so they don't appear in `tools/list` and can't be called. `tiger db connect`, `tiger db connection-string`, and the `db_execute_query` MCP tool open the database session in Tiger Cloud's immutable read-only mode (writes and DDL are rejected by the server). Read commands/tools are unaffected — `tiger db schema` and the `db_schema` MCP tool always open a read-only session regardless of this setting. Default: `false`.
+- `read_only` - Which services this CLI may change: `all`, `prod`, or `off` (default: `off`, which protects nothing). An interactive `tiger auth login` offers a menu of the three modes, and records your choice either way, so it only asks until you answer once. `true` and `on` are accepted as aliases for `all`, and `false` for `off`, so existing config files and `TIGER_READ_ONLY=true` behave as before.
+
+  Changing a protected service is refused, and so is creating one: `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` and `tiger db create role` return an error. Connection strings for it open the session in Tiger Cloud's immutable read-only mode, so the server rejects writes and DDL — that covers `tiger db connect`, `tiger db connection-string`, the `db_execute_query` MCP tool, and the connection strings embedded in `tiger service` output and the equivalent MCP tools.
+
+  - `all` protects every service, and the MCP write tools aren't registered at all, so they don't appear in `tools/list` and can't be called.
+  - `prod` protects only services tagged `PROD`, leaving `DEV` services writable. `tiger service create`/`fork` are gated on the `--environment` they request, so creating a `DEV` service is allowed and a `PROD` one is not — otherwise you could create a service this same mode then refuses to delete. Forking a `PROD` service into a `DEV` fork is allowed, since that reads production without changing it. The MCP write tools stay registered — they still work on `DEV` services — and refuse per call instead. Reading a service's tag costs one extra API call for `tiger service start`/`stop`/`resize`/`delete`, and the operation is refused if that lookup fails. A read replica is judged on its own tag, so a replica of a `PROD` primary is protected only if that replica set is itself tagged `PROD`.
+
 - `service_id` - Default service ID. Cleared automatically when the active project changes: by `tiger project`, and by `tiger auth login` unless it lands on the same project as the previous login. A service belongs to the project it was created in
 - `version_check` - When `true`, the CLI checks for a newer version on each invocation (in an interactive terminal) and prints a notice if one is available. Set to `false` to disable. Default: `true`.
 
@@ -266,7 +272,7 @@ Environment variables override configuration file values. All variables use the 
 - `TIGER_DOCS_MCP` - Enable/disable docs MCP proxy
 - `TIGER_OUTPUT` - Output format: `json`, `yaml`, or `table`
 - `TIGER_PASSWORD_STORAGE` - Password storage method: `keyring`, `pgpass`, or `none`
-- `TIGER_READ_ONLY` - When `true`, write/destructive CLI commands return an error, the corresponding Tiger MCP write tools are not registered, and `db_execute_query` runs against a read-only database connection
+- `TIGER_READ_ONLY` - Which services this CLI may change: `all`, `prod`, or `off` (same aliases as `read_only`)
 - `TIGER_PUBLIC_KEY` - Public key to use for authentication (takes priority over stored credentials)
 - `TIGER_SECRET_KEY` - Secret key to use for authentication (takes priority over stored credentials)
 - `TIGER_SERVICE_ID` - Default service ID

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -31,8 +31,21 @@ const nextStepsMessage = `
 • Install MCP server for your favorite AI coding tool: tiger mcp install
 • List existing services: tiger service list
 • Create a new service: tiger service create
-• Enable read-only mode: tiger config set read_only true
 `
+
+// readOnlyNextStep tells the user how to set read_only by hand. Printing it to
+// someone who just picked a mode from the menu would read as if their answer
+// didn't take, so it's only for logins that left the choice unmade.
+const readOnlyNextStep = "• Protect services from writes: tiger config set read_only prod (or all, off)\n"
+
+// nextSteps is the post-login message, picking up readOnlyNextStep when the
+// config file holds no read_only value.
+func nextSteps(readOnlySet bool) string {
+	if readOnlySet {
+		return nextStepsMessage
+	}
+	return nextStepsMessage + readOnlyNextStep
+}
 
 var (
 	// openBrowser can be overridden for testing
@@ -184,7 +197,165 @@ func finishLogin(cmd *cobra.Command, cfg *config.Config, prevProjectID, projectI
 		clearStaleDefaultService(cmd, cfg)
 	}
 	cmd.Printf("Successfully logged in (project: %s)\n", projectID)
-	cmd.Print(nextStepsMessage)
+
+	readOnlySet := offerProdProtection(cmd, cfg)
+	cmd.Print(nextSteps(readOnlySet))
+}
+
+// offerProdProtection asks which services to protect from writes. Every choice
+// is recorded, so it asks exactly once — including of users who predate the
+// option. Choosing "off" stores read_only=off rather than leaving the key
+// absent, which a later login would read as never having been asked.
+//
+// It reports whether the config file now holds a read_only value, written just
+// now or by an earlier login. False means nobody has set one, so nextSteps says
+// how to do it by hand.
+func offerProdProtection(cmd *cobra.Command, cfg *config.Config) bool {
+	// TIGER_READ_ONLY outranks the config file, so a mode chosen here wouldn't
+	// take effect.
+	if os.Getenv("TIGER_READ_ONLY") != "" {
+		return true
+	}
+
+	stored, err := config.LoadForOutput(cfg.ConfigDir, false, true)
+	if err != nil {
+		// Can't tell whether it was ever answered, so don't ask — but do print the
+		// bullet, which is the harmless half of the two.
+		return false
+	}
+	if stored.ReadOnly != nil {
+		return true
+	}
+
+	// Both streams, per the convention: stdin so the answer can be read, stderr so
+	// the question can be seen. An unseen prompt reads as a hang.
+	if !util.IsTerminal(cmd.InOrStdin()) || !util.IsTerminal(cmd.ErrOrStderr()) {
+		return false
+	}
+
+	mode, chose := selectReadOnlyMode(cmd)
+	if !chose {
+		// Dismissed rather than answered, so record nothing and ask again.
+		return false
+	}
+
+	if _, err := cfg.Set("read_only", string(mode)); err != nil {
+		cmd.PrintErrf("⚠️  Warning: could not set read_only: %v\n", err)
+		return false
+	}
+	if msg := readOnlyConfirmation(mode); msg != "" {
+		cmd.PrintErrln(msg)
+	}
+	return true
+}
+
+// readOnlyConfirmation is what to report after a mode is stored.
+func readOnlyConfirmation(mode config.ReadOnlyMode) string {
+	switch mode {
+	case config.ReadOnlyProd:
+		return "Services tagged PROD are now protected from writes."
+	case config.ReadOnlyAll:
+		return "All services are now protected from writes."
+	default:
+		return ""
+	}
+}
+
+// readOnlyChoice is one option in the post-login menu.
+type readOnlyChoice struct {
+	mode  config.ReadOnlyMode
+	label string
+}
+
+// readOnlyChoices lists every mode, so the menu doubles as the one place a new
+// user learns the option exists. Recommended mode first, which is also where
+// the cursor starts.
+var readOnlyChoices = []readOnlyChoice{
+	{config.ReadOnlyProd, "Services tagged PROD only (recommended)"},
+	{config.ReadOnlyAll, "Every service"},
+	{config.ReadOnlyOff, "Nothing - allow writes everywhere"},
+}
+
+// selectReadOnlyMode shows the menu and reports the chosen mode. The bool is
+// false when the user dismissed it without choosing, which is not an answer.
+var selectReadOnlyMode = selectReadOnlyModeImpl
+
+func selectReadOnlyModeImpl(cmd *cobra.Command) (config.ReadOnlyMode, bool) {
+	program := tea.NewProgram(readOnlyModel{},
+		tea.WithInput(cmd.InOrStdin()),
+		tea.WithOutput(cmd.ErrOrStderr()),
+		tea.WithContext(cmd.Context()),
+		tea.WithoutSignalHandler())
+
+	finalModel, err := program.Run()
+	if err != nil {
+		// A menu we couldn't show is not a decline: leave the key absent so the
+		// next login asks again.
+		return "", false
+	}
+
+	chosen := finalModel.(readOnlyModel).chosen
+	return chosen, chosen != ""
+}
+
+// readOnlyModel is the menu. A zero chosen means dismissed, so quitting can't be
+// mistaken for picking the mode the cursor happened to rest on.
+type readOnlyModel struct {
+	cursor int
+	chosen config.ReadOnlyMode
+}
+
+func (m readOnlyModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m readOnlyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch key := msg.String(); key {
+		case "ctrl+c", "q", "esc":
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(readOnlyChoices)-1 {
+				m.cursor++
+			}
+		case "enter", "space":
+			m.chosen = readOnlyChoices[m.cursor].mode
+			return m, tea.Quit
+		default:
+			// Number keys jump straight to that option ('1' -> first, etc.).
+			if len(key) == 1 && key[0] >= '1' && key[0] <= '9' {
+				if idx := int(key[0] - '1'); idx < len(readOnlyChoices) {
+					m.cursor = idx
+					m.chosen = readOnlyChoices[idx].mode
+					return m, tea.Quit
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m readOnlyModel) View() tea.View {
+	var s strings.Builder
+	s.WriteString("Which services should be protected from writes?\n\n")
+
+	for i, choice := range readOnlyChoices {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+		s.WriteString(fmt.Sprintf("%s %d. %s\n", cursor, i+1, choice.label))
+	}
+
+	// No "change it later" hint: dismissing prints the readOnlyNextStep bullet a
+	// few lines below, and "q to decide later" already says so anyway.
+	s.WriteString("\nUse ↑/↓ arrows or number keys to select, enter to confirm, q to decide later")
+	return tea.NewView(s.String())
 }
 
 func flagOrEnvVar(flagVal, envVarName string) string {

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
@@ -25,7 +27,10 @@ func TestAuthLoginCmd(t *testing.T) {
 	// public key are rejected, everything else is accepted with the project ID
 	// "test-project-id".
 	authInfoServer := startMockAuthInfoServer(t)
-	patURLs := map[string]any{"api_url": authInfoServer.URL}
+	// read_only is pinned so the post-login prompt never fires in these cases:
+	// a stored value is what makes offerProdProtection skip it. The prompt has
+	// its own TestOfferProdProtection.
+	patURLs := map[string]any{"api_url": authInfoServer.URL, "read_only": "off"}
 
 	// OAuth flow cases. The flow's stderr embeds a random state and callback
 	// port, so it is matched with matchOAuthStderr rather than exactly.
@@ -73,7 +78,7 @@ func TestAuthLoginCmd(t *testing.T) {
 				withIsTerminal(true),
 				withReadPassword("prompted-secret"),
 			},
-			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextSteps(true),
 			wantStderr: "You can find your API credentials at: https://console.cloud.tigerdata.com/dashboard/settings\n\nEnter your secret key: \nValidating API key...\n",
 			checks:     []checkFunc{checkStoredAPIKey("test-public-key:prompted-secret", "test-project-id")},
 		},
@@ -85,7 +90,7 @@ func TestAuthLoginCmd(t *testing.T) {
 				withIsTerminal(true),
 				withStdin("prompted-public\n"),
 			},
-			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextSteps(true),
 			wantStderr: "You can find your API credentials at: https://console.cloud.tigerdata.com/dashboard/settings\n\nEnter your public key: Validating API key...\n",
 			checks:     []checkFunc{checkStoredAPIKey("prompted-public:test-secret-key", "test-project-id")},
 		},
@@ -111,7 +116,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			name:       "stores credentials from flags",
 			args:       []string{"auth", "login", "--public-key", "test-public-key", "--secret-key", "test-secret-key"},
 			opts:       []runOption{withConfig(patURLs)},
-			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextSteps(true),
 			wantStderr: "Validating API key...\n",
 			checks:     []checkFunc{checkStoredAPIKey("test-public-key:test-secret-key", "test-project-id")},
 		},
@@ -140,7 +145,7 @@ func TestAuthLoginCmd(t *testing.T) {
 				"--project-id", "test-project-id",
 			},
 			opts:       []runOption{withConfig(patURLs)},
-			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextSteps(true),
 			wantStderr: "Validating API key...\n",
 			checks:     []checkFunc{checkStoredAPIKey("test-public-key:test-secret-key", "test-project-id")},
 		},
@@ -152,7 +157,7 @@ func TestAuthLoginCmd(t *testing.T) {
 				withEnv("TIGER_PUBLIC_KEY", "env-public-key"),
 				withEnv("TIGER_SECRET_KEY", "env-secret-key"),
 			},
-			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: test-project-id)\n" + nextSteps(true),
 			wantStderr: "Validating API key...\n",
 			checks:     []checkFunc{checkStoredAPIKey("env-public-key:env-secret-key", "test-project-id")},
 		},
@@ -160,7 +165,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			name:       "oauth single project",
 			args:       []string{"auth", "login"},
 			opts:       oauthOpts(singleProject.URL),
-			wantStdout: "Successfully logged in (project: project-123)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: project-123)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(singleProject.URL, ""),
 			checks:     []checkFunc{checkStoredOAuthCredentials("project-123")},
 		},
@@ -169,7 +174,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			name:       "oauth multiple projects with interactive selection",
 			args:       []string{"auth", "login"},
 			opts:       oauthOpts(multiProject.URL, withIsTerminal(true), withSelectProject(2)),
-			wantStdout: "Successfully logged in (project: project-789)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: project-789)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(multiProject.URL, ""),
 			checks:     []checkFunc{checkStoredOAuthCredentials("project-789")},
 		},
@@ -187,7 +192,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			name:       "oauth project-id flag skips selection",
 			args:       []string{"auth", "login", "--project-id", "project-456"},
 			opts:       oauthOpts(multiProject.URL),
-			wantStdout: "Successfully logged in (project: project-456)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: project-456)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(multiProject.URL, ""),
 			checks:     []checkFunc{checkStoredOAuthCredentials("project-456")},
 		},
@@ -223,7 +228,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			opts: oauthOpts(singleProject.URL,
 				withConfig(map[string]any{"service_id": "svc-before"}),
 				withStoredCredentials(prevOAuthCredentials("project-old"))),
-			wantStdout: "Successfully logged in (project: project-123)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: project-123)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(singleProject.URL, regexp.QuoteMeta(
 				"Cleared default service (config key service_id): it belonged to the previous project\n")),
 			checks: []checkFunc{checkDefaultService("")},
@@ -235,7 +240,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			args: []string{"auth", "login"},
 			opts: oauthOpts(singleProject.URL,
 				withConfig(map[string]any{"service_id": "svc-before"})),
-			wantStdout: "Successfully logged in (project: project-123)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: project-123)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(singleProject.URL, regexp.QuoteMeta(
 				"Cleared default service (config key service_id): it belonged to the previous project\n")),
 			checks: []checkFunc{checkDefaultService("")},
@@ -246,7 +251,7 @@ func TestAuthLoginCmd(t *testing.T) {
 			opts: oauthOpts(singleProject.URL,
 				withConfig(map[string]any{"service_id": "svc-before"}),
 				withStoredCredentials(prevOAuthCredentials("project-123"))),
-			wantStdout: "Successfully logged in (project: project-123)\n" + nextStepsMessage,
+			wantStdout: "Successfully logged in (project: project-123)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(singleProject.URL, ""),
 			checks:     []checkFunc{checkDefaultService("svc-before")},
 		},
@@ -344,6 +349,8 @@ func oauthURLs(serverURL string) map[string]any {
 		"console_url": serverURL,
 		"gateway_url": serverURL,
 		"api_url":     serverURL,
+		// See patURLs: pinned so the post-login prompt stays out of these cases.
+		"read_only": "off",
 	}
 }
 
@@ -469,5 +476,136 @@ func checkStoredAPIKey(apiKey, projectID string) checkFunc {
 		if creds.ProjectID != projectID {
 			t.Errorf("stored project ID = %q, want %q", creds.ProjectID, projectID)
 		}
+	}
+}
+
+// TestOfferProdProtection covers the post-login read-only prompt with the menu
+// itself stubbed out; TestReadOnlyModel_KeySelection covers the menu. The
+// "already ..." cases guard the ask-exactly-once property, which a stored
+// read_only value is the only thing enforcing.
+func TestOfferProdProtection(t *testing.T) {
+	tests := []struct {
+		name string
+		// preexisting is empty when read_only is absent from the file.
+		preexisting string
+		// answer is what the menu returns; "" means dismissed without choosing.
+		answer config.ReadOnlyMode
+		// env is TIGER_READ_ONLY, which outranks the config file.
+		env         string
+		notATTY     bool
+		wantMenu    bool
+		wantStored  string // "" = key must stay absent
+		wantMessage string // "" = nothing printed
+		// wantReadOnlySet is the return value, which decides whether the caller
+		// prints the "tiger config set read_only" bullet - false means it does.
+		wantReadOnlySet bool
+	}{
+		{name: "prod stores prod", answer: config.ReadOnlyProd, wantMenu: true, wantStored: "prod", wantMessage: "Services tagged PROD are now protected", wantReadOnlySet: true},
+		{name: "all stores all", answer: config.ReadOnlyAll, wantMenu: true, wantStored: "all", wantMessage: "All services are now protected", wantReadOnlySet: true},
+		{name: "off stores off silently", answer: config.ReadOnlyOff, wantMenu: true, wantStored: "off", wantReadOnlySet: true},
+		{name: "dismissed records nothing", answer: "", wantMenu: true, wantStored: ""},
+		{name: "not a terminal skips silently", answer: config.ReadOnlyProd, notATTY: true, wantStored: ""},
+		{name: "already declined", preexisting: "off", answer: config.ReadOnlyProd, wantStored: "off", wantReadOnlySet: true},
+		{name: "already opted in", preexisting: "prod", answer: config.ReadOnlyOff, wantStored: "prod", wantReadOnlySet: true},
+		{name: "already set to all", preexisting: "all", answer: config.ReadOnlyProd, wantStored: "all", wantReadOnlySet: true},
+		// The env var wins over the file, so writing a choice there would be a lie.
+		{name: "env var answers it without prompting", env: "all", answer: config.ReadOnlyProd, wantStored: "", wantReadOnlySet: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if tt.env != "" {
+				t.Setenv("TIGER_READ_ONLY", tt.env)
+			}
+			values := map[string]any{}
+			if tt.preexisting != "" {
+				values["read_only"] = tt.preexisting
+			}
+			writeConfigFile(t, tmpDir, values)
+			cfg, err := config.Load(testFlags(t, tmpDir))
+			if err != nil {
+				t.Fatalf("config.Load failed: %v", err)
+			}
+			stubIsTerminal(t, !tt.notATTY)
+
+			shown := false
+			original := selectReadOnlyMode
+			t.Cleanup(func() { selectReadOnlyMode = original })
+			selectReadOnlyMode = func(_ *cobra.Command) (config.ReadOnlyMode, bool) {
+				shown = true
+				return tt.answer, tt.answer != ""
+			}
+
+			cmd := &cobra.Command{}
+			cmd.SetContext(t.Context())
+			errOut := new(bytes.Buffer)
+			cmd.SetOut(new(bytes.Buffer))
+			cmd.SetErr(errOut)
+
+			readOnlySet := offerProdProtection(cmd, cfg)
+
+			if shown != tt.wantMenu {
+				t.Errorf("menu shown = %t, want %t", shown, tt.wantMenu)
+			}
+			if readOnlySet != tt.wantReadOnlySet {
+				t.Errorf("readOnlySet = %t, want %t", readOnlySet, tt.wantReadOnlySet)
+			}
+
+			stored, err := config.LoadForOutput(tmpDir, false, true)
+			if err != nil {
+				t.Fatalf("LoadForOutput failed: %v", err)
+			}
+			got := ""
+			if stored.ReadOnly != nil {
+				got = string(*stored.ReadOnly)
+			}
+			if got != tt.wantStored {
+				t.Errorf("stored read_only = %q, want %q", got, tt.wantStored)
+			}
+
+			if tt.wantMessage == "" {
+				if errOut.Len() != 0 {
+					t.Errorf("expected no output, got %q", errOut.String())
+				}
+			} else if !strings.Contains(errOut.String(), tt.wantMessage) {
+				t.Errorf("expected %q in output, got %q", tt.wantMessage, errOut.String())
+			}
+		})
+	}
+}
+
+// TestReadOnlyModel_KeySelection checks that every mode is reachable and that
+// dismissing leaves chosen empty, which is what keeps a quit from being recorded
+// as picking whichever mode the cursor rested on.
+func TestReadOnlyModel_KeySelection(t *testing.T) {
+	// Ctrl+C is {Code: 'c', Mod: tea.ModCtrl}; the raw control byte {Code: 3}
+	// stringifies to "\x03" and would match nothing.
+	cases := []struct {
+		name string
+		keys []tea.KeyPressMsg
+		want config.ReadOnlyMode // "" = dismissed
+	}{
+		{"enter takes the recommended default", []tea.KeyPressMsg{{Code: tea.KeyEnter}}, config.ReadOnlyProd},
+		{"space takes it too", []tea.KeyPressMsg{{Code: tea.KeySpace}}, config.ReadOnlyProd},
+		{"'2' selects all", []tea.KeyPressMsg{{Code: '2'}}, config.ReadOnlyAll},
+		{"'3' selects off", []tea.KeyPressMsg{{Code: '3'}}, config.ReadOnlyOff},
+		{"down then enter selects all", []tea.KeyPressMsg{{Code: tea.KeyDown}, {Code: tea.KeyEnter}}, config.ReadOnlyAll},
+		{"q dismisses", []tea.KeyPressMsg{{Code: 'q'}}, ""},
+		{"esc dismisses", []tea.KeyPressMsg{{Code: tea.KeyEsc}}, ""},
+		{"ctrl+c dismisses", []tea.KeyPressMsg{{Code: 'c', Mod: tea.ModCtrl}}, ""},
+		{"cursor can't run past the end", []tea.KeyPressMsg{{Code: tea.KeyDown}, {Code: tea.KeyDown}, {Code: tea.KeyDown}, {Code: tea.KeyEnter}}, config.ReadOnlyOff},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m tea.Model = readOnlyModel{}
+			for _, key := range tc.keys {
+				m, _ = m.Update(key)
+			}
+			if got := m.(readOnlyModel).chosen; got != tc.want {
+				t.Errorf("chosen = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/cmd/config_set.go
+++ b/internal/cmd/config_set.go
@@ -20,11 +20,12 @@ func buildConfigSetCmd(app *common.App) *cobra.Command {
 			cfg := app.GetConfig()
 
 			key, value := args[0], args[1]
-			if err := cfg.Set(key, value); err != nil {
+			stored, err := cfg.Set(key, value)
+			if err != nil {
 				return fmt.Errorf("failed to set config: %w", err)
 			}
 
-			cmd.Printf("Set %s = %s\n", key, value)
+			cmd.Printf("Set %s = %s\n", key, stored)
 			return nil
 		},
 	}

--- a/internal/cmd/config_show.go
+++ b/internal/cmd/config_show.go
@@ -91,7 +91,7 @@ func outputTable(w io.Writer, cfg *config.ConfigOutput) error {
 		table.Append("password_storage", *cfg.PasswordStorage)
 	}
 	if cfg.ReadOnly != nil {
-		table.Append("read_only", fmt.Sprintf("%t", *cfg.ReadOnly))
+		table.Append("read_only", string(*cfg.ReadOnly))
 	}
 	if cfg.ReleasesURL != nil {
 		table.Append("releases_url", *cfg.ReleasesURL)

--- a/internal/cmd/config_show_test.go
+++ b/internal/cmd/config_show_test.go
@@ -28,7 +28,7 @@ const (
 │ mcp_max_rows     │ 100                                                           │
 │ output           │ table                                                         │
 │ password_storage │ keyring                                                       │
-│ read_only        │ false                                                         │
+│ read_only        │ off                                                           │
 │ releases_url     │ https://cli.tigerdata.com                                     │
 │ service_id       │                                                               │
 │ version_check    │ true                                                          │
@@ -46,7 +46,7 @@ const (
   "mcp_max_rows": 100,
   "output": "table",
   "password_storage": "keyring",
-  "read_only": false,
+  "read_only": "off",
   "releases_url": "https://cli.tigerdata.com",
   "service_id": "",
   "version_check": true
@@ -63,7 +63,7 @@ gateway_url: https://console.cloud.tigerdata.com/api
 mcp_max_rows: 100
 output: table
 password_storage: keyring
-read_only: false
+read_only: "off"
 releases_url: https://cli.tigerdata.com
 service_id: ""
 version_check: true
@@ -109,7 +109,7 @@ func TestConfigShowCmd(t *testing.T) {
 │ mcp_max_rows     │ 100                                                           │
 │ output           │ table                                                         │
 │ password_storage │ pgpass                                                        │
-│ read_only        │ false                                                         │
+│ read_only        │ off                                                           │
 │ releases_url     │ https://cli.tigerdata.com                                     │
 │ service_id       │ test-service                                                  │
 │ version_check    │ true                                                          │
@@ -135,7 +135,7 @@ func TestConfigShowCmd(t *testing.T) {
   "mcp_max_rows": 100,
   "output": "json",
   "password_storage": "keyring",
-  "read_only": false,
+  "read_only": "off",
   "releases_url": "https://cli.tigerdata.com",
   "service_id": "",
   "version_check": true
@@ -173,7 +173,7 @@ gateway_url: https://console.cloud.tigerdata.com/api
 mcp_max_rows: 100
 output: yaml
 password_storage: keyring
-read_only: false
+read_only: "off"
 releases_url: https://cli.tigerdata.com
 service_id: ""
 version_check: true
@@ -216,7 +216,7 @@ version_check: true
 │ mcp_max_rows     │ 100                                                           │
 │ output           │ table                                                         │
 │ password_storage │ keyring                                                       │
-│ read_only        │ false                                                         │
+│ read_only        │ off                                                           │
 │ releases_url     │ https://cli.tigerdata.com                                     │
 │ service_id       │ env-service                                                   │
 │ version_check    │ true                                                          │
@@ -249,7 +249,7 @@ version_check: true
 │ mcp_max_rows     │ 100                                                           │
 │ output           │ table                                                         │
 │ password_storage │ keyring                                                       │
-│ read_only        │ false                                                         │
+│ read_only        │ off                                                           │
 │ releases_url     │ https://cli.tigerdata.com                                     │
 │ service_id       │                                                               │
 │ version_check    │ true                                                          │
@@ -276,7 +276,7 @@ version_check: true
 │ mcp_max_rows     │ 100                                                           │
 │ output           │ table                                                         │
 │ password_storage │ keyring                                                       │
-│ read_only        │ false                                                         │
+│ read_only        │ off                                                           │
 │ releases_url     │ https://cli.tigerdata.com                                     │
 │ service_id       │                                                               │
 │ version_check    │ false                                                         │

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -46,8 +46,9 @@ Authentication is handled automatically using:
 
 Use --read-only to open the psql session in Tiger Cloud's immutable read-only
 mode (writes and DDL are rejected by the server). The global read_only config
-option (or TIGER_READ_ONLY=true) also forces this behavior, so sessions started
-while read-only mode is on are always read-only.
+option (or TIGER_READ_ONLY) also forces this behavior: read_only=all makes every
+session read-only, and read_only=prod makes sessions against services tagged PROD
+read-only while leaving DEV services writable.
 
 When run in an interactive terminal, this command checks whether the service has
 any read replicas. If it does, it offers to connect to one of them instead of the
@@ -91,11 +92,6 @@ Examples:
 		ValidArgsFunction: serviceIDCompletion(app),
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, _, _, err := app.GetAll()
-			if err != nil {
-				return err
-			}
-
 			// Separate service ID from additional psql flags
 			serviceArgs, psqlFlags := separateServiceAndPsqlArgs(cmd, args)
 
@@ -113,7 +109,7 @@ Examples:
 			opts := common.ConnectionDetailsOptions{
 				Pooled:   dbConnectPooled,
 				Role:     dbConnectRole,
-				ReadOnly: dbConnectReadOnly || cfg.ReadOnly,
+				ReadOnly: dbConnectReadOnly,
 			}
 
 			// Connects straight to a replica named by ID, or offers the interactive
@@ -204,6 +200,10 @@ func selectConnection(
 			}
 		}
 	}
+
+	// The target is settled now, so read-only mode can have its say. --read-only
+	// is already in opts and only adds to the restriction.
+	opts.ReadOnly = opts.ReadOnly || common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(chosen.ConnectionService)) != nil
 
 	details, err := buildConnectionDetailsForTarget(cmd, cfg, chosen, opts)
 	if err != nil {
@@ -404,9 +404,13 @@ func connectWithPasswordMenu(
 		return fmt.Errorf("authentication failed and no TTY available for interactive password entry")
 	}
 
+	// Password reset is admin-only, and rotating the master password is a
+	// control-plane write, so read-only mode hides the option rather than
+	// offering what it would refuse.
+	canResetPassword := details.Role == "tsdbadmin" &&
+		common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(service)) == nil
+
 	// Interactive recovery loop
-	// Only allow password reset for admin role
-	canResetPassword := details.Role == "tsdbadmin"
 	for {
 		option, err := selectPasswordRecoveryOption(cmd, canResetPassword)
 		if err != nil {

--- a/internal/cmd/db_connection_string.go
+++ b/internal/cmd/db_connection_string.go
@@ -31,9 +31,10 @@ Use --with-password to include the password directly in the connection string.
 
 Use --read-only to emit a connection string that opens the session in Tiger
 Cloud's immutable read-only mode (writes and DDL are rejected by the server).
-The global read_only config option (or TIGER_READ_ONLY=true) also forces this
-behavior, so connection strings produced while read-only mode is on always
-open read-only sessions.
+The global read_only config option (or TIGER_READ_ONLY) also forces this
+behavior: read_only=all makes every connection string read-only, and
+read_only=prod makes those for services tagged PROD read-only while leaving DEV
+services writable.
 
 Examples:
   # Get connection string for default service
@@ -71,7 +72,7 @@ Examples:
 				Pooled:       dbConnectionStringPooled,
 				Role:         dbConnectionStringRole,
 				WithPassword: dbConnectionStringWithPassword,
-				ReadOnly:     dbConnectionStringReadOnly || cfg.ReadOnly,
+				ReadOnly:     dbConnectionStringReadOnly || common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(target.ConnectionService)) != nil,
 			})
 			if err != nil {
 				return err

--- a/internal/cmd/db_connection_string_test.go
+++ b/internal/cmd/db_connection_string_test.go
@@ -24,6 +24,17 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		expectGetService(m, "rep-67890", sampleReplica())
 		expectGetService(m, "svc-12345", sampleService())
 	}
+	// read_only=prod judges a service by this tag, so these cases need to set it.
+	tagged := func(env string) func(*api.Service) {
+		return func(s *api.Service) {
+			s.Metadata = &api.ServiceMetadata{Environment: &env}
+		}
+	}
+	setupGetTagged := func(env string) func(*mocks.MockClientWithResponsesInterface) {
+		return func(m *mocks.MockClientWithResponsesInterface) {
+			expectGetService(m, "svc-12345", sampleService(tagged(env)))
+		}
+	}
 	withPooler := func(s *api.Service) {
 		s.ConnectionPooler = &api.ConnectionPooler{
 			Endpoint: &api.Endpoint{
@@ -132,17 +143,45 @@ func TestDbConnectionStringCmd(t *testing.T) {
 			wantStdout: readOnlyURI,
 		},
 		{
-			name:       "read-only from config",
+			name:       "read-only from config all",
 			args:       []string{"db", "connection-string", "svc-12345"},
 			setup:      setupGet,
-			opts:       []runOption{withConfig(map[string]any{"read_only": true})},
+			opts:       []runOption{withConfig(map[string]any{"read_only": "all"})},
 			wantStdout: readOnlyURI,
 		},
 		{
-			name:       "read-only flag and config",
+			name:       "read-only flag and config all",
 			args:       []string{"db", "connection-string", "svc-12345", "--read-only"},
 			setup:      setupGet,
-			opts:       []runOption{withConfig(map[string]any{"read_only": true})},
+			opts:       []runOption{withConfig(map[string]any{"read_only": "all"})},
+			wantStdout: readOnlyURI,
+		},
+		{
+			name:       "config prod, PROD service",
+			args:       []string{"db", "connection-string", "svc-12345"},
+			setup:      setupGetTagged("PROD"),
+			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
+			wantStdout: readOnlyURI,
+		},
+		{
+			name:       "config prod, DEV service",
+			args:       []string{"db", "connection-string", "svc-12345"},
+			setup:      setupGetTagged("DEV"),
+			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
+			wantStdout: directURI,
+		},
+		{
+			name:       "config prod, untagged service",
+			args:       []string{"db", "connection-string", "svc-12345"},
+			setup:      setupGet,
+			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
+			wantStdout: directURI,
+		},
+		{
+			name:       "flag on beats config prod",
+			args:       []string{"db", "connection-string", "svc-12345", "--read-only"},
+			setup:      setupGetTagged("DEV"),
+			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
 			wantStdout: readOnlyURI,
 		},
 		{

--- a/internal/cmd/db_create_role.go
+++ b/internal/cmd/db_create_role.go
@@ -102,6 +102,11 @@ PostgreSQL Configuration Parameters That May Be Set:
 				return err
 			}
 
+			// Refuse here rather than letting the server reject the CREATE ROLE.
+			if err := common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(service)); err != nil {
+				return err
+			}
+
 			// A read replica is read-only, so a role can't be created there.
 			if common.IsReadReplica(service) {
 				return fmt.Errorf("%q is a read replica; create the role on its primary service %q instead",

--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -407,11 +407,17 @@ func withEnv(key, value string) runOption {
 // of the test (true lets commands take their interactive path against a
 // non-TTY stdin). Use this with withStdin to simulate interactive input.
 func withIsTerminal(isTerminal bool) runOption {
-	return withSetup(func(t *testing.T) {
-		original := util.IsTerminal
-		util.IsTerminal = func(any) bool { return isTerminal }
-		t.Cleanup(func() { util.IsTerminal = original })
-	})
+	return withSetup(func(t *testing.T) { stubIsTerminal(t, isTerminal) })
+}
+
+// stubIsTerminal makes util.IsTerminal report val for the duration of the test.
+// withIsTerminal is the runOption form; this is for tests that call a helper
+// directly rather than running a command.
+func stubIsTerminal(t *testing.T, val bool) {
+	t.Helper()
+	original := util.IsTerminal
+	util.IsTerminal = func(any) bool { return val }
+	t.Cleanup(func() { util.IsTerminal = original })
 }
 
 // withReadPassword makes util.ReadPassword return the given password. The real

--- a/internal/cmd/mcp_get_test.go
+++ b/internal/cmd/mcp_get_test.go
@@ -23,6 +23,7 @@ Output:
     • connection_string (required): string - PostgreSQL connection string (password embedded only if with_password=true)
     • created: string
     • direct_endpoint: string - Direct database connection endpoint
+    • environment (required): string - Environment tag (DEV or PROD). Under read_only=prod, services tagged PROD cannot be modified.
     • id (required): string - Service identifier (10-character alphanumeric string)
     • name (required): string
     • password: string - Password for tsdbadmin user (only included if with_password=true)
@@ -49,6 +50,7 @@ List all database services in your Tiger Cloud project. Returns services with st
 Output:
   • services (required): []object, null
     • created: string
+    • environment (required): string - Environment tag (DEV or PROD). Under read_only=prod, services tagged PROD cannot be modified.
     • id (required): string - Service identifier (10-character alphanumeric string)
     • name (required): string
     • region (required): string
@@ -81,6 +83,10 @@ Output:
           "additionalProperties": false,
           "properties": {
             "created": {
+              "type": "string"
+            },
+            "environment": {
+              "description": "Environment tag (DEV or PROD). Under read_only=prod, services tagged PROD cannot be modified.",
               "type": "string"
             },
             "id": {
@@ -123,7 +129,8 @@ Output:
             "name",
             "status",
             "type",
-            "region"
+            "region",
+            "environment"
           ],
           "type": "object"
         },
@@ -161,6 +168,9 @@ outputSchema:
         properties:
           created:
             type: string
+          environment:
+            description: Environment tag (DEV or PROD). Under read_only=prod, services tagged PROD cannot be modified.
+            type: string
           id:
             description: Service identifier (10-character alphanumeric string)
             type: string
@@ -191,6 +201,7 @@ outputSchema:
           - status
           - type
           - region
+          - environment
         type: object
       type:
         - "null"

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -190,6 +190,7 @@ func prepareServiceForOutput(cmd *cobra.Command, cfg *config.Config, service api
 		Role:            "tsdbadmin",
 		WithPassword:    withPassword,
 		InitialPassword: util.Deref(service.InitialPassword),
+		ReadOnly:        common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(service)) != nil,
 	}
 
 	if connectionDetails, err := common.GetConnectionDetails(cfg, service, opts); err != nil {
@@ -234,7 +235,7 @@ func handlePasswordSaving(cmd *cobra.Command, cfg *config.Config, service api.Se
 
 // setDefaultService sets the given service as the default service in the configuration
 func setDefaultService(cmd *cobra.Command, cfg *config.Config, serviceID string) error {
-	if err := cfg.Set("service_id", serviceID); err != nil {
+	if _, err := cfg.Set("service_id", serviceID); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -119,12 +119,14 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
+			// Gate on the requested tag: under prod mode, creating DEV is
+			// allowed and creating PROD is not.
+			environmentTag := api.EnvironmentTag(createEnvironment)
+			if err := common.CheckReadOnly(cfg, environmentTag); err != nil {
 				return err
 			}
 
 			// Prepare service creation request
-			environmentTag := api.EnvironmentTag(createEnvironment)
 			serviceCreateReq := api.ServiceCreate{
 				Name:           createServiceName,
 				Addons:         util.ConvertStringSlicePtr[api.ServiceCreateAddons](addons),

--- a/internal/cmd/service_delete.go
+++ b/internal/cmd/service_delete.go
@@ -58,7 +58,7 @@ Examples:
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
+			if err := common.CheckReadOnlyByServiceID(cmd.Context(), cfg, client, projectID, serviceID); err != nil {
 				return err
 			}
 

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -104,7 +104,10 @@ Examples:
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
+			// Gate on the fork's own tag: under prod mode, forking a PROD source
+			// into a DEV fork is allowed — it reads production without changing it.
+			environmentTag := api.EnvironmentTag(forkEnvironment)
+			if err := common.CheckReadOnly(cfg, environmentTag); err != nil {
 				return err
 			}
 
@@ -151,7 +154,6 @@ Examples:
 			cmd.PrintErrf("🍴 Forking service '%s' to create '%s' at %s...\n", serviceID, displayName, strategyDesc)
 
 			// Create ForkServiceCreate request
-			environmentTag := api.EnvironmentTag(forkEnvironment)
 			forkReq := api.ForkServiceCreate{
 				ForkStrategy:   forkStrategy,
 				TargetTime:     targetTime,

--- a/internal/cmd/service_resize.go
+++ b/internal/cmd/service_resize.go
@@ -64,10 +64,6 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
-				return err
-			}
-
 			// Determine service ID
 			serviceID, err := getServiceID(cfg, args)
 			if err != nil {
@@ -83,6 +79,10 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			// At least one of CPU or memory must be specified
 			if cpuMemoryCfg == nil {
 				return fmt.Errorf("must specify at least one of --cpu or --memory")
+			}
+
+			if err := common.CheckReadOnlyByServiceID(cmd.Context(), cfg, client, projectID, serviceID); err != nil {
+				return err
 			}
 
 			// Display resize information

--- a/internal/cmd/service_start.go
+++ b/internal/cmd/service_start.go
@@ -42,13 +42,13 @@ Examples:
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
-				return err
-			}
-
 			// Determine source service ID
 			serviceID, err := getServiceID(cfg, args)
 			if err != nil {
+				return err
+			}
+
+			if err := common.CheckReadOnlyByServiceID(cmd.Context(), cfg, client, projectID, serviceID); err != nil {
 				return err
 			}
 

--- a/internal/cmd/service_stop.go
+++ b/internal/cmd/service_stop.go
@@ -42,13 +42,13 @@ Examples:
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
-				return err
-			}
-
 			// Determine source service ID
 			serviceID, err := getServiceID(cfg, args)
 			if err != nil {
+				return err
+			}
+
+			if err := common.CheckReadOnlyByServiceID(cmd.Context(), cfg, client, projectID, serviceID); err != nil {
 				return err
 			}
 

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/mock/gomock"
+
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/api/mocks"
 	"github.com/timescale/tiger-cli/internal/common"
@@ -102,4 +104,211 @@ func checkStoredPassword(serviceID, want string) checkFunc {
 			t.Errorf("stored password = %q, want %q", got, want)
 		}
 	}
+}
+
+// notRefusedForDEV asserts an error isn't one of the read-only refusals. The DEV
+// half of the prod-mode cases only needs to prove the gate let the command reach
+// the API; what the API then says is that command's own test.
+var notRefusedForDEV = matchFunc(func(t *testing.T, got string) {
+	t.Helper()
+	for _, refusal := range []string{"read-only mode", "read_only"} {
+		if strings.Contains(got, refusal) {
+			t.Errorf("command was refused for a DEV service: %s", got)
+		}
+	}
+})
+
+// expectTaggedService registers the tag lookup a ...ByServiceID gate makes (and,
+// for update-password, the fetch the command was making anyway).
+func expectTaggedService(tag string) func(*mocks.MockClientWithResponsesInterface) {
+	return func(m *mocks.MockClientWithResponsesInterface) {
+		expectGetService(m, "svc-12345", sampleService(func(s *api.Service) {
+			s.Metadata = &api.ServiceMetadata{Environment: &tag}
+		}))
+	}
+}
+
+// TestDestructiveCommands_ReadOnly checks that read_only=all refuses every
+// destructive command. No expectations are registered, so any API call the gate
+// failed to prevent fails the case as an unexpected call.
+func TestDestructiveCommands_ReadOnly(t *testing.T) {
+	readOnly := []runOption{withConfig(map[string]any{"read_only": "all"})}
+	refused := common.ErrReadOnly.Error()
+
+	runCmdTests(t, []cmdTest{
+		{
+			name:    "create",
+			args:    []string{"service", "create", "--addons", "none", "--region", "us-east-1", "--cpu", "1000", "--memory", "4"},
+			opts:    readOnly,
+			wantErr: refused,
+		},
+		{name: "fork", args: []string{"service", "fork", "svc-12345", "--now"}, opts: readOnly, wantErr: refused},
+		{name: "start", args: []string{"service", "start", "svc-12345"}, opts: readOnly, wantErr: refused},
+		{name: "stop", args: []string{"service", "stop", "svc-12345"}, opts: readOnly, wantErr: refused},
+		{
+			name:    "resize",
+			args:    []string{"service", "resize", "svc-12345", "--cpu", "1000", "--memory", "4"},
+			opts:    readOnly,
+			wantErr: refused,
+		},
+		{
+			name:    "update-password",
+			args:    []string{"service", "update-password", "svc-12345", "--auto-generate"},
+			opts:    readOnly,
+			wantErr: refused,
+		},
+		{name: "delete", args: []string{"service", "delete", "svc-12345", "--confirm"}, opts: readOnly, wantErr: refused},
+	})
+}
+
+// TestDestructiveCommands_ReadOnlyProd checks that read_only=prod refuses a
+// destructive command against a PROD service and lets it through against a DEV
+// one. The PROD cases register only the tag lookup, so an attempted mutation
+// fails as an unexpected call; the DEV cases register the mutation, so gomock
+// fails the case if the gate swallowed it.
+func TestDestructiveCommands_ReadOnlyProd(t *testing.T) {
+	prod := []runOption{withConfig(map[string]any{"read_only": "prod"})}
+	// CheckReadOnlyByServiceID names the service it refused; update-password
+	// gates on an already-fetched service and doesn't.
+	refusedByID := `service svc-12345: ` + common.ErrReadOnlyProd.Error()
+
+	serverError := httpResponse(http.StatusInternalServerError)
+
+	runCmdTests(t, []cmdTest{
+		{
+			name:    "start refuses PROD",
+			args:    []string{"service", "start", "svc-12345"},
+			setup:   expectTaggedService("PROD"),
+			opts:    prod,
+			wantErr: refusedByID,
+		},
+		{
+			name: "start allows DEV",
+			args: []string{"service", "start", "svc-12345"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				expectTaggedService("DEV")(m)
+				m.EXPECT().StartServiceWithResponse(validCtx, testProjectID, "svc-12345").
+					Return(&api.StartServiceResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+		{
+			name:    "stop refuses PROD",
+			args:    []string{"service", "stop", "svc-12345"},
+			setup:   expectTaggedService("PROD"),
+			opts:    prod,
+			wantErr: refusedByID,
+		},
+		{
+			name: "stop allows DEV",
+			args: []string{"service", "stop", "svc-12345"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				expectTaggedService("DEV")(m)
+				m.EXPECT().StopServiceWithResponse(validCtx, testProjectID, "svc-12345").
+					Return(&api.StopServiceResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+		{
+			name:    "resize refuses PROD",
+			args:    []string{"service", "resize", "svc-12345", "--cpu", "1000", "--memory", "4"},
+			setup:   expectTaggedService("PROD"),
+			opts:    prod,
+			wantErr: refusedByID,
+		},
+		{
+			name: "resize allows DEV",
+			args: []string{"service", "resize", "svc-12345", "--cpu", "1000", "--memory", "4"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				expectTaggedService("DEV")(m)
+				m.EXPECT().ResizeServiceWithResponse(validCtx, testProjectID, "svc-12345", api.ResizeInput{CPUMillis: "1000", MemoryGbs: "4"}).
+					Return(&api.ResizeServiceResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+		{
+			name:    "delete refuses PROD",
+			args:    []string{"service", "delete", "svc-12345", "--confirm"},
+			setup:   expectTaggedService("PROD"),
+			opts:    prod,
+			wantErr: refusedByID,
+		},
+		{
+			name: "delete allows DEV",
+			args: []string{"service", "delete", "svc-12345", "--confirm"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				expectTaggedService("DEV")(m)
+				m.EXPECT().DeleteServiceWithResponse(validCtx, testProjectID, "svc-12345").
+					Return(&api.DeleteServiceResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+		{
+			name:    "update-password refuses PROD",
+			args:    []string{"service", "update-password", "svc-12345", "--auto-generate"},
+			setup:   expectTaggedService("PROD"),
+			opts:    prod,
+			wantErr: common.ErrReadOnlyProd.Error(),
+		},
+		{
+			name: "update-password allows DEV",
+			args: []string{"service", "update-password", "svc-12345", "--auto-generate"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				expectTaggedService("DEV")(m)
+				m.EXPECT().UpdatePasswordWithResponse(validCtx, testProjectID, "svc-12345", gomock.Any()).
+					Return(&api.UpdatePasswordResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+	})
+}
+
+// TestCreateFork_ReadOnlyProd checks that read_only=prod gates service create and
+// fork on the tag they request rather than on any existing service, so creating
+// DEV is allowed and creating PROD is not.
+func TestCreateFork_ReadOnlyProd(t *testing.T) {
+	prod := []runOption{withConfig(map[string]any{"read_only": "prod"})}
+	serverError := httpResponse(http.StatusInternalServerError)
+
+	runCmdTests(t, []cmdTest{
+		{
+			name:    "create PROD is refused",
+			args:    []string{"service", "create", "--addons", "none", "--environment", "PROD"},
+			opts:    prod,
+			wantErr: common.ErrReadOnlyProd.Error(),
+		},
+		{
+			name: "create DEV is allowed",
+			args: []string{"service", "create", "--addons", "none", "--environment", "DEV"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				m.EXPECT().CreateServiceWithResponse(validCtx, testProjectID, gomock.Any()).
+					Return(&api.CreateServiceResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+		{
+			// Forking a PROD source into a DEV fork reads production without
+			// changing it, so only the fork's own tag is gated.
+			name:    "fork to PROD is refused",
+			args:    []string{"service", "fork", "svc-12345", "--now", "--environment", "PROD"},
+			opts:    prod,
+			wantErr: common.ErrReadOnlyProd.Error(),
+		},
+		{
+			name: "fork to DEV is allowed",
+			args: []string{"service", "fork", "svc-12345", "--now", "--environment", "DEV"},
+			setup: func(m *mocks.MockClientWithResponsesInterface) {
+				m.EXPECT().ForkServiceWithResponse(validCtx, testProjectID, "svc-12345", gomock.Any()).
+					Return(&api.ForkServiceResponse{HTTPResponse: serverError}, nil)
+			},
+			opts:    prod,
+			wantErr: notRefusedForDEV,
+		},
+	})
 }

--- a/internal/cmd/service_update_password.go
+++ b/internal/cmd/service_update_password.go
@@ -59,8 +59,10 @@ Examples:
 				return err
 			}
 
-			if err := common.CheckReadOnly(cfg); err != nil {
-				return err
+			// Refuse without an API call under read_only=all. prod needs the tag,
+			// so the real gate waits for the fetch below.
+			if cfg.ReadOnly.BlocksAll() {
+				return common.ErrReadOnly
 			}
 
 			// Determine service ID
@@ -93,6 +95,12 @@ Examples:
 				return fmt.Errorf("empty response from API")
 			}
 			service := *serviceResp.JSON200
+
+			// The prod half of the gate, riding on the fetch above and still
+			// ahead of any prompt or write.
+			if err := common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(service)); err != nil {
+				return err
+			}
 
 			// A read replica has no separate password to rotate.
 			if common.IsReadReplica(service) {

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -2,22 +2,7 @@ package common
 
 import (
 	"errors"
-
-	"github.com/timescale/tiger-cli/internal/config"
 )
-
-// ErrReadOnly is returned when a destructive operation is attempted while
-// read-only mode is enabled in the user's config.
-var ErrReadOnly = errors.New("this operation is not allowed in read-only mode")
-
-// CheckReadOnly returns ErrReadOnly if read-only mode is enabled. Callers
-// should invoke this before any destructive API call.
-func CheckReadOnly(cfg *config.Config) error {
-	if cfg.ReadOnly {
-		return ErrReadOnly
-	}
-	return nil
-}
 
 // Exit codes as defined in the CLI specification
 const (

--- a/internal/common/errors_test.go
+++ b/internal/common/errors_test.go
@@ -3,26 +3,116 @@ package common
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
 func TestCheckReadOnly(t *testing.T) {
 	tests := []struct {
-		name    string
-		cfg     *config.Config
+		mode    config.ReadOnlyMode
+		tag     api.EnvironmentTag
 		wantErr error
 	}{
-		{name: "read-only off allows writes", cfg: &config.Config{ReadOnly: false}, wantErr: nil},
-		{name: "read-only on blocks writes", cfg: &config.Config{ReadOnly: true}, wantErr: ErrReadOnly},
+		{mode: config.ReadOnlyOff, tag: api.EnvironmentTagDEV, wantErr: nil},
+		{mode: config.ReadOnlyOff, tag: api.EnvironmentTagPROD, wantErr: nil},
+		{mode: config.ReadOnlyAll, tag: api.EnvironmentTagDEV, wantErr: ErrReadOnly},
+		{mode: config.ReadOnlyAll, tag: api.EnvironmentTagPROD, wantErr: ErrReadOnly},
+		{mode: config.ReadOnlyProd, tag: api.EnvironmentTagDEV, wantErr: nil},
+		{mode: config.ReadOnlyProd, tag: api.EnvironmentTagPROD, wantErr: ErrReadOnlyProd},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/%s", tt.mode, tt.tag), func(t *testing.T) {
+			cfg := &config.Config{ReadOnly: tt.mode}
+
+			err := CheckReadOnly(cfg, tt.tag)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("CheckReadOnly(read_only=%q, %q) error = %v, want %v", tt.mode, tt.tag, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckReadOnlyByServiceID(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        config.ReadOnlyMode
+		tag         string
+		fetchStatus int
+		wantErr     error
+		// wantFetch records whether the check should have spent an API call.
+		wantFetch bool
+		// wantExitCode, when set, is the exit code the refusal must carry - see the
+		// wrap in CheckReadOnlyByServiceID for why it needs re-attaching.
+		wantExitCode int
+	}{
+		{name: "off skips the fetch", mode: config.ReadOnlyOff, tag: "PROD", wantErr: nil},
+		{name: "all refuses without the fetch", mode: config.ReadOnlyAll, tag: "DEV", wantErr: ErrReadOnly},
+		{name: "prod allows a DEV service", mode: config.ReadOnlyProd, tag: "DEV", wantErr: nil, wantFetch: true},
+		{name: "prod refuses a PROD service", mode: config.ReadOnlyProd, tag: "PROD", wantErr: ErrReadOnlyProd, wantFetch: true},
+		{name: "prod allows an untagged service", mode: config.ReadOnlyProd, tag: "", wantErr: nil, wantFetch: true},
+		{
+			// We can't tell whether the service is PROD, so refuse. No sentinel
+			// on these, so they're asserted by exit code.
+			name:         "prod refuses when the fetch fails",
+			mode:         config.ReadOnlyProd,
+			fetchStatus:  http.StatusInternalServerError,
+			wantFetch:    true,
+			wantExitCode: ExitGeneralError,
+		},
+		{
+			name:         "prod refuses an unknown service as not found",
+			mode:         config.ReadOnlyProd,
+			fetchStatus:  http.StatusNotFound,
+			wantFetch:    true,
+			wantExitCode: ExitServiceNotFound,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckReadOnly(tt.cfg)
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("CheckReadOnly(%+v) error = %v, want %v", tt.cfg, err, tt.wantErr)
+			var fetched bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fetched = true
+				if tt.fetchStatus != 0 {
+					w.WriteHeader(tt.fetchStatus)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if tt.tag == "" {
+					fmt.Fprint(w, `{"service_id":"svc-1"}`)
+					return
+				}
+				fmt.Fprintf(w, `{"service_id":"svc-1","metadata":{"environment":%q}}`, tt.tag)
+			}))
+			defer server.Close()
+
+			client, err := api.NewClientWithResponses(server.URL)
+			if err != nil {
+				t.Fatalf("NewClientWithResponses failed: %v", err)
+			}
+
+			cfg := &config.Config{ReadOnly: tt.mode}
+			err = CheckReadOnlyByServiceID(t.Context(), cfg, client, "proj-1", "svc-1")
+
+			if tt.wantExitCode != 0 {
+				exitErr, ok := errors.AsType[ExitCodeError](err)
+				if !ok {
+					t.Fatalf("refusal carries no ExitCodeError: %v", err)
+				}
+				if got := exitErr.ExitCode(); got != tt.wantExitCode {
+					t.Errorf("ExitCode() = %d, want %d (error: %v)", got, tt.wantExitCode, err)
+				}
+			} else if !errors.Is(err, tt.wantErr) {
+				t.Errorf("CheckReadOnlyByServiceID(read_only=%q, tag=%q) error = %v, want %v", tt.mode, tt.tag, err, tt.wantErr)
+			}
+
+			if fetched != tt.wantFetch {
+				t.Errorf("service fetched = %t, want %t (read_only=%q)", fetched, tt.wantFetch, tt.mode)
 			}
 		})
 	}

--- a/internal/common/read_only.go
+++ b/internal/common/read_only.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/config"
+)
+
+// ErrReadOnly is returned when read_only=all blocks a destructive operation.
+var ErrReadOnly = errors.New("this operation is not allowed in read-only mode")
+
+// ErrReadOnlyProd is returned when read_only=prod blocks a destructive operation
+// on a service tagged PROD.
+var ErrReadOnlyProd = errors.New(`this operation is not allowed on services tagged PROD while read_only is set to "prod"`)
+
+// CheckReadOnly returns an error when read-only mode blocks writes to a service
+// with the given environment tag. Use CheckReadOnlyByServiceID when only the ID
+// is known; where a boolean is wanted, compare the result against nil.
+func CheckReadOnly(cfg *config.Config, tag api.EnvironmentTag) error {
+	switch cfg.ReadOnly {
+	case config.ReadOnlyAll:
+		return ErrReadOnly
+	case config.ReadOnlyProd:
+		if tag == api.EnvironmentTagPROD {
+			return ErrReadOnlyProd
+		}
+	}
+	return nil
+}
+
+// CheckReadOnlyByServiceID is CheckReadOnly for a caller that has only the
+// service's ID, fetching the service to read its tag. A failed fetch is a
+// refusal: we can't tell whether the service is PROD.
+//
+// Only prod's verdict depends on the tag, so only prod pays for the lookup.
+func CheckReadOnlyByServiceID(ctx context.Context, cfg *config.Config, client api.ClientWithResponsesInterface, projectID, serviceID string) error {
+	if cfg.ReadOnly.BlocksAll() {
+		return ErrReadOnly
+	}
+	if cfg.ReadOnly != config.ReadOnlyProd {
+		return nil
+	}
+
+	service, err := GetService(ctx, client, projectID, serviceID)
+	if err != nil {
+		// %w keeps any ExitCodeError in the chain, and main.go unwraps to find it,
+		// so an unknown service still exits with its own code rather than 1.
+		return fmt.Errorf("cannot verify whether service %s is tagged PROD (read_only=%s): %w", serviceID, cfg.ReadOnly, err)
+	}
+
+	if err := CheckReadOnly(cfg, ServiceEnvironmentTag(*service)); err != nil {
+		return fmt.Errorf("service %s: %w", serviceID, err)
+	}
+	return nil
+}

--- a/internal/common/replica.go
+++ b/internal/common/replica.go
@@ -14,6 +14,8 @@ import (
 // credentials to use. They're the same for a primary; for a read replica the
 // CredentialService is the parent primary, whose credentials it shares.
 type ConnectionTarget struct {
+	// ConnectionService alone decides a session's read-only verdict, so a replica
+	// is judged on its own environment tag rather than its primary's.
 	ConnectionService api.Service
 	CredentialService api.Service
 	IsReplica         bool
@@ -93,12 +95,20 @@ func ResolveConnectionTargetByID(ctx context.Context, client api.ClientWithRespo
 // a service's read replica sets (as listed via the /replicaSets endpoint). The
 // replica supplies the endpoint; the primary supplies the credentials.
 func NewReplicaConnectionTarget(primary api.Service, replica api.ReadReplicaSet) *ConnectionTarget {
+	// Carry the replica's own tag over. ReplicaSetMetadata and ServiceMetadata are
+	// separate types holding the same field, so it's copied rather than assigned.
+	var metadata *api.ServiceMetadata
+	if replica.Metadata != nil {
+		metadata = &api.ServiceMetadata{Environment: replica.Metadata.Environment}
+	}
+
 	return &ConnectionTarget{
 		ConnectionService: api.Service{
 			ServiceID:        replica.ID,
 			Name:             replica.Name,
 			Endpoint:         replica.Endpoint,
 			ConnectionPooler: replica.ConnectionPooler,
+			Metadata:         metadata,
 		},
 		CredentialService: primary,
 		IsReplica:         true,

--- a/internal/common/replica_test.go
+++ b/internal/common/replica_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/config"
 	"github.com/timescale/tiger-cli/internal/util"
 )
 
@@ -162,6 +163,51 @@ func TestNewReplicaConnectionTarget(t *testing.T) {
 	}
 	if target.CredentialService.ServiceID != "svcprimary" {
 		t.Errorf("expected credential to be the primary, got %q", target.CredentialService.ServiceID)
+	}
+}
+
+// TestConnectionTargetReadOnlyVerdict checks that a replica is judged on its own
+// environment tag rather than its primary's, which requires that tag to survive
+// NewReplicaConnectionTarget.
+func TestConnectionTargetReadOnlyVerdict(t *testing.T) {
+	tagged := func(svc api.Service, tag string) api.Service {
+		if tag != "" {
+			svc.Metadata = &api.ServiceMetadata{Environment: new(tag)}
+		}
+		return svc
+	}
+
+	cases := []struct {
+		name        string
+		mode        config.ReadOnlyMode
+		primaryTag  string
+		replicaTag  string
+		wantSession bool
+	}{
+		{name: "off never forces read-only", mode: config.ReadOnlyOff, primaryTag: "PROD", replicaTag: "PROD"},
+		{name: "all always forces read-only", mode: config.ReadOnlyAll, wantSession: true},
+		{name: "prod leaves a DEV replica writable", mode: config.ReadOnlyProd, primaryTag: "DEV", replicaTag: "DEV"},
+		{name: "prod protects a PROD replica", mode: config.ReadOnlyProd, primaryTag: "DEV", replicaTag: "PROD", wantSession: true},
+		{name: "prod ignores the primary's tag", mode: config.ReadOnlyProd, primaryTag: "PROD", replicaTag: "DEV"},
+		{name: "prod leaves an untagged replica writable", mode: config.ReadOnlyProd, primaryTag: "PROD"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			primary := tagged(primaryService(), tt.primaryTag)
+			replica := api.ReadReplicaSet{ID: "rep1", Name: "rep"}
+			if tt.replicaTag != "" {
+				replica.Metadata = &api.ReplicaSetMetadata{Environment: new(tt.replicaTag)}
+			}
+
+			target := NewReplicaConnectionTarget(primary, replica)
+			cfg := &config.Config{ReadOnly: tt.mode}
+			got := CheckReadOnly(cfg, ServiceEnvironmentTag(target.ConnectionService)) != nil
+			if got != tt.wantSession {
+				t.Errorf("CheckReadOnly(read_only=%q, primary=%q, replica=%q) != nil = %t, want %t",
+					tt.mode, tt.primaryTag, tt.replicaTag, got, tt.wantSession)
+			}
+		})
 	}
 }
 

--- a/internal/common/service.go
+++ b/internal/common/service.go
@@ -5,11 +5,28 @@ import (
 	"math/rand"
 	"slices"
 	"strings"
+
+	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/util"
 )
 
 // Matches front-end logic for generating a random service name
 func GenerateServiceName() string {
 	return fmt.Sprintf("db-%d", 10000+rand.Intn(90000))
+}
+
+// ServiceEnvironmentTag returns a service's environment tag. Anything but PROD
+// reads as DEV, since metadata is optional and treating unknowns as protected
+// would have read_only=prod block untagged services.
+func ServiceEnvironmentTag(service api.Service) api.EnvironmentTag {
+	if service.Metadata == nil {
+		return api.EnvironmentTagDEV
+	}
+
+	if strings.EqualFold(util.DerefStr(service.Metadata.Environment), string(api.EnvironmentTagPROD)) {
+		return api.EnvironmentTagPROD
+	}
+	return api.EnvironmentTagDEV
 }
 
 // Addon constants - these match the ServiceCreateAddons from the API

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ const (
 	DefaultMCPMaxRows      = 100
 	DefaultOutput          = "table"
 	DefaultPasswordStorage = "keyring"
-	DefaultReadOnly        = false
+	DefaultReadOnly        = ReadOnlyOff
 	DefaultReleasesURL     = "https://cli.tigerdata.com"
 	DefaultVersionCheck    = true
 
@@ -38,6 +38,61 @@ const (
 	// initial PKCE flow and refresh-token grants.
 	TigerCLIClientID = "45e1b16d-e435-4049-97b2-8daad150818c"
 )
+
+// ReadOnlyMode selects which services read-only mode protects from mutating
+// operations. The legacy booleans map onto it: true is ReadOnlyAll, false is
+// ReadOnlyOff.
+type ReadOnlyMode string
+
+const (
+	ReadOnlyAll  ReadOnlyMode = "all"  // every service
+	ReadOnlyProd ReadOnlyMode = "prod" // only services tagged PROD
+	ReadOnlyOff  ReadOnlyMode = "off"  // none
+)
+
+// BlocksAll reports whether the mode blocks writes to every service. It's the
+// only verdict reachable without knowing the target.
+func (m ReadOnlyMode) BlocksAll() bool {
+	return m == ReadOnlyAll
+}
+
+// parseReadOnlyMode converts a user-supplied read_only value into a ReadOnlyMode,
+// still accepting the booleans this option took before the modes existed.
+func parseReadOnlyMode(value string) (ReadOnlyMode, error) {
+	trimmed := strings.TrimSpace(value)
+
+	// Empty means unset. Erroring would be unrecoverable — config.Load runs for
+	// every command, so even `config set` couldn't repair the file.
+	if trimmed == "" {
+		return ReadOnlyOff, nil
+	}
+
+	// Matched case-insensitively, unlike `output` and `password_storage`: PROD is
+	// how the tag is spelled everywhere else, so it's the spelling most likely to
+	// be copied, and ParseBool below is case-insensitive anyway.
+	lowered := strings.ToLower(trimmed)
+
+	switch mode := ReadOnlyMode(lowered); mode {
+	case ReadOnlyAll, ReadOnlyProd, ReadOnlyOff:
+		return mode, nil
+	}
+
+	// `on` pairs with the `off` mode name; strconv.ParseBool rejects it.
+	if lowered == "on" {
+		return ReadOnlyAll, nil
+	}
+
+	// ParseBool also covers 1/0 and t/f, which is what viper's weak typing
+	// produces for a boolean config value.
+	if b, err := strconv.ParseBool(trimmed); err == nil {
+		if b {
+			return ReadOnlyAll, nil
+		}
+		return ReadOnlyOff, nil
+	}
+
+	return "", fmt.Errorf("invalid read_only value: %s (must be all, prod, or off)", value)
+}
 
 var defaultValues = map[string]any{
 	"analytics":        DefaultAnalytics,
@@ -70,20 +125,20 @@ var flagBindings = map[string]string{
 // Config holds the effective configuration for a single command invocation,
 // resolved through viper's normal precedence (flag > env > file > default).
 type Config struct {
-	APIURL          string `mapstructure:"api_url"`
-	Analytics       bool   `mapstructure:"analytics"`
-	Color           bool   `mapstructure:"color"`
-	ConsoleURL      string `mapstructure:"console_url"`
-	DocsMCP         bool   `mapstructure:"docs_mcp"`
-	DocsMCPURL      string `mapstructure:"docs_mcp_url"`
-	GatewayURL      string `mapstructure:"gateway_url"`
-	MCPMaxRows      int    `mapstructure:"mcp_max_rows"`
-	Output          string `mapstructure:"output"`
-	PasswordStorage string `mapstructure:"password_storage"`
-	ReadOnly        bool   `mapstructure:"read_only"`
-	ReleasesURL     string `mapstructure:"releases_url"`
-	ServiceID       string `mapstructure:"service_id"`
-	VersionCheck    bool   `mapstructure:"version_check"`
+	APIURL          string       `mapstructure:"api_url"`
+	Analytics       bool         `mapstructure:"analytics"`
+	Color           bool         `mapstructure:"color"`
+	ConsoleURL      string       `mapstructure:"console_url"`
+	DocsMCP         bool         `mapstructure:"docs_mcp"`
+	DocsMCPURL      string       `mapstructure:"docs_mcp_url"`
+	GatewayURL      string       `mapstructure:"gateway_url"`
+	MCPMaxRows      int          `mapstructure:"mcp_max_rows"`
+	Output          string       `mapstructure:"output"`
+	PasswordStorage string       `mapstructure:"password_storage"`
+	ReadOnly        ReadOnlyMode `mapstructure:"read_only"`
+	ReleasesURL     string       `mapstructure:"releases_url"`
+	ServiceID       string       `mapstructure:"service_id"`
+	VersionCheck    bool         `mapstructure:"version_check"`
 
 	ConfigDir string         `mapstructure:"-"`
 	flags     *pflag.FlagSet `mapstructure:"-"`
@@ -92,20 +147,20 @@ type Config struct {
 // ConfigOutput is the shape `tiger config show` renders. Every field is a
 // pointer so unset values can be omitted when defaults are suppressed.
 type ConfigOutput struct {
-	Analytics       *bool   `mapstructure:"analytics" json:"analytics,omitempty"`
-	APIURL          *string `mapstructure:"api_url" json:"api_url,omitempty"`
-	Color           *bool   `mapstructure:"color" json:"color,omitempty"`
-	ConsoleURL      *string `mapstructure:"console_url" json:"console_url,omitempty"`
-	DocsMCP         *bool   `mapstructure:"docs_mcp" json:"docs_mcp,omitempty"`
-	DocsMCPURL      *string `mapstructure:"docs_mcp_url" json:"docs_mcp_url,omitempty"`
-	GatewayURL      *string `mapstructure:"gateway_url" json:"gateway_url,omitempty"`
-	MCPMaxRows      *int    `mapstructure:"mcp_max_rows" json:"mcp_max_rows,omitempty"`
-	Output          *string `mapstructure:"output" json:"output,omitempty"`
-	PasswordStorage *string `mapstructure:"password_storage" json:"password_storage,omitempty"`
-	ReadOnly        *bool   `mapstructure:"read_only" json:"read_only,omitempty"`
-	ReleasesURL     *string `mapstructure:"releases_url" json:"releases_url,omitempty"`
-	ServiceID       *string `mapstructure:"service_id" json:"service_id,omitempty"`
-	VersionCheck    *bool   `mapstructure:"version_check" json:"version_check,omitempty"`
+	Analytics       *bool         `mapstructure:"analytics" json:"analytics,omitempty"`
+	APIURL          *string       `mapstructure:"api_url" json:"api_url,omitempty"`
+	Color           *bool         `mapstructure:"color" json:"color,omitempty"`
+	ConsoleURL      *string       `mapstructure:"console_url" json:"console_url,omitempty"`
+	DocsMCP         *bool         `mapstructure:"docs_mcp" json:"docs_mcp,omitempty"`
+	DocsMCPURL      *string       `mapstructure:"docs_mcp_url" json:"docs_mcp_url,omitempty"`
+	GatewayURL      *string       `mapstructure:"gateway_url" json:"gateway_url,omitempty"`
+	MCPMaxRows      *int          `mapstructure:"mcp_max_rows" json:"mcp_max_rows,omitempty"`
+	Output          *string       `mapstructure:"output" json:"output,omitempty"`
+	PasswordStorage *string       `mapstructure:"password_storage" json:"password_storage,omitempty"`
+	ReadOnly        *ReadOnlyMode `mapstructure:"read_only" json:"read_only,omitempty"`
+	ReleasesURL     *string       `mapstructure:"releases_url" json:"releases_url,omitempty"`
+	ServiceID       *string       `mapstructure:"service_id" json:"service_id,omitempty"`
+	VersionCheck    *bool         `mapstructure:"version_check" json:"version_check,omitempty"`
 }
 
 // Load creates a new Config instance. The provided flag set is used to resolve
@@ -146,6 +201,13 @@ func LoadForOutput(configDir string, withEnv bool, noDefaults bool) (*ConfigOutp
 	if err := v.Unmarshal(cfg); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config for output: %w", err)
 	}
+	if cfg.ReadOnly != nil {
+		mode, err := parseReadOnlyMode(string(*cfg.ReadOnly))
+		if err != nil {
+			return nil, err
+		}
+		cfg.ReadOnly = &mode
+	}
 
 	return cfg, nil
 }
@@ -171,20 +233,32 @@ func (c *Config) reload() error {
 	if err := v.Unmarshal(c); err != nil {
 		return fmt.Errorf("error unmarshaling config: %w", err)
 	}
+
+	// read_only arrives as whatever its source held — viper's WeaklyTypedInput
+	// renders a YAML bool or int as "1"/"0" — so normalize it here rather than
+	// leaving a value no gate matches.
+	mode, err := parseReadOnlyMode(string(c.ReadOnly))
+	if err != nil {
+		return err
+	}
+	c.ReadOnly = mode
 	return nil
 }
 
-func (c *Config) Set(key, value string) error {
+// Set writes a config value and returns it as stored, which isn't always the
+// input: read_only normalizes legacy booleans into modes. Echo the return value
+// to the user, not the argument.
+func (c *Config) Set(key, value string) (string, error) {
 	// Validate and convert the value to the correct type for the config file
 	validated, err := validateValue(key, value)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Write to config file
 	configFile, err := c.EnsureConfigDir()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	v := viper.New()
@@ -194,10 +268,10 @@ func (c *Config) Set(key, value string) error {
 	v.Set(key, validated)
 
 	if err := v.WriteConfigAs(configFile); err != nil {
-		return fmt.Errorf("error writing config file: %w", err)
+		return "", fmt.Errorf("error writing config file: %w", err)
 	}
 
-	return c.reload()
+	return fmt.Sprint(validated), c.reload()
 }
 
 func (c *Config) Unset(key string) error {
@@ -274,7 +348,9 @@ func ValidConfigOptionValues(key string) []string {
 		return ValidOutputFormats()
 	case "password_storage":
 		return ValidPasswordStorageOptions()
-	case "analytics", "color", "docs_mcp", "read_only", "version_check":
+	case "read_only":
+		return ValidReadOnlyModes()
+	case "analytics", "color", "docs_mcp", "version_check":
 		return []string{"true", "false"}
 	default:
 		return nil
@@ -284,6 +360,10 @@ func ValidConfigOptionValues(key string) []string {
 // ValidPasswordStorageOptions returns the accepted values for password_storage.
 func ValidPasswordStorageOptions() []string {
 	return []string{"keyring", "pgpass", "none"}
+}
+
+func ValidReadOnlyModes() []string {
+	return []string{string(ReadOnlyAll), string(ReadOnlyProd), string(ReadOnlyOff)}
 }
 
 func GetConfigFile(dir string) string {
@@ -385,8 +465,21 @@ func validateValue(key, value string) (any, error) {
 	switch key {
 	case "api_url", "console_url", "docs_mcp_url", "gateway_url", "releases_url", "service_id":
 		return value, nil
-	case "analytics", "color", "docs_mcp", "read_only", "version_check":
+	case "analytics", "color", "docs_mcp", "version_check":
 		return parseBool(key, value)
+	case "read_only":
+		// parseReadOnlyMode reads empty as off so a malformed file can't brick every
+		// command. Typed here it's a slip, and silently turning protection off is
+		// the wrong way to resolve one — `unset` clears the key.
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("invalid read_only value: %q (must be all, prod, or off; use `tiger config unset read_only` to clear it)", value)
+		}
+		// Stored as the canonical mode, cleaning up a legacy boolean in the file.
+		mode, err := parseReadOnlyMode(value)
+		if err != nil {
+			return nil, err
+		}
+		return string(mode), nil
 	case "mcp_max_rows":
 		return parsePositiveInt(key, value)
 	case "output":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestLoad_DefaultValues(t *testing.T) {
 		t.Errorf("Expected Analytics %t, got %t", DefaultAnalytics, cfg.Analytics)
 	}
 	if cfg.ReadOnly != DefaultReadOnly {
-		t.Errorf("Expected ReadOnly %t, got %t", DefaultReadOnly, cfg.ReadOnly)
+		t.Errorf("Expected ReadOnly %s, got %s", DefaultReadOnly, cfg.ReadOnly)
 	}
 	if cfg.MCPMaxRows != DefaultMCPMaxRows {
 		t.Errorf("Expected MCPMaxRows %d, got %d", DefaultMCPMaxRows, cfg.MCPMaxRows)
@@ -89,8 +90,115 @@ read_only: true
 	if cfg.Analytics != false {
 		t.Errorf("Expected Analytics false, got %t", cfg.Analytics)
 	}
-	if !cfg.ReadOnly {
-		t.Errorf("Expected ReadOnly true, got false")
+	// A legacy boolean still means "every service".
+	if cfg.ReadOnly != ReadOnlyAll {
+		t.Errorf("Expected ReadOnly %s, got %s", ReadOnlyAll, cfg.ReadOnly)
+	}
+}
+
+// TestParseReadOnlyMode covers the value vocabulary. It's a pure function, so the
+// matrix lives here rather than in TestLoad_ReadOnlyMode, which pays for a temp
+// dir and a config file per case.
+func TestParseReadOnlyMode(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    ReadOnlyMode
+		wantErr bool
+	}{
+		{value: "all", want: ReadOnlyAll},
+		{value: "prod", want: ReadOnlyProd},
+		{value: "off", want: ReadOnlyOff},
+
+		// Accepted spellings, legacy and otherwise.
+		{value: "true", want: ReadOnlyAll},
+		{value: "false", want: ReadOnlyOff},
+		{value: "1", want: ReadOnlyAll},
+		{value: "0", want: ReadOnlyOff},
+		{value: "on", want: ReadOnlyAll},
+		// Lenient here on purpose: a file with a bare `read_only:` must not fail
+		// the load. validateValue rejects it on the config set path instead.
+		{value: "", want: ReadOnlyOff},
+		{value: "  prod  ", want: ReadOnlyProd},
+
+		// Case-insensitive, so the PROD spelling used everywhere else is accepted.
+		{value: "PROD", want: ReadOnlyProd},
+		{value: "ON", want: ReadOnlyAll},
+		{value: "Off", want: ReadOnlyOff},
+
+		{value: "sometimes", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.value), func(t *testing.T) {
+			got, err := parseReadOnlyMode(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseReadOnlyMode(%q) = %q, want an error", tt.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseReadOnlyMode(%q) failed: %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseReadOnlyMode(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoad_ReadOnlyMode covers the plumbing rather than the vocabulary (see
+// TestParseReadOnlyMode): that each source reaches the parser, and that a shape
+// only viper can produce survives the round trip.
+func TestLoad_ReadOnlyMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileBody string
+		env      string
+		want     ReadOnlyMode
+		wantErr  bool
+	}{
+		{name: "unset falls back to the default", want: DefaultReadOnly},
+		{name: "from file", fileBody: "read_only: prod\n", want: ReadOnlyProd},
+		{name: "from env", env: "prod", want: ReadOnlyProd},
+		{name: "env overrides file", fileBody: "read_only: all\n", env: "off", want: ReadOnlyOff},
+		{name: "invalid value fails the load", fileBody: "read_only: sometimes\n", wantErr: true},
+
+		// A YAML int reaches the decoder as an int, not a string. Left unparsed it
+		// would store a mode no gate matches, and the old bool field read 1 as
+		// true, so this is the fail-open regression guard.
+		{name: "YAML int", fileBody: "read_only: 1\n", want: ReadOnlyAll},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := setupTestConfig(t)
+
+			if tt.fileBody != "" {
+				if err := os.WriteFile(GetConfigFile(tmpDir), []byte(tt.fileBody), 0644); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+			}
+
+			t.Setenv("TIGER_CONFIG_DIR", tmpDir)
+			if tt.env != "" {
+				t.Setenv("TIGER_READ_ONLY", tt.env)
+			}
+
+			cfg, err := Load(nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Load(nil) succeeded with ReadOnly = %q, want an error", cfg.ReadOnly)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load(nil) failed: %v", err)
+			}
+			if cfg.ReadOnly != tt.want {
+				t.Errorf("ReadOnly = %q, want %q", cfg.ReadOnly, tt.want)
+			}
+		})
 	}
 }
 
@@ -184,8 +292,8 @@ func TestLoad_FromEnvironmentVariables(t *testing.T) {
 	if cfg.Analytics != false {
 		t.Errorf("Expected Analytics false, got %t", cfg.Analytics)
 	}
-	if !cfg.ReadOnly {
-		t.Errorf("Expected ReadOnly true, got false")
+	if cfg.ReadOnly != ReadOnlyAll {
+		t.Errorf("Expected ReadOnly %s, got %s", ReadOnlyAll, cfg.ReadOnly)
 	}
 }
 
@@ -272,7 +380,7 @@ func TestSet_PersistsToDisk(t *testing.T) {
 		"analytics":  "false",
 	}
 	for key, value := range values {
-		if err := cfg.Set(key, value); err != nil {
+		if _, err := cfg.Set(key, value); err != nil {
 			t.Fatalf("Set(%q, %q) failed: %v", key, value, err)
 		}
 	}
@@ -397,6 +505,38 @@ func TestSet(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			key:   "read_only",
+			value: "prod",
+			checkFunc: func() bool {
+				return cfg.ReadOnly == ReadOnlyProd
+			},
+		},
+		{
+			key:   "read_only",
+			value: "true",
+			checkFunc: func() bool {
+				return cfg.ReadOnly == ReadOnlyAll
+			},
+		},
+		{
+			key:           "read_only",
+			value:         "invalid",
+			expectedError: true,
+		},
+		// Empty is lenient in parseReadOnlyMode so a malformed file can't brick
+		// every command, but typed at config set it's a slip - and resolving one
+		// by silently turning protection off is the wrong direction.
+		{
+			key:           "read_only",
+			value:         "",
+			expectedError: true,
+		},
+		{
+			key:           "read_only",
+			value:         "   ",
+			expectedError: true,
+		},
+		{
 			key:           "unknown_key",
 			value:         "value",
 			expectedError: true,
@@ -405,7 +545,7 @@ func TestSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s=%s", tt.key, tt.value), func(t *testing.T) {
-			err := cfg.Set(tt.key, tt.value)
+			_, err := cfg.Set(tt.key, tt.value)
 
 			if tt.expectedError {
 				if err == nil {
@@ -421,6 +561,41 @@ func TestSet(t *testing.T) {
 
 			if tt.checkFunc != nil && !tt.checkFunc() {
 				t.Errorf("Configuration value not set correctly for %s=%s", tt.key, tt.value)
+			}
+		})
+	}
+}
+
+// TestSet_ReadOnlyNormalizesOnWrite checks the one thing TestSet's checkFunc
+// can't: read_only is stored as the canonical mode rather than verbatim, so a
+// config file written with a legacy boolean is cleaned up rather than kept.
+func TestSet_ReadOnlyNormalizesOnWrite(t *testing.T) {
+	for _, tt := range []struct{ value, want, wantFile string }{
+		{value: "prod", want: "prod", wantFile: "read_only: prod"},
+		{value: "true", want: "all", wantFile: "read_only: all"},
+		{value: "on", want: "all", wantFile: "read_only: all"},
+		// The writer quotes `off`, which unquoted would round-trip as a YAML 1.1
+		// boolean. That quoting is what makes the mode name safe to store.
+		{value: "false", want: "off", wantFile: `read_only: "off"`},
+	} {
+		t.Run(tt.value, func(t *testing.T) {
+			tmpDir := setupTestConfig(t)
+			cfg := &Config{ConfigDir: tmpDir}
+
+			stored, err := cfg.Set("read_only", tt.value)
+			if err != nil {
+				t.Fatalf("Set(read_only, %q) failed: %v", tt.value, err)
+			}
+			if stored != tt.want {
+				t.Errorf("Set returned %q, want %q", stored, tt.want)
+			}
+
+			body, err := os.ReadFile(GetConfigFile(tmpDir))
+			if err != nil {
+				t.Fatalf("Failed to read config file: %v", err)
+			}
+			if got := strings.TrimSpace(string(body)); got != tt.wantFile {
+				t.Errorf("config file = %q, want %q", got, tt.wantFile)
 			}
 		})
 	}
@@ -693,7 +868,7 @@ func TestSet_CreatesConfigDirectory(t *testing.T) {
 	configDir := filepath.Join(tmpDir, "nested", "config")
 
 	cfg := &Config{ConfigDir: configDir}
-	if err := cfg.Set("api_url", "https://test.api.com/v1"); err != nil {
+	if _, err := cfg.Set("api_url", "https://test.api.com/v1"); err != nil {
 		t.Fatalf("Set() failed: %v", err)
 	}
 
@@ -771,6 +946,23 @@ func TestEnsureConfigDir_ErrorSuggestsOverride(t *testing.T) {
 	for _, want := range []string{"TIGER_CONFIG_DIR", "--config-dir"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("expected error to mention %q; got: %s", want, err.Error())
+		}
+	}
+}
+
+// TestValidConfigOptionValues_ReadOnly guards the completion values for
+// read_only.
+func TestValidConfigOptionValues_ReadOnly(t *testing.T) {
+	got := ValidConfigOptionValues("read_only")
+	want := []string{"all", "prod", "off"}
+	if !slices.Equal(got, want) {
+		t.Errorf("ValidConfigOptionValues(\"read_only\") = %v, want %v", got, want)
+	}
+
+	// Every offered value must survive the parser that validateValue uses.
+	for _, v := range got {
+		if _, err := parseReadOnlyMode(v); err != nil {
+			t.Errorf("completion offers %q, which parseReadOnlyMode rejects: %v", v, err)
 		}
 	}
 }

--- a/internal/mcp/db_execute_query.go
+++ b/internal/mcp/db_execute_query.go
@@ -164,7 +164,7 @@ func (s *Server) handleDBExecuteQuery(ctx context.Context, req *mcp.CallToolRequ
 		slog.Duration("timeout", timeout),
 		slog.String("role", input.Role),
 		slog.Bool("pooled", input.Pooled),
-		slog.Bool("read_only", cfg.ReadOnly),
+		slog.String("read_only", string(cfg.ReadOnly)),
 	)
 
 	// service_id may name a service or one of its read replicas.
@@ -172,6 +172,9 @@ func (s *Server) handleDBExecuteQuery(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return nil, DBExecuteQueryOutput{}, err
 	}
+
+	// Under prod mode the resolved target's tag decides.
+	readOnlySession := common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(target.ConnectionService)) != nil
 
 	// A replica without a pooler connects directly; surface that as a warning.
 	poolerWarning := common.ReplicaPoolerWarning(target, input.Pooled)
@@ -199,7 +202,7 @@ func (s *Server) handleDBExecuteQuery(ctx context.Context, req *mcp.CallToolRequ
 		Pooled:       input.Pooled,
 		Role:         input.Role,
 		WithPassword: true,
-		ReadOnly:     cfg.ReadOnly,
+		ReadOnly:     readOnlySession,
 	}, mode)
 	if err != nil {
 		return nil, DBExecuteQueryOutput{}, err

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -1,6 +1,7 @@
 package mcp
 
-// readOnlyGatedTools are the service-mutating tools addTool skips in read-only mode.
+// readOnlyGatedTools are the service-mutating tools addTool skips under
+// read_only=all.
 var readOnlyGatedTools = []string{
 	toolServiceCreate,
 	toolServiceFork,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -53,9 +53,11 @@ type Server struct {
 	app *common.App
 }
 
-// addTool registers an MCP tool, skipping readOnlyGatedTools in read-only mode.
-func addTool[In, Out any](s *Server, readOnly bool, t *mcp.Tool, h mcp.ToolHandlerFor[In, Out]) {
-	if readOnly && slices.Contains(readOnlyGatedTools, t.Name) {
+// addTool registers an MCP tool, skipping readOnlyGatedTools under read_only=all.
+// Under prod they stay registered — they still work on DEV services — and refuse
+// per call in the handler, once the target is known.
+func addTool[In, Out any](s *Server, mode config.ReadOnlyMode, t *mcp.Tool, h mcp.ToolHandlerFor[In, Out]) {
+	if mode.BlocksAll() && slices.Contains(readOnlyGatedTools, t.Name) {
 		s.logger.Info("Skipping write tool in read-only mode", slog.String("tool", t.Name))
 		return
 	}
@@ -65,17 +67,27 @@ func addTool[In, Out any](s *Server, readOnly bool, t *mcp.Tool, h mcp.ToolHandl
 // buildServerInstructions returns the `instructions` string the MCP SDK sends
 // to clients at initialize. Evaluated once at server start, like tool registration.
 func buildServerInstructions(cfg *config.Config) string {
-	intro := "Tiger MCP provides tools for managing and querying Tiger Cloud database services (managed TimescaleDB/PostgreSQL). "
+	const (
+		intro        = "Tiger MCP provides tools for managing and querying Tiger Cloud database services (managed TimescaleDB/PostgreSQL). "
+		capabilities = "Use it to provision and fork services, start/stop/resize instances, rotate credentials, fetch service logs, execute SQL queries, and search Tiger documentation."
+	)
 
-	if cfg == nil || !cfg.ReadOnly {
+	switch cfg.ReadOnly {
+	case config.ReadOnlyAll:
+		// The write tools aren't registered, so announce the mode instead of
+		// advertising them.
 		return intro +
-			"Use it to provision and fork services, start/stop/resize instances, rotate credentials, fetch service logs, execute SQL queries, and search Tiger documentation."
+			"READ-ONLY MODE IS ENABLED. Service-mutating tools are not registered, so do not offer to create, fork, start, stop, resize, or modify services. " +
+			"db_execute_query connects read-only, so writes and DDL are rejected by the server."
+	case config.ReadOnlyProd:
+		// The write tools are registered, so keep advertising them but explain
+		// the refusals — otherwise one looks like a bug.
+		return intro + capabilities + " " +
+			"READ-ONLY MODE IS ENABLED FOR PRODUCTION SERVICES. Services tagged PROD cannot be modified: the service-mutating tools refuse them, and db_execute_query connects to them read-only, so writes and DDL are rejected by the server. " +
+			"Services tagged DEV are unaffected. Check a service's environment field (from service_get or service_list) before offering to modify it."
+	default:
+		return intro + capabilities
 	}
-	// Read-only mode: announce the mode and the blocked operations so the model
-	// won't attempt them.
-	return intro +
-		"READ-ONLY MODE IS ENABLED. Service-mutating tools are not registered, so do not offer to create, fork, start, stop, resize, or modify services. " +
-		"db_execute_query connects read-only, so writes and DDL are rejected by the server."
 }
 
 // NewServer creates a new Tiger MCP server instance. The app must already be
@@ -101,8 +113,8 @@ func NewServer(ctx context.Context, app *common.App, logger *slog.Logger) (*Serv
 		app:       app,
 	}
 
-	// Register all tools (including proxied docs tools). readOnly and
-	// experimental are captured here and threaded through registration only.
+	// Register all tools (including proxied docs tools). The read-only mode and
+	// experimental gate are captured here and threaded through registration only.
 	// experimental follows the ghost pattern — env-var only, undocumented; see
 	// CLAUDE.md's "Experimental Feature Gating".
 	server.registerTools(ctx, cfg.ReadOnly, app.Experimental)
@@ -135,12 +147,12 @@ func (s *Server) HTTPHandler() http.Handler {
 }
 
 // registerTools registers all available MCP tools
-func (s *Server) registerTools(ctx context.Context, readOnly, experimental bool) {
+func (s *Server) registerTools(ctx context.Context, mode config.ReadOnlyMode, experimental bool) {
 	// Service management tools
-	s.registerServiceTools(readOnly, experimental)
+	s.registerServiceTools(mode, experimental)
 
 	// Database operation tools
-	s.registerDatabaseTools(readOnly)
+	s.registerDatabaseTools(mode)
 
 	// TODO: Register more tool groups
 
@@ -149,31 +161,31 @@ func (s *Server) registerTools(ctx context.Context, readOnly, experimental bool)
 }
 
 // registerServiceTools registers service management tools with comprehensive schemas and descriptions
-func (s *Server) registerServiceTools(readOnly, experimental bool) {
-	addTool(s, readOnly, newServiceListTool(), s.handleServiceList)
-	addTool(s, readOnly, newServiceGetTool(), s.handleServiceGet)
-	addTool(s, readOnly, newServiceCreateTool(), s.handleServiceCreate)
-	addTool(s, readOnly, newServiceForkTool(), s.handleServiceFork)
-	addTool(s, readOnly, newServiceUpdatePasswordTool(), s.handleServiceUpdatePassword)
-	addTool(s, readOnly, newServiceStartTool(), s.handleServiceStart)
-	addTool(s, readOnly, newServiceStopTool(), s.handleServiceStop)
-	addTool(s, readOnly, newServiceResizeTool(), s.handleServiceResize)
-	addTool(s, readOnly, newServiceLogsTool(), s.handleServiceLogs)
+func (s *Server) registerServiceTools(mode config.ReadOnlyMode, experimental bool) {
+	addTool(s, mode, newServiceListTool(), s.handleServiceList)
+	addTool(s, mode, newServiceGetTool(), s.handleServiceGet)
+	addTool(s, mode, newServiceCreateTool(), s.handleServiceCreate)
+	addTool(s, mode, newServiceForkTool(), s.handleServiceFork)
+	addTool(s, mode, newServiceUpdatePasswordTool(), s.handleServiceUpdatePassword)
+	addTool(s, mode, newServiceStartTool(), s.handleServiceStart)
+	addTool(s, mode, newServiceStopTool(), s.handleServiceStop)
+	addTool(s, mode, newServiceResizeTool(), s.handleServiceResize)
+	addTool(s, mode, newServiceLogsTool(), s.handleServiceLogs)
 
 	// Metrics tools target gateway endpoints marked `x-tigerdata-preview: true`. They
 	// are registered only when the experimental gate is on at server startup;
 	// the user must restart the MCP server after toggling the gate. Handler
 	// bodies re-check the gate defensively in case config changes mid-session.
 	if experimental {
-		addTool(s, readOnly, newServiceMetricsAvailableTool(), s.handleServiceMetricsAvailable)
-		addTool(s, readOnly, newServiceMetricsSeriesTool(), s.handleServiceMetricsSeries)
-		addTool(s, readOnly, newServiceBackupsTool(), s.handleServiceBackups)
+		addTool(s, mode, newServiceMetricsAvailableTool(), s.handleServiceMetricsAvailable)
+		addTool(s, mode, newServiceMetricsSeriesTool(), s.handleServiceMetricsSeries)
+		addTool(s, mode, newServiceBackupsTool(), s.handleServiceBackups)
 	}
 }
 
 // registerDatabaseTools registers database operation tools with comprehensive schemas and descriptions
-func (s *Server) registerDatabaseTools(readOnly bool) {
-	addTool(s, readOnly, newDBExecuteQueryTool(), s.handleDBExecuteQuery)
+func (s *Server) registerDatabaseTools(mode config.ReadOnlyMode) {
+	addTool(s, mode, newDBExecuteQueryTool(), s.handleDBExecuteQuery)
 
 	mcp.AddTool(s.mcpServer, newDBSchemaTool(), s.handleDBSchema)
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ var alwaysRegisteredTools = []string{
 // registeredToolNames returns the tool names a server advertises over a real
 // client/server session. registerDocsProxy is skipped: it connects to a remote
 // server.
-func registeredToolNames(t *testing.T, readOnly bool) []string {
+func registeredToolNames(t *testing.T, readOnly config.ReadOnlyMode) []string {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -69,11 +69,12 @@ func registeredToolNames(t *testing.T, readOnly bool) []string {
 func TestReadOnlyToolRegistration(t *testing.T) {
 	for _, tt := range []struct {
 		name             string
-		readOnly         bool
+		readOnly         config.ReadOnlyMode
 		wantGatedPresent bool
 	}{
-		{"read-write registers all tools", false, true},
-		{"read-only skips gated tools", true, false},
+		{"read-write registers all tools", config.ReadOnlyOff, true},
+		{"read-only skips gated tools", config.ReadOnlyAll, false},
+		{"prod mode keeps gated tools registered", config.ReadOnlyProd, true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			names := registeredToolNames(t, tt.readOnly)
@@ -97,29 +98,36 @@ func TestReadOnlyToolRegistration(t *testing.T) {
 func TestBuildServerInstructions(t *testing.T) {
 	const capabilitiesMarker = "Tiger MCP provides tools"
 
-	readWrite := buildServerInstructions(&config.Config{ReadOnly: false})
-	readOnly := buildServerInstructions(&config.Config{ReadOnly: true})
+	readWrite := buildServerInstructions(&config.Config{ReadOnly: config.ReadOnlyOff})
+	readOnly := buildServerInstructions(&config.Config{ReadOnly: config.ReadOnlyAll})
+	prodOnly := buildServerInstructions(&config.Config{ReadOnly: config.ReadOnlyProd})
 
-	// The capabilities blurb is always present, including for a nil config.
-	for _, got := range []string{buildServerInstructions(nil), readWrite, readOnly} {
+	// The capabilities blurb is always present, whatever the mode.
+	for _, got := range []string{readWrite, readOnly, prodOnly} {
 		if !strings.Contains(got, capabilitiesMarker) {
 			t.Errorf("instructions missing capabilities blurb: %q", got)
 		}
 	}
 
-	// The read-only banner appears only in read-only mode.
+	// The read-only banner appears only when a read-only mode is set.
 	const banner = "READ-ONLY MODE IS ENABLED"
-	if !strings.Contains(readOnly, banner) {
-		t.Errorf("read-only instructions missing banner: %q", readOnly)
+	for _, got := range []string{readOnly, prodOnly} {
+		if !strings.Contains(got, banner) {
+			t.Errorf("read-only instructions missing banner: %q", got)
+		}
 	}
 	if strings.Contains(readWrite, banner) {
 		t.Errorf("read-write instructions should not contain banner: %q", readWrite)
 	}
 
-	// Read-only instructions never name the gated write tools.
+	// Read-only instructions never name the gated tools, since they aren't
+	// registered; prod-mode ones must explain what the registered tools refuse.
 	for _, tool := range readOnlyGatedTools {
 		if strings.Contains(readOnly, tool) {
 			t.Errorf("read-only instructions should not name gated tool %q: %q", tool, readOnly)
 		}
+	}
+	if !strings.Contains(prodOnly, "PROD") {
+		t.Errorf("prod-mode instructions should explain that PROD services are refused: %q", prodOnly)
 	}
 }

--- a/internal/mcp/service_create.go
+++ b/internal/mcp/service_create.go
@@ -103,7 +103,9 @@ func (s *Server) handleServiceCreate(ctx context.Context, req *mcp.CallToolReque
 		return nil, ServiceCreateOutput{}, err
 	}
 
-	if err := common.CheckReadOnly(cfg); err != nil {
+	// Deliberately DEV-only: this tool takes no environment_tag, so the API always
+	// tags what it creates DEV.
+	if err := common.CheckReadOnly(cfg, api.EnvironmentTagDEV); err != nil {
 		return nil, ServiceCreateOutput{}, err
 	}
 
@@ -161,7 +163,7 @@ func (s *Server) handleServiceCreate(ctx context.Context, req *mcp.CallToolReque
 
 	// Set as default service if requested (defaults to true)
 	if input.SetDefault {
-		if err := cfg.Set("service_id", serviceID); err != nil {
+		if _, err := cfg.Set("service_id", serviceID); err != nil {
 			// Log warning but don't fail the service creation
 			s.logger.Warn("MCP: Failed to set service as default", slog.Any("error", err))
 		} else {

--- a/internal/mcp/service_fork.go
+++ b/internal/mcp/service_fork.go
@@ -106,7 +106,8 @@ func (s *Server) handleServiceFork(ctx context.Context, req *mcp.CallToolRequest
 		return nil, ServiceForkOutput{}, err
 	}
 
-	if err := common.CheckReadOnly(cfg); err != nil {
+	// Deliberately DEV-only: the fork is always tagged DEV.
+	if err := common.CheckReadOnly(cfg, api.EnvironmentTagDEV); err != nil {
 		return nil, ServiceForkOutput{}, err
 	}
 
@@ -187,7 +188,7 @@ func (s *Server) handleServiceFork(ctx context.Context, req *mcp.CallToolRequest
 
 	// Set as default service if requested (defaults to true)
 	if input.SetDefault {
-		if err := cfg.Set("service_id", serviceID); err != nil {
+		if _, err := cfg.Set("service_id", serviceID); err != nil {
 			// Log warning but don't fail the service fork
 			s.logger.Warn("MCP: Failed to set service as default", slog.Any("error", err))
 		} else {

--- a/internal/mcp/service_list.go
+++ b/internal/mcp/service_list.go
@@ -32,13 +32,14 @@ func (ServiceListOutput) Schema() *jsonschema.Schema {
 
 // ServiceInfo represents simplified service information for MCP output
 type ServiceInfo struct {
-	ServiceID string        `json:"id" jsonschema:"Service identifier (10-character alphanumeric string)"`
-	Name      string        `json:"name"`
-	Status    string        `json:"status" jsonschema:"Service status (e.g., READY, PAUSED, CONFIGURING, UPGRADING)"`
-	Type      string        `json:"type"`
-	Region    string        `json:"region"`
-	Created   string        `json:"created,omitempty"`
-	Resources *ResourceInfo `json:"resources,omitempty"`
+	ServiceID   string        `json:"id" jsonschema:"Service identifier (10-character alphanumeric string)"`
+	Name        string        `json:"name"`
+	Status      string        `json:"status" jsonschema:"Service status (e.g., READY, PAUSED, CONFIGURING, UPGRADING)"`
+	Type        string        `json:"type"`
+	Region      string        `json:"region"`
+	Created     string        `json:"created,omitempty"`
+	Environment string        `json:"environment" jsonschema:"Environment tag (DEV or PROD). Under read_only=prod, services tagged PROD cannot be modified."`
+	Resources   *ResourceInfo `json:"resources,omitempty"`
 }
 
 func (ServiceInfo) Schema() *jsonschema.Schema {
@@ -108,6 +109,9 @@ func (s *Server) convertToServiceInfo(service api.Service) ServiceInfo {
 		Type:      string(service.ServiceType),
 		Region:    service.RegionCode,
 		Created:   service.Created.Format("2006-01-02T15:04:05Z"),
+		// The read_only=prod instructions point the model at this field, so a list
+		// result has to carry it too, not just ServiceDetail.
+		Environment: string(common.ServiceEnvironmentTag(service)),
 	}
 
 	// Add resource information if available

--- a/internal/mcp/service_resize.go
+++ b/internal/mcp/service_resize.go
@@ -76,7 +76,7 @@ func (s *Server) handleServiceResize(ctx context.Context, req *mcp.CallToolReque
 		return nil, ServiceResizeOutput{}, err
 	}
 
-	if err := common.CheckReadOnly(cfg); err != nil {
+	if err := common.CheckReadOnlyByServiceID(ctx, cfg, client, projectID, input.ServiceID); err != nil {
 		return nil, ServiceResizeOutput{}, err
 	}
 

--- a/internal/mcp/service_start.go
+++ b/internal/mcp/service_start.go
@@ -68,7 +68,7 @@ func (s *Server) handleServiceStart(ctx context.Context, req *mcp.CallToolReques
 		return nil, ServiceStartOutput{}, err
 	}
 
-	if err := common.CheckReadOnly(cfg); err != nil {
+	if err := common.CheckReadOnlyByServiceID(ctx, cfg, client, projectID, input.ServiceID); err != nil {
 		return nil, ServiceStartOutput{}, err
 	}
 

--- a/internal/mcp/service_stop.go
+++ b/internal/mcp/service_stop.go
@@ -68,7 +68,7 @@ func (s *Server) handleServiceStop(ctx context.Context, req *mcp.CallToolRequest
 		return nil, ServiceStopOutput{}, err
 	}
 
-	if err := common.CheckReadOnly(cfg); err != nil {
+	if err := common.CheckReadOnlyByServiceID(ctx, cfg, client, projectID, input.ServiceID); err != nil {
 		return nil, ServiceStopOutput{}, err
 	}
 

--- a/internal/mcp/service_update_password.go
+++ b/internal/mcp/service_update_password.go
@@ -66,8 +66,10 @@ func (s *Server) handleServiceUpdatePassword(ctx context.Context, req *mcp.CallT
 		return nil, ServiceUpdatePasswordOutput{}, err
 	}
 
-	if err := common.CheckReadOnly(cfg); err != nil {
-		return nil, ServiceUpdatePasswordOutput{}, err
+	// Refuse without an API call under read_only=all. prod needs the tag, so the
+	// real gate waits for the fetch below.
+	if cfg.ReadOnly.BlocksAll() {
+		return nil, ServiceUpdatePasswordOutput{}, common.ErrReadOnly
 	}
 
 	s.logger.Info("MCP: Updating service password",
@@ -79,8 +81,8 @@ func (s *Server) handleServiceUpdatePassword(ctx context.Context, req *mcp.CallT
 		Password: input.Password,
 	}
 
-	// Fetch first so we can reject read replicas and reuse the service for
-	// password storage below.
+	// Fetch first so we can apply the read-only gate, reject read replicas, and
+	// reuse the service for password storage below.
 	serviceResp, err := client.GetServiceWithResponse(ctx, projectID, input.ServiceID)
 	if err != nil {
 		return nil, ServiceUpdatePasswordOutput{}, fmt.Errorf("failed to get service details: %w", err)
@@ -92,6 +94,12 @@ func (s *Server) handleServiceUpdatePassword(ctx context.Context, req *mcp.CallT
 		return nil, ServiceUpdatePasswordOutput{}, fmt.Errorf("empty response from API")
 	}
 	service := *serviceResp.JSON200
+
+	// The prod half of the gate, riding on the fetch above.
+	if err := common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(service)); err != nil {
+		return nil, ServiceUpdatePasswordOutput{}, err
+	}
+
 	if common.IsReadReplica(service) {
 		return nil, ServiceUpdatePasswordOutput{}, fmt.Errorf("%q is a read replica; update the password on its primary service %q instead",
 			input.ServiceID, util.DerefStr(service.ForkedFrom.ServiceID))

--- a/internal/mcp/utils.go
+++ b/internal/mcp/utils.go
@@ -61,6 +61,7 @@ type ServiceDetail struct {
 	Type             string        `json:"type"`
 	Region           string        `json:"region"`
 	Created          string        `json:"created,omitempty"`
+	Environment      string        `json:"environment" jsonschema:"Environment tag (DEV or PROD). Under read_only=prod, services tagged PROD cannot be modified."`
 	Resources        *ResourceInfo `json:"resources,omitempty"`
 	Replicas         int           `json:"replicas" jsonschema:"Number of HA replicas (0=single node/no HA, 1+=HA enabled)"`
 	DirectEndpoint   string        `json:"direct_endpoint,omitempty" jsonschema:"Direct database connection endpoint"`
@@ -84,6 +85,8 @@ func (s *Server) convertToServiceDetail(cfg *config.Config, service api.Service,
 		Type:      string(service.ServiceType),
 		Region:    service.RegionCode,
 		Created:   service.Created.Format("2006-01-02T15:04:05Z"),
+		// The read_only=prod instructions tell the model to check this first.
+		Environment: string(common.ServiceEnvironmentTag(service)),
 	}
 
 	// Add resource information if available
@@ -149,6 +152,7 @@ func (s *Server) convertToServiceDetail(cfg *config.Config, service api.Service,
 		Role:            "tsdbadmin",
 		WithPassword:    withPassword,
 		InitialPassword: util.Deref(service.InitialPassword),
+		ReadOnly:        common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(service)) != nil,
 	}); err != nil {
 		s.logger.Error("MCP: Failed to build connection string", slog.Any("error", err))
 	} else {


### PR DESCRIPTION
`read_only` was a bool: writes were refused either everywhere or nowhere. It now takes three modes, so an agent can be let loose on development services while production stays protected:

-   all:   every service (equivalent to the old `true`)
-   prod:  only services tagged PROD
-   off:   nothing (equivalent to the old `false`, and still the default)

The booleans keep working - `read_only: true` in a config file, or TIGER_READ_ONLY=true, still mean `all`. The default stays `off`; flipping it to `prod` is a separate decision, since it would change behavior for production services - notably `tiger db connect`, which would start opening read-only sessions.

Because `prod` protects only services tagged PROD, every gate needs its target's environment tag. common.CheckReadOnly(cfg, tag) is the verdict, and CheckReadOnlyByServiceID fetches the service when only its ID is known - one extra API call, and only under `prod`. Both require a tag, so a gate cannot silently skip prod mode.

Notes on the individual surfaces:

- MCP registration cannot express `prod`, so the write tools stay registered (they still work on DEV services) and refuse per call instead. The server instructions gained a prod variant so a refusal does not look like a bug, and ServiceDetail now reports each service's environment tag so the model can check before offering to modify one.
- Database sessions reach the same verdict as the control-plane gate: a mode that refuses writes to a service also opens its connections read-only. That covers the connection strings embedded in service get/list output, not just the db commands.
- A replica set is judged on its own environment tag rather than its primary's, on both planes, matching how the API tags replica sets individually.
- `db create role` is gated too, and the `db connect` password-recovery menu no longer offers to rotate the password of a protected service.

## First-login prompt

`read_only` defaults to `off`, so the protection above only reaches users who go looking for it. Flipping the default would change behaviour for every existing user — notably `tiger db connect`, which would start opening read-only sessions against `PROD` services, with Postgres reporting the refusal so nothing points at the setting.

A first interactive `tiger auth login` now offers it instead:

```
Protect services tagged PROD from writes? [Y/n]:
```

- Triggered only when no credentials existed beforehand, so existing users are never asked and no default changes. The answer is written to the config file, so `config show` reflects a choice rather than a version-dependent default.
- Both answers are recorded, so it asks exactly once. Declining stores `read_only: off` rather than leaving the key absent — absence can't record a negative answer, so a logout and second login would otherwise ask again. The guard tests key *presence* rather than the resolved value, since `off` is also the default.
- Skipped when stdin isn't a terminal, so scripted and CI logins neither block nor change behaviour. Unlike the CLI's other TTY gates it skips silently rather than erroring, since nothing is being refused.