### PR TITLE
Add tiger project command for switching the active project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ The middleware automatically excludes sensitive fields using a centralized ignor
    Annotations: map[string]string{analytics.OmitArgsAnnotation: "true"},
    ```
 
-3. **For error messages:** The `error` event property records the command's error text verbatim. Wrap errors whose message embeds sensitive data with `analytics.RedactError(err, "safe message")` — the user sees the full message, analytics records the redacted one.
+3. **For error messages:** The `error` event property records the command's error text verbatim, so don't interpolate sensitive values (project IDs, keys, queries) into error messages. Echo them on stderr (`cmd.PrintErrf`) instead when the user needs them — stderr never reaches analytics.
 
 **Common sensitive fields to watch for:**
 - Credentials: API keys, tokens, passwords, secret keys
@@ -323,7 +323,7 @@ Tiger CLI is a Go-based command-line interface for managing Tiger, the modern da
   flags, and configuration initialization. Files ending in `_helper.go` hold
   cross-group helpers rather than commands — see "Where Helpers Go" below.
   - `db_connect.go` - The whole `db connect`/`psql` flow, including read replica selection: in an interactive terminal, when the service has one or more active read replicas (listed via the `/replicaSets` API), prompts to connect to the primary or one of the replicas. Skipped when stdin is not a TTY, when `--no-replica-prompt` is set, or when the service has no read replicas. Also handles password recovery when the stored password is rejected.
-  - `project.go` - `tiger project`, which switches the active project via `cfg.SwitchProject`. The active project lives in the stored credentials, not the config file, so switching requires an OAuth login — an API key is scoped to one project, and env API keys take precedence over stored credentials entirely. A switch clears the `service_id` config value (a default service belongs to its project) and reloads the App so later readers — analytics in particular — see the new project. `project_helper.go` holds the project fetching and selection shared with `auth login`. Deliberately has no MCP counterpart: a per-request MCP session must not switch a process-wide default shared with other sessions.
+  - `project.go` - `tiger project`, which switches the active project via `cfg.SwitchProject`. The active project lives in the stored credentials, not the config file, so switching requires an OAuth login — an API key is scoped to one project, and env API keys take precedence over stored credentials entirely. Any project change clears the `service_id` config value via `clearStaleDefaultService` — `auth login` calls it too, since a default service belongs to its project — and updates the App's client so later readers (analytics in particular) see the new project. `project_helper.go` holds the project fetching and selection shared with `auth login`. Deliberately has no MCP counterpart: a per-request MCP session must not switch a process-wide default shared with other sessions.
   - `upgrade.go` - Self-update command (download latest release, verify checksum, replace running binary in place)
 - **Configuration**: `internal/config/config.go` - `Config` struct plus load/write
   helpers. Each `Load` uses its own viper instance (no global state); see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,9 +296,15 @@ The middleware automatically excludes sensitive fields using a centralized ignor
 1. **For sensitive flags or MCP tool parameters:** Add the field name to the `ignore` list in `internal/analytics/analytics.go`
    - Note: Flag names with dashes (like `public-key`) should be added with underscores (`public_key`) to the ignore list
 
-2. **For positional arguments:** Currently, all positional arguments are tracked automatically. If a command is added that accepts sensitive data as a positional argument (not as a flag), you must either:
-   - Refactor to use a flag instead
-   - Add filtering logic in `wrapCommands()` in `internal/cmd/root.go` to sanitize or omit the args from tracking
+2. **For positional arguments:** Positional arguments are tracked automatically for every command. A command whose argument carries something the ignore list excludes elsewhere opts out with the `analytics.OmitArgsAnnotation` annotation (defined in `internal/analytics/analytics.go`), which makes `wrapCommands` skip the `args` property for that command:
+
+   ```go
+   Annotations: map[string]string{analytics.OmitArgsAnnotation: "true"},
+   ```
+
+   The constant lives beside the `ignore` list, so both redaction mechanisms sit together. `tiger project` uses it, since its argument is a project ID and `project_id` is on the ignore list. For anything else sensitive, either refactor to use a flag or add filtering logic in `wrapCommands()`.
+
+3. **For error messages:** The `error` event property records the command's error text verbatim, so an error whose message embeds sensitive data re-leaks what the ignore list excludes. Wrap such errors with `analytics.RedactError(err, "safe message")` — the user sees the full message, analytics records the redacted one. `resolveProjectID` is the model.
 
 **Common sensitive fields to watch for:**
 - Credentials: API keys, tokens, passwords, secret keys
@@ -313,12 +319,13 @@ Tiger CLI is a Go-based command-line interface for managing Tiger, the modern da
 
 - **Entry Point**: `cmd/tiger/main.go` - Simple main that delegates to cmd.Execute()
 - **Command Structure**: `internal/cmd/` - Cobra-based command definitions for all
-  CLI commands (auth, service, db, config, mcp, version, upgrade, completion).
+  CLI commands (auth, project, service, db, config, mcp, version, upgrade, completion).
   Each command lives in its own file, named to match the command in snake_case
   (see "One File Per Command" below). `root.go` holds the root command, global
   flags, and configuration initialization. Files ending in `_helper.go` hold
   cross-group helpers rather than commands — see "Where Helpers Go" below.
   - `db_connect.go` - The whole `db connect`/`psql` flow, including read replica selection: in an interactive terminal, when the service has one or more active read replicas (listed via the `/replicaSets` API), prompts to connect to the primary or one of the replicas. Skipped when stdin is not a TTY, when `--no-replica-prompt` is set, or when the service has no read replicas. Also handles password recovery when the stored password is rejected.
+  - `project.go` - `tiger project`, which switches the active project via `cfg.SwitchProject`. The active project lives in the stored credentials (`storedCredentials.ProjectID`), not in the config file, so switching is only possible for an OAuth login — an API key is scoped to one project, and API keys in the environment take precedence over stored credentials entirely. Clears the `service_id` config value on a switch, since a default service belongs to the project it was set in, then calls `app.Load` so the API client is rebuilt against the new project (its token-persisting closure is bound to the project it was built for). `project_helper.go` holds the project fetching and selection shared with `auth login`. Deliberately has no MCP counterpart: switching a process-wide default from a per-request MCP session would change state for every other session sharing the credentials.
   - `upgrade.go` - Self-update command (download latest release, verify checksum, replace running binary in place)
 - **Configuration**: `internal/config/config.go` - `Config` struct plus load/write
   helpers. Each `Load` uses its own viper instance (no global state); see
@@ -667,7 +674,7 @@ Place a helper by who calls it, working down this list until one matches:
 2. **Several commands in one group** → the group file (`service.go`, `db.go`).
 3. **Across groups** → a package-level `<topic>_helper.go` file:
    `completion_helper.go`, `flag_helper.go`, `logger_helper.go`,
-   `password_helper.go`.
+   `password_helper.go`, `project_helper.go`.
 4. **A genuine standalone utility** — small and isolated, with no notion of a
    command (`util.GenerateSecurePassword`) → `internal/util`. Anything shaped
    around the CLI stays in `cmd` even if its signature looks generic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,15 +296,13 @@ The middleware automatically excludes sensitive fields using a centralized ignor
 1. **For sensitive flags or MCP tool parameters:** Add the field name to the `ignore` list in `internal/analytics/analytics.go`
    - Note: Flag names with dashes (like `public-key`) should be added with underscores (`public_key`) to the ignore list
 
-2. **For positional arguments:** Positional arguments are tracked automatically for every command. A command whose argument carries something the ignore list excludes elsewhere opts out with the `analytics.OmitArgsAnnotation` annotation (defined in `internal/analytics/analytics.go`), which makes `wrapCommands` skip the `args` property for that command:
+2. **For positional arguments:** Positional arguments are tracked automatically. A command whose argument is sensitive opts out with the `analytics.OmitArgsAnnotation` annotation, which makes `wrapCommands` skip the `args` property — `tiger project` does this, since its argument is a project ID:
 
    ```go
    Annotations: map[string]string{analytics.OmitArgsAnnotation: "true"},
    ```
 
-   The constant lives beside the `ignore` list, so both redaction mechanisms sit together. `tiger project` uses it, since its argument is a project ID and `project_id` is on the ignore list. For anything else sensitive, either refactor to use a flag or add filtering logic in `wrapCommands()`.
-
-3. **For error messages:** The `error` event property records the command's error text verbatim, so an error whose message embeds sensitive data re-leaks what the ignore list excludes. Wrap such errors with `analytics.RedactError(err, "safe message")` — the user sees the full message, analytics records the redacted one. `resolveProjectID` is the model.
+3. **For error messages:** The `error` event property records the command's error text verbatim. Wrap errors whose message embeds sensitive data with `analytics.RedactError(err, "safe message")` — the user sees the full message, analytics records the redacted one.
 
 **Common sensitive fields to watch for:**
 - Credentials: API keys, tokens, passwords, secret keys
@@ -325,7 +323,7 @@ Tiger CLI is a Go-based command-line interface for managing Tiger, the modern da
   flags, and configuration initialization. Files ending in `_helper.go` hold
   cross-group helpers rather than commands — see "Where Helpers Go" below.
   - `db_connect.go` - The whole `db connect`/`psql` flow, including read replica selection: in an interactive terminal, when the service has one or more active read replicas (listed via the `/replicaSets` API), prompts to connect to the primary or one of the replicas. Skipped when stdin is not a TTY, when `--no-replica-prompt` is set, or when the service has no read replicas. Also handles password recovery when the stored password is rejected.
-  - `project.go` - `tiger project`, which switches the active project via `cfg.SwitchProject`. The active project lives in the stored credentials (`storedCredentials.ProjectID`), not in the config file, so switching is only possible for an OAuth login — an API key is scoped to one project, and API keys in the environment take precedence over stored credentials entirely. Clears the `service_id` config value on a switch, since a default service belongs to the project it was set in, then calls `app.Load` so the API client is rebuilt against the new project (its token-persisting closure is bound to the project it was built for). `project_helper.go` holds the project fetching and selection shared with `auth login`. Deliberately has no MCP counterpart: switching a process-wide default from a per-request MCP session would change state for every other session sharing the credentials.
+  - `project.go` - `tiger project`, which switches the active project via `cfg.SwitchProject`. The active project lives in the stored credentials, not the config file, so switching requires an OAuth login — an API key is scoped to one project, and env API keys take precedence over stored credentials entirely. A switch clears the `service_id` config value (a default service belongs to its project) and reloads the App so later readers — analytics in particular — see the new project. `project_helper.go` holds the project fetching and selection shared with `auth login`. Deliberately has no MCP counterpart: a per-request MCP session must not switch a process-wide default shared with other sessions.
   - `upgrade.go` - Self-update command (download latest release, verify checksum, replace running binary in place)
 - **Configuration**: `internal/config/config.go` - `Config` struct plus load/write
   helpers. Each `Load` uses its own viper instance (no global state); see

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ tiger mcp install
 Tiger CLI provides the following commands:
 
 - `tiger auth` - Authentication management
-  - `login` - Log in to your Tiger account
+  - `login` - Log in to your Tiger account (use `--project-id` to pick a project without the interactive prompt)
   - `logout` - Log out from your Tiger account
   - `status` - Show current authentication status and project ID (alias: `whoami`)
+- `tiger project [project-id]` - Switch the active project, prompting for one when no ID is given. Requires an OAuth login, since an API key is scoped to a single project (aliases: `projects`, `proj`)
 - `tiger service` - Service lifecycle management (aliases: `services`, `svc`)
   - `list` - List all services (alias: `ls`)
   - `create` - Create a new service
@@ -250,7 +251,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
 - `read_only` - When `true`, mutating operations are refused: the `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` CLI commands return an error, and their MCP equivalents are not registered, so they don't appear in `tools/list` and can't be called. `tiger db connect`, `tiger db connection-string`, and the `db_execute_query` MCP tool open the database session in Tiger Cloud's immutable read-only mode (writes and DDL are rejected by the server). Read commands/tools are unaffected — `tiger db schema` and the `db_schema` MCP tool always open a read-only session regardless of this setting. Default: `false`.
-- `service_id` - Default service ID
+- `service_id` - Default service ID. Cleared automatically by `tiger project`, since a service belongs to the project it was created in
 - `version_check` - When `true`, the CLI checks for a newer version on each invocation (in an interactive terminal) and prints a notice if one is available. Set to `false` to disable. Default: `true`.
 
 ### Environment Variables
@@ -263,6 +264,7 @@ Environment variables override configuration file values. All variables use the 
 - `TIGER_DOCS_MCP` - Enable/disable docs MCP proxy
 - `TIGER_OUTPUT` - Output format: `json`, `yaml`, or `table`
 - `TIGER_PASSWORD_STORAGE` - Password storage method: `keyring`, `pgpass`, or `none`
+- `TIGER_PROJECT_ID` - Project to log in to, used by `tiger auth login` in place of the interactive project selection
 - `TIGER_READ_ONLY` - When `true`, write/destructive CLI commands return an error, the corresponding Tiger MCP write tools are not registered, and `db_execute_query` runs against a read-only database connection
 - `TIGER_PUBLIC_KEY` - Public key to use for authentication (takes priority over stored credentials)
 - `TIGER_SECRET_KEY` - Secret key to use for authentication (takes priority over stored credentials)

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
 - `read_only` - When `true`, mutating operations are refused: the `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` CLI commands return an error, and their MCP equivalents are not registered, so they don't appear in `tools/list` and can't be called. `tiger db connect`, `tiger db connection-string`, and the `db_execute_query` MCP tool open the database session in Tiger Cloud's immutable read-only mode (writes and DDL are rejected by the server). Read commands/tools are unaffected — `tiger db schema` and the `db_schema` MCP tool always open a read-only session regardless of this setting. Default: `false`.
-- `service_id` - Default service ID. Cleared automatically by `tiger project`, since a service belongs to the project it was created in
+- `service_id` - Default service ID. Cleared automatically when the active project changes (`tiger project`, or `tiger auth login` landing on a different project), since a service belongs to the project it was created in
 - `version_check` - When `true`, the CLI checks for a newer version on each invocation (in an interactive terminal) and prints a notice if one is available. Set to `false` to disable. Default: `true`.
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `output` - Output format: `json`, `yaml`, or `table` (default: `table`)
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
 - `read_only` - When `true`, mutating operations are refused: the `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` CLI commands return an error, and their MCP equivalents are not registered, so they don't appear in `tools/list` and can't be called. `tiger db connect`, `tiger db connection-string`, and the `db_execute_query` MCP tool open the database session in Tiger Cloud's immutable read-only mode (writes and DDL are rejected by the server). Read commands/tools are unaffected — `tiger db schema` and the `db_schema` MCP tool always open a read-only session regardless of this setting. Default: `false`.
-- `service_id` - Default service ID. Cleared automatically when the active project changes (`tiger project`, or `tiger auth login` landing on a different project), since a service belongs to the project it was created in
+- `service_id` - Default service ID. Cleared automatically when the active project changes (`tiger project`, or `tiger auth login` landing on a different project) and on `tiger auth logout`, since a service belongs to the project it was created in
 - `version_check` - When `true`, the CLI checks for a newer version on each invocation (in an interactive terminal) and prints a notice if one is available. Set to `false` to disable. Default: `true`.
 
 ### Environment Variables

--- a/cmd/tiger/main.go
+++ b/cmd/tiger/main.go
@@ -13,8 +13,10 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		// Check if it's a custom exit code error
-		if exitErr, ok := err.(interface{ ExitCode() int }); ok {
+		// Check if it's a custom exit code error. errors.As unwraps, so the
+		// code survives fmt.Errorf wrapping.
+		var exitErr interface{ ExitCode() int }
+		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())
 		}
 		os.Exit(1)

--- a/cmd/tiger/main.go
+++ b/cmd/tiger/main.go
@@ -14,15 +14,12 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		// A common.ExitCodeError anywhere in the chain sets the exit code.
-		// Other ExitCode() carriers (psql's *exec.ExitError) count only
-		// unwrapped, so a wrapped foreign code can't collide with ours.
+		// A common.ExitCodeError anywhere in the chain sets the exit code;
+		// foreign carriers (psql's *exec.ExitError) are converted to it at
+		// their call sites (see launchPsql).
 		var codeErr common.ExitCodeError
 		if errors.As(err, &codeErr) {
 			os.Exit(codeErr.ExitCode())
-		}
-		if exitErr, ok := err.(interface{ ExitCode() int }); ok {
-			os.Exit(exitErr.ExitCode())
 		}
 		os.Exit(1)
 	}

--- a/cmd/tiger/main.go
+++ b/cmd/tiger/main.go
@@ -9,14 +9,19 @@ import (
 	"syscall"
 
 	"github.com/timescale/tiger-cli/internal/cmd"
+	"github.com/timescale/tiger-cli/internal/common"
 )
 
 func main() {
 	if err := run(); err != nil {
-		// Check if it's a custom exit code error. errors.As unwraps, so the
-		// code survives fmt.Errorf wrapping.
-		var exitErr interface{ ExitCode() int }
-		if errors.As(err, &exitErr) {
+		// A common.ExitCodeError anywhere in the chain sets the exit code.
+		// Other ExitCode() carriers (psql's *exec.ExitError) count only
+		// unwrapped, so a wrapped foreign code can't collide with ours.
+		var codeErr common.ExitCodeError
+		if errors.As(err, &codeErr) {
+			os.Exit(codeErr.ExitCode())
+		}
+		if exitErr, ok := err.(interface{ ExitCode() int }); ok {
 			os.Exit(exitErr.ExitCode())
 		}
 		os.Exit(1)

--- a/cmd/tiger/main.go
+++ b/cmd/tiger/main.go
@@ -15,8 +15,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		// A common.ExitCodeError anywhere in the chain sets the exit code;
-		// foreign carriers (psql's *exec.ExitError) are converted to it at
-		// their call sites (see launchPsql).
+		// foreign carriers are converted to it at their call sites (launchPsql).
 		var codeErr common.ExitCodeError
 		if errors.As(err, &codeErr) {
 			os.Exit(codeErr.ExitCode())

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,7 +124,7 @@ Tiger CLI is a Go-based command-line interface for managing Tiger resources. The
 
 - **Entry Point**: `cmd/tiger/main.go` - Simple main that delegates to cmd.Execute()
 - **Command Structure**: `internal/cmd/` - Cobra-based command definitions for all
-  CLI commands (auth, service, db, config, mcp, version, upgrade). Each command
+  CLI commands (auth, project, service, db, config, mcp, version, upgrade). Each command
   lives in its own file, named to match the command in snake_case
   (`tiger service create` → `service_create.go`). `root.go` holds the root
   command, global flags, and `wrapCommands`, which gives every command the same

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -16,9 +16,8 @@ import (
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
-// OmitArgsAnnotation is a cobra command annotation that keeps a command's
-// positional arguments out of its analytics event — the ignore list below can't
-// do it, since arguments arrive without names.
+// OmitArgsAnnotation is a cobra annotation that keeps a command's positional
+// arguments out of its analytics event — they have no names for the ignore list.
 const OmitArgsAnnotation = "analytics_omit_args"
 
 // A list of properties that should never be recorded in analytics events.
@@ -136,8 +135,7 @@ func (e redactedError) Error() string { return e.err.Error() }
 func (e redactedError) Unwrap() error { return e.err }
 
 // RedactError wraps err so analytics records redacted in place of the error's
-// own text. Use it on errors whose message embeds data the ignore list keeps
-// out of analytics elsewhere (project IDs and names, for example).
+// own text, for messages embedding data the ignore list excludes elsewhere.
 func RedactError(err error, redacted string) error {
 	if err == nil {
 		return nil

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"os"
 	"runtime"
@@ -14,6 +15,11 @@ import (
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/config"
 )
+
+// OmitArgsAnnotation is a cobra command annotation that keeps a command's
+// positional arguments out of its analytics event — the ignore list below can't
+// do it, since arguments arrive without names.
+const OmitArgsAnnotation = "analytics_omit_args"
 
 // A list of properties that should never be recorded in analytics events.
 // Used to filter flags and MCP tool call parameters from automatic tracking.
@@ -98,19 +104,45 @@ func FlagSet(flagSet *pflag.FlagSet) Option {
 
 // Error creates an Option that adds success and error information to event
 // properties. If err is nil, sets success: true. If err is not nil, sets
-// success: false and includes the error message.
+// success: false and includes the error message — the redacted one, for errors
+// wrapped with RedactError.
 //
 // This is commonly used at the end of command execution to track whether
 // operations succeeded or failed, and what errors occurred.
 func Error(err error) Option {
 	return func(properties map[string]any) {
-		if err != nil {
-			properties["success"] = false
-			properties["error"] = err.Error()
-		} else {
+		if err == nil {
 			properties["success"] = true
+			return
 		}
+		properties["success"] = false
+		msg := err.Error()
+		var re redactedError
+		if errors.As(err, &re) {
+			msg = re.redacted
+		}
+		properties["error"] = msg
 	}
+}
+
+// redactedError carries a sanitized message for analytics while leaving the
+// user-facing error text untouched.
+type redactedError struct {
+	err      error
+	redacted string
+}
+
+func (e redactedError) Error() string { return e.err.Error() }
+func (e redactedError) Unwrap() error { return e.err }
+
+// RedactError wraps err so analytics records redacted in place of the error's
+// own text. Use it on errors whose message embeds data the ignore list keeps
+// out of analytics elsewhere (project IDs and names, for example).
+func RedactError(err error, redacted string) error {
+	if err == nil {
+		return nil
+	}
+	return redactedError{err: err, redacted: redacted}
 }
 
 // Identify associates the provided properties with the user for the sake of

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -2,7 +2,6 @@ package analytics
 
 import (
 	"context"
-	"errors"
 	"maps"
 	"os"
 	"runtime"
@@ -103,44 +102,19 @@ func FlagSet(flagSet *pflag.FlagSet) Option {
 
 // Error creates an Option that adds success and error information to event
 // properties. If err is nil, sets success: true. If err is not nil, sets
-// success: false and includes the error message — the redacted one, for errors
-// wrapped with RedactError.
+// success: false and includes the error message.
 //
 // This is commonly used at the end of command execution to track whether
 // operations succeeded or failed, and what errors occurred.
 func Error(err error) Option {
 	return func(properties map[string]any) {
-		if err == nil {
+		if err != nil {
+			properties["success"] = false
+			properties["error"] = err.Error()
+		} else {
 			properties["success"] = true
-			return
 		}
-		properties["success"] = false
-		msg := err.Error()
-		var re redactedError
-		if errors.As(err, &re) {
-			msg = re.redacted
-		}
-		properties["error"] = msg
 	}
-}
-
-// redactedError carries a sanitized message for analytics while leaving the
-// user-facing error text untouched.
-type redactedError struct {
-	err      error
-	redacted string
-}
-
-func (e redactedError) Error() string { return e.err.Error() }
-func (e redactedError) Unwrap() error { return e.err }
-
-// RedactError wraps err so analytics records redacted in place of the error's
-// own text, for messages embedding data the ignore list excludes elsewhere.
-func RedactError(err error, redacted string) error {
-	if err == nil {
-		return nil
-	}
-	return redactedError{err: err, redacted: redacted}
 }
 
 // Identify associates the provided properties with the user for the sake of

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -96,13 +96,18 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 func NewTigerClientForCredentials(cfg *config.Config, creds *config.Credentials) (*ClientWithResponses, error) {
 	if creds.OAuth != nil {
 		persist := func(t *oauth2.Token) error {
-			// Re-read storage: a concurrent `tiger project` switch must not
-			// be undone, and a replaced login must not be resurrected.
-			stored, err := cfg.GetStoredCredentials()
-			if err != nil || stored.OAuth == nil {
-				return nil
+			// Re-read storage so a concurrent `tiger project` switch isn't
+			// undone and a login replaced by an API key isn't overwritten. A
+			// failed read falls back to the captured project: a transient
+			// keyring error must not drop a rotated (one-time) refresh token.
+			projectID := creds.ProjectID
+			if stored, err := cfg.GetStoredCredentials(); err == nil {
+				if stored.OAuth == nil {
+					return nil
+				}
+				projectID = stored.ProjectID
 			}
-			return cfg.StoreOAuthCredentials(t, stored.ProjectID)
+			return cfg.StoreOAuthCredentials(t, projectID)
 		}
 		return NewTigerClientWithToken(cfg, creds.OAuth, persist)
 	}

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -96,9 +96,8 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 func NewTigerClientForCredentials(cfg *config.Config, creds *config.Credentials) (*ClientWithResponses, error) {
 	if creds.OAuth != nil {
 		persist := func(t *oauth2.Token) error {
-			// Re-read the stored project at write time: `tiger project` (in
-			// this or another process) may have repointed the login since this
-			// client was built, and a refresh must not undo that switch.
+			// Re-read the stored project: `tiger project` may have repointed
+			// the login since this client was built; a refresh must not undo it.
 			projectID := creds.ProjectID
 			if stored, err := cfg.GetStoredCredentials(); err == nil {
 				projectID = stored.ProjectID

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -96,10 +96,9 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 func NewTigerClientForCredentials(cfg *config.Config, creds *config.Credentials) (*ClientWithResponses, error) {
 	if creds.OAuth != nil {
 		persist := func(t *oauth2.Token) error {
-			// Re-read storage so a concurrent `tiger project` switch isn't
-			// undone and a login replaced by an API key isn't overwritten. A
-			// failed read falls back to the captured project: a transient
-			// keyring error must not drop a rotated (one-time) refresh token.
+			// Re-read storage so a concurrent switch isn't undone and an
+			// API-key relogin isn't overwritten. A failed read falls back to
+			// the captured project — never drop a rotated one-time token.
 			projectID := creds.ProjectID
 			if stored, err := cfg.GetStoredCredentials(); err == nil {
 				if stored.OAuth == nil {

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -96,13 +96,13 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 func NewTigerClientForCredentials(cfg *config.Config, creds *config.Credentials) (*ClientWithResponses, error) {
 	if creds.OAuth != nil {
 		persist := func(t *oauth2.Token) error {
-			// Re-read the stored project: `tiger project` may have repointed
-			// the login since this client was built; a refresh must not undo it.
-			projectID := creds.ProjectID
-			if stored, err := cfg.GetStoredCredentials(); err == nil {
-				projectID = stored.ProjectID
+			// Re-read storage: a concurrent `tiger project` switch must not
+			// be undone, and a replaced login must not be resurrected.
+			stored, err := cfg.GetStoredCredentials()
+			if err != nil || stored.OAuth == nil {
+				return nil
 			}
-			return cfg.StoreOAuthCredentials(t, projectID)
+			return cfg.StoreOAuthCredentials(t, stored.ProjectID)
 		}
 		return NewTigerClientWithToken(cfg, creds.OAuth, persist)
 	}

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -96,7 +96,14 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 func NewTigerClientForCredentials(cfg *config.Config, creds *config.Credentials) (*ClientWithResponses, error) {
 	if creds.OAuth != nil {
 		persist := func(t *oauth2.Token) error {
-			return cfg.StoreOAuthCredentials(t, creds.ProjectID)
+			// Re-read the stored project at write time: `tiger project` (in
+			// this or another process) may have repointed the login since this
+			// client was built, and a refresh must not undo that switch.
+			projectID := creds.ProjectID
+			if stored, err := cfg.GetStoredCredentials(); err == nil {
+				projectID = stored.ProjectID
+			}
+			return cfg.StoreOAuthCredentials(t, projectID)
 		}
 		return NewTigerClientWithToken(cfg, creds.OAuth, persist)
 	}

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
-	"github.com/timescale/tiger-cli/internal/analytics"
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
 	"github.com/timescale/tiger-cli/internal/config"
@@ -100,6 +99,13 @@ Examples:
 			}
 			requestedProjectID := flagOrEnvVar(projectIDFlag, "TIGER_PROJECT_ID")
 
+			// Captured before the login replaces it: landing on a different
+			// project clears the default service, like `tiger project` does.
+			prevProjectID := ""
+			if stored, err := cfg.GetStoredCredentials(); err == nil {
+				prevProjectID = stored.ProjectID
+			}
+
 			if creds.publicKey == "" && creds.secretKey == "" {
 				l := &oauthLogin{
 					cfg:               cfg,
@@ -124,6 +130,9 @@ Examples:
 				app.SetClient(client, projectID)
 				// Identify the user for analytics.
 				common.IdentifyOAuthUser(cmd.Context(), cfg, client, projectID)
+				if err := clearStaleDefaultService(cmd, cfg, prevProjectID, projectID); err != nil {
+					return err
+				}
 				finishLogin(cmd, projectID)
 				return nil
 			} else if creds.publicKey == "" || creds.secretKey == "" {
@@ -153,10 +162,10 @@ Examples:
 			// flagOrEnvVar above.
 			if requestedProjectID != "" && requestedProjectID != authInfo.APIKey.Project.ID {
 				if projectIDFlag != "" {
+					// No project IDs in the message — analytics records error
+					// text verbatim; `tiger auth status` shows the key's project.
 					return common.ExitWithCode(common.ExitInvalidParameters,
-						analytics.RedactError(
-							fmt.Errorf("API key is scoped to project %s, not the requested %s", authInfo.APIKey.Project.ID, requestedProjectID),
-							"API key is scoped to a different project than requested"))
+						errors.New("API key is scoped to a different project than the requested one"))
 				}
 				cmd.PrintErrf("Warning: ignoring TIGER_PROJECT_ID (%s) - this API key is scoped to project %s\n", requestedProjectID, authInfo.APIKey.Project.ID)
 			}
@@ -166,6 +175,9 @@ Examples:
 			// See the OAuth branch above: keep the App's client in sync with the
 			// credentials we just stored.
 			app.SetClient(client, authInfo.APIKey.Project.ID)
+			if err := clearStaleDefaultService(cmd, cfg, prevProjectID, authInfo.APIKey.Project.ID); err != nil {
+				return err
+			}
 			finishLogin(cmd, authInfo.APIKey.Project.ID)
 			return nil
 		},

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -11,14 +11,13 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
+	"github.com/timescale/tiger-cli/internal/analytics"
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
 	"github.com/timescale/tiger-cli/internal/config"
@@ -37,13 +36,8 @@ const nextStepsMessage = `
 • Enable read-only mode: tiger config set read_only true
 `
 
-var (
-	// openBrowser can be overridden for testing
-	openBrowser = openBrowserImpl
-
-	// selectProjectInteractively can be overridden for testing
-	selectProjectInteractively = selectProjectInteractivelyImpl
-)
+// openBrowser can be overridden for testing
+var openBrowser = openBrowserImpl
 
 type credentials struct {
 	publicKey string
@@ -52,6 +46,7 @@ type credentials struct {
 
 func buildLoginCmd(app *common.App) *cobra.Command {
 	var flags credentials
+	var projectIDFlag string
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -64,17 +59,25 @@ The OAuth flow will:
 - Let you select a project (if you have multiple)
 - Store an OAuth session for the selected project
 
+Use --project-id (or the TIGER_PROJECT_ID environment variable) to pick the project up front
+and skip the interactive selection, which is what you want when no terminal is available. After
+logging in, switch between projects with 'tiger project'.
+
 The credentials and project ID will be stored securely in the system keyring, or in a fallback file with
 restricted permissions.
 
 You may also provide API keys via flags or environment variables, in which case they will be used
-directly. The CLI will prompt for any missing information.
+directly. The CLI will prompt for any missing information. An API key is scoped to a single project,
+so --project-id only confirms which project that is.
 
 You can find your API credentials at: https://console.cloud.tigerdata.com/dashboard/settings
 
 Examples:
   # Interactive login with OAuth (opens browser)
   tiger auth login
+
+  # OAuth login without the interactive project picker
+  tiger auth login --project-id rp1pz7uyae
 
   # Login with keys (project ID will be auto-detected)
   tiger auth login --public-key your-public-key --secret-key your-secret-key
@@ -95,14 +98,17 @@ Examples:
 				publicKey: flagOrEnvVar(flags.publicKey, "TIGER_PUBLIC_KEY"),
 				secretKey: flagOrEnvVar(flags.secretKey, "TIGER_SECRET_KEY"),
 			}
+			requestedProjectID := flagOrEnvVar(projectIDFlag, "TIGER_PROJECT_ID")
 
 			if creds.publicKey == "" && creds.secretKey == "" {
 				l := &oauthLogin{
-					cfg:        cfg,
-					authURL:    cfg.ConsoleURL + "/oauth/authorize",
-					tokenURL:   cfg.GatewayURL + "/idp/external/cli/token",
-					successURL: cfg.ConsoleURL + "/oauth/code/success",
-					cmd:        cmd,
+					cfg:               cfg,
+					authURL:           cfg.ConsoleURL + "/oauth/authorize",
+					tokenURL:          cfg.GatewayURL + "/idp/external/cli/token",
+					successURL:        cfg.ConsoleURL + "/oauth/code/success",
+					projectID:         requestedProjectID,
+					projectIDFromFlag: projectIDFlag != "",
+					cmd:               cmd,
 				}
 
 				token, client, projectID, err := l.loginWithOAuth(cmd.Context())
@@ -141,6 +147,22 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("API key validation failed: %w", err)
 			}
+			// An API key carries its own project, so there's nothing to select.
+			// A mismatch is still reported rather than ignored: scripts pass
+			// --project-id without knowing which auth method they'll get. Only
+			// the explicit flag fails, though — TIGER_PROJECT_ID is ambient, and
+			// may well be set for OAuth logins elsewhere in the environment.
+			// Checking projectIDFlag rather than cobra's Changed keeps an
+			// explicitly empty flag counting as unset, like flagOrEnvVar above.
+			if requestedProjectID != "" && requestedProjectID != authInfo.APIKey.Project.ID {
+				if projectIDFlag != "" {
+					return common.ExitWithCode(common.ExitInvalidParameters,
+						analytics.RedactError(
+							fmt.Errorf("API key is scoped to project %s, not the requested %s", authInfo.APIKey.Project.ID, requestedProjectID),
+							"API key is scoped to a different project than requested"))
+				}
+				cmd.PrintErrf("Warning: ignoring TIGER_PROJECT_ID (%s) - this API key is scoped to project %s\n", requestedProjectID, authInfo.APIKey.Project.ID)
+			}
 			if err := cfg.StoreCredentials(apiKey, authInfo.APIKey.Project.ID); err != nil {
 				return fmt.Errorf("failed to store credentials: %w", err)
 			}
@@ -154,6 +176,10 @@ Examples:
 
 	cmd.Flags().StringVar(&flags.publicKey, "public-key", "", "Public key for authentication")
 	cmd.Flags().StringVar(&flags.secretKey, "secret-key", "", "Secret key for authentication")
+	cmd.Flags().StringVar(&projectIDFlag, "project-id", "", "Project ID to log in to (skips interactive project selection)")
+
+	// Only fails if the flag doesn't exist, which the line above guarantees.
+	_ = cmd.RegisterFlagCompletionFunc("project-id", projectIDCompletion(app))
 
 	return cmd
 }
@@ -205,7 +231,12 @@ type oauthLogin struct {
 	authURL    string
 	tokenURL   string
 	successURL string
-	cmd        *cobra.Command
+	// projectID comes from --project-id or TIGER_PROJECT_ID; empty means
+	// select one after authenticating. projectIDFromFlag records which: the
+	// flag is authoritative, the ambient env var only warns.
+	projectID         string
+	projectIDFromFlag bool
+	cmd               *cobra.Command
 }
 
 func (l *oauthLogin) loginWithOAuth(ctx context.Context) (*oauth2.Token, *api.ClientWithResponses, string, error) {
@@ -221,12 +252,24 @@ func (l *oauthLogin) loginWithOAuth(ctx context.Context) (*oauth2.Token, *api.Cl
 		return nil, nil, "", fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	projectID, err := l.selectProjectID(ctx, client)
+	projects, err := fetchProjects(ctx, client)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	project, err := resolveProjectID(l.cmd, projects, l.projectID,
+		"pass --project-id or set TIGER_PROJECT_ID")
+	if err != nil && l.projectID != "" && !l.projectIDFromFlag {
+		// TIGER_PROJECT_ID is ambient and may be set for a different login
+		// elsewhere in the environment, so an inaccessible project it names
+		// downgrades to a warning, matching the API-key branch.
+		l.cmd.PrintErrf("Warning: ignoring TIGER_PROJECT_ID (%s) - project not found or not accessible\n", l.projectID)
+		project, err = resolveProjectID(l.cmd, projects, "", "pass --project-id")
+	}
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("failed to select project: %w", err)
 	}
 
-	return token, client, projectID, nil
+	return token, client, project.ID, nil
 }
 
 func (l *oauthLogin) getOAuthToken(ctx context.Context) (*oauth2.Token, error) {
@@ -402,141 +445,4 @@ func openBrowserImpl(url string) error {
 	}
 
 	return cmd.Start()
-}
-
-func (l *oauthLogin) selectProjectID(ctx context.Context, client *api.ClientWithResponses) (string, error) {
-	resp, err := client.GetProjectsWithResponse(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get user projects: %w", err)
-	}
-	if resp.JSON200 == nil {
-		return "", common.ExitWithErrorFromStatusCode(resp.StatusCode(), resp.JSON4XX)
-	}
-	projects := *resp.JSON200
-
-	switch len(projects) {
-	case 0:
-		return "", fmt.Errorf("user has no accessible projects")
-	case 1:
-		return projects[0].ID, nil
-	default:
-		if !util.IsTerminal(l.cmd.InOrStdin()) || !util.IsTerminal(l.cmd.ErrOrStderr()) {
-			return "", fmt.Errorf("TTY not detected - cannot select between %d projects. Log in with API keys instead (--public-key, --secret-key)", len(projects))
-		}
-		return selectProjectInteractively(l.cmd, projects)
-	}
-}
-
-// selectProjectInteractivelyImpl is the default implementation for project selection using Bubble Tea
-func selectProjectInteractivelyImpl(cmd *cobra.Command, projects []api.Project) (string, error) {
-	model := projectSelectModel{
-		projects: projects,
-		cursor:   0,
-	}
-
-	program := tea.NewProgram(model,
-		tea.WithInput(cmd.InOrStdin()),
-		tea.WithOutput(cmd.ErrOrStderr()),
-		tea.WithContext(cmd.Context()),
-		tea.WithoutSignalHandler())
-	finalModel, err := program.Run()
-	if err != nil {
-		return "", fmt.Errorf("failed to run project selection: %w", err)
-	}
-
-	result := finalModel.(projectSelectModel)
-	if result.selected == "" {
-		return "", fmt.Errorf("no project selected")
-	}
-
-	return result.selected, nil
-}
-
-type projectSelectModel struct {
-	projects     []api.Project
-	cursor       int
-	selected     string
-	numberBuffer string
-}
-
-func (m projectSelectModel) Init() tea.Cmd {
-	return nil
-}
-
-func (m projectSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
-			return m, tea.Quit
-		case "up", "k":
-			// Clear buffer when using arrows
-			m.numberBuffer = ""
-			if m.cursor > 0 {
-				m.cursor--
-			}
-		case "down", "j":
-			// Clear buffer when using arrows
-			m.numberBuffer = ""
-			if m.cursor < len(m.projects)-1 {
-				m.cursor++
-			}
-		case "enter", "space":
-			m.selected = m.projects[m.cursor].ID
-			return m, tea.Quit
-		case "backspace":
-			// Handle backspace to remove last character from buffer
-			if len(m.numberBuffer) > 0 {
-				m.updateNumberBuffer(m.numberBuffer[:len(m.numberBuffer)-1])
-			}
-		case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
-			// Add digit to buffer and update cursor position
-			m.updateNumberBuffer(m.numberBuffer + msg.String())
-		case "ctrl+w", "esc":
-			// Clear buffer on escape
-			m.numberBuffer = ""
-		}
-	}
-	return m, nil
-}
-
-// updateNumberBuffer moves the cursor to the project matching the number buffer
-func (m *projectSelectModel) updateNumberBuffer(newBuffer string) {
-	if newBuffer == "" {
-		m.numberBuffer = newBuffer
-		return
-	}
-
-	// Parse the buffer as a number
-	num, err := strconv.Atoi(newBuffer)
-	if err != nil {
-		return
-	}
-
-	// Convert from 1-based to 0-based index and validate bounds
-	index := num - 1
-	if index >= 0 && index < len(m.projects) {
-		m.numberBuffer = newBuffer
-		m.cursor = index
-	}
-}
-
-func (m projectSelectModel) View() tea.View {
-	s := "Select a project:\n\n"
-
-	for i, project := range m.projects {
-		cursor := " "
-		if m.cursor == i {
-			cursor = ">"
-		}
-		s += fmt.Sprintf("%s %d. %s (%s)\n", cursor, i+1, project.Name, project.ID)
-	}
-
-	// Show the current number buffer if user is typing
-	if m.numberBuffer != "" {
-		s += fmt.Sprintf("\nTyping: %s", m.numberBuffer)
-	}
-
-	s += "\nUse ↑/↓ arrows or number keys to navigate, enter to select, q to quit"
-	return tea.NewView(s)
 }

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -181,10 +181,9 @@ Examples:
 	return cmd
 }
 
-// completeLogin runs the post-store steps shared by both login flavors: hand
-// the freshly authenticated client to the App so later readers — analytics in
-// particular — use the new credentials, clear a default service left over
-// from a different project, and print the success message.
+// completeLogin runs the post-store steps shared by both login flavors: update
+// the App's client so later readers (analytics) use the new credentials, clear
+// a default service left from a different project, and print the success message.
 func completeLogin(cmd *cobra.Command, app *common.App, cfg *config.Config, client *api.ClientWithResponses, prevProjectID, projectID string) {
 	app.SetClient(client, projectID)
 	clearStaleDefaultService(cmd, cfg, prevProjectID, projectID)

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -178,6 +178,10 @@ Examples:
 	cmd.Flags().StringVar(&flags.secretKey, "secret-key", "", "Secret key for authentication")
 	cmd.Flags().StringVar(&projectIDFlag, "project-id", "", "Project ID to log in to (skips interactive project selection)")
 
+	// Suppress cobra's default file completion; filenames are never project IDs.
+	// Only fails if the flag doesn't exist, which the line above guarantees.
+	_ = cmd.RegisterFlagCompletionFunc("project-id", cobra.NoFileCompletions)
+
 	return cmd
 }
 

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -178,9 +178,6 @@ Examples:
 	cmd.Flags().StringVar(&flags.secretKey, "secret-key", "", "Secret key for authentication")
 	cmd.Flags().StringVar(&projectIDFlag, "project-id", "", "Project ID to log in to (skips interactive project selection)")
 
-	// Only fails if the flag doesn't exist, which the line above guarantees.
-	_ = cmd.RegisterFlagCompletionFunc("project-id", projectIDCompletion(app))
-
 	return cmd
 }
 

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -147,13 +147,10 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("API key validation failed: %w", err)
 			}
-			// An API key carries its own project, so there's nothing to select.
-			// A mismatch is still reported rather than ignored: scripts pass
-			// --project-id without knowing which auth method they'll get. Only
-			// the explicit flag fails, though — TIGER_PROJECT_ID is ambient, and
-			// may well be set for OAuth logins elsewhere in the environment.
-			// Checking projectIDFlag rather than cobra's Changed keeps an
-			// explicitly empty flag counting as unset, like flagOrEnvVar above.
+			// An API key carries its own project: a mismatched --project-id is
+			// an error, while the ambient TIGER_PROJECT_ID only warns. An empty
+			// flag counts as unset (projectIDFlag, not cobra's Changed), like
+			// flagOrEnvVar above.
 			if requestedProjectID != "" && requestedProjectID != authInfo.APIKey.Project.ID {
 				if projectIDFlag != "" {
 					return common.ExitWithCode(common.ExitInvalidParameters,
@@ -179,7 +176,6 @@ Examples:
 	cmd.Flags().StringVar(&projectIDFlag, "project-id", "", "Project ID to log in to (skips interactive project selection)")
 
 	// Suppress cobra's default file completion; filenames are never project IDs.
-	// Only fails if the flag doesn't exist, which the line above guarantees.
 	_ = cmd.RegisterFlagCompletionFunc("project-id", cobra.NoFileCompletions)
 
 	return cmd
@@ -260,9 +256,8 @@ func (l *oauthLogin) loginWithOAuth(ctx context.Context) (*oauth2.Token, *api.Cl
 	project, err := resolveProjectID(l.cmd, projects, l.projectID,
 		"pass --project-id or set TIGER_PROJECT_ID")
 	if err != nil && l.projectID != "" && !l.projectIDFromFlag {
-		// TIGER_PROJECT_ID is ambient and may be set for a different login
-		// elsewhere in the environment, so an inaccessible project it names
-		// downgrades to a warning, matching the API-key branch.
+		// TIGER_PROJECT_ID is ambient and may belong to a different login, so
+		// an inaccessible project it names only warns, like the API-key branch.
 		l.cmd.PrintErrf("Warning: ignoring TIGER_PROJECT_ID (%s) - project not found or not accessible\n", l.projectID)
 		project, err = resolveProjectID(l.cmd, projects, "", "pass --project-id")
 	}

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -63,7 +63,8 @@ and skip the interactive selection, which is what you want when no terminal is a
 logging in, switch between projects with 'tiger project'.
 
 The credentials and project ID will be stored securely in the system keyring, or in a fallback file with
-restricted permissions.
+restricted permissions. Logging in to a different project than the previous login clears the default
+service (config key service_id), since a default service belongs to the project it was set in.
 
 You may also provide API keys via flags or environment variables, in which case they will be used
 directly. The CLI will prompt for any missing information. An API key is scoped to a single project,
@@ -124,16 +125,9 @@ Examples:
 				if err := cfg.StoreOAuthCredentials(token, projectID); err != nil {
 					return fmt.Errorf("failed to store credentials: %w", err)
 				}
-				// Hand the freshly authenticated client to the App so later
-				// readers — analytics in particular — use the new credentials
-				// instead of the pre-login state.
-				app.SetClient(client, projectID)
 				// Identify the user for analytics.
 				common.IdentifyOAuthUser(cmd.Context(), cfg, client, projectID)
-				if err := clearStaleDefaultService(cmd, cfg, prevProjectID, projectID); err != nil {
-					return err
-				}
-				finishLogin(cmd, projectID)
+				completeLogin(cmd, app, cfg, client, prevProjectID, projectID)
 				return nil
 			} else if creds.publicKey == "" || creds.secretKey == "" {
 				creds, err = promptForCredentials(cmd, cfg.ConsoleURL, creds)
@@ -172,13 +166,7 @@ Examples:
 			if err := cfg.StoreCredentials(apiKey, authInfo.APIKey.Project.ID); err != nil {
 				return fmt.Errorf("failed to store credentials: %w", err)
 			}
-			// See the OAuth branch above: keep the App's client in sync with the
-			// credentials we just stored.
-			app.SetClient(client, authInfo.APIKey.Project.ID)
-			if err := clearStaleDefaultService(cmd, cfg, prevProjectID, authInfo.APIKey.Project.ID); err != nil {
-				return err
-			}
-			finishLogin(cmd, authInfo.APIKey.Project.ID)
+			completeLogin(cmd, app, cfg, client, prevProjectID, authInfo.APIKey.Project.ID)
 			return nil
 		},
 	}
@@ -191,6 +179,16 @@ Examples:
 	_ = cmd.RegisterFlagCompletionFunc("project-id", cobra.NoFileCompletions)
 
 	return cmd
+}
+
+// completeLogin runs the post-store steps shared by both login flavors: hand
+// the freshly authenticated client to the App so later readers — analytics in
+// particular — use the new credentials, clear a default service left over
+// from a different project, and print the success message.
+func completeLogin(cmd *cobra.Command, app *common.App, cfg *config.Config, client *api.ClientWithResponses, prevProjectID, projectID string) {
+	app.SetClient(client, projectID)
+	clearStaleDefaultService(cmd, cfg, prevProjectID, projectID)
+	finishLogin(cmd, projectID)
 }
 
 func finishLogin(cmd *cobra.Command, projectID string) {

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
@@ -318,6 +317,25 @@ func TestAuthLogin_APIKeyValidationSuccess(t *testing.T) {
 	}
 }
 
+// assertOAuthLoginOutput checks the OAuth login flow's full output: the auth
+// URL, the browser message, and the success line naming projectID.
+func assertOAuthLoginOutput(t *testing.T, output, mockServerURL, projectID string) {
+	t.Helper()
+
+	expectedPattern := fmt.Sprintf(`^Auth URL is: %s/oauth/authorize\?client_id=45e1b16d-e435-4049-97b2-8daad150818c&code_challenge=[A-Za-z0-9_-]+&code_challenge_method=S256&redirect_uri=http%%3A%%2F%%2Flocalhost%%3A\d+%%2Fcallback&response_type=code&state=[A-Za-z0-9_-]+\n`+
+		`Opening browser for authentication\.\.\.\n`+
+		`Successfully logged in \(project: %s\)\n`+
+		regexp.QuoteMeta(nextStepsMessage)+`$`, regexp.QuoteMeta(mockServerURL), regexp.QuoteMeta(projectID))
+
+	matched, err := regexp.MatchString(expectedPattern, output)
+	if err != nil {
+		t.Fatalf("Regex compilation failed: %v", err)
+	}
+	if !matched {
+		t.Errorf("Output doesn't match expected pattern.\nPattern: %s\nActual output: '%s'", expectedPattern, output)
+	}
+}
+
 func TestAuthLogin_OAuth_SingleProject(t *testing.T) {
 	mockServerURL := setupOAuthTest(t, []api.Project{
 		{ID: "project-123", Name: "Test Project"},
@@ -330,37 +348,10 @@ func TestAuthLogin_OAuth_SingleProject(t *testing.T) {
 		t.Fatalf("Login failed: %v", err)
 	}
 
-	expectedPattern := fmt.Sprintf(`^Auth URL is: %s/oauth/authorize\?client_id=45e1b16d-e435-4049-97b2-8daad150818c&code_challenge=[A-Za-z0-9_-]+&code_challenge_method=S256&redirect_uri=http%%3A%%2F%%2Flocalhost%%3A\d+%%2Fcallback&response_type=code&state=[A-Za-z0-9_-]+\n`+
-		`Opening browser for authentication\.\.\.\n`+
-		`Successfully logged in \(project: project-123\)\n`+
-		regexp.QuoteMeta(nextStepsMessage)+`$`, regexp.QuoteMeta(mockServerURL))
+	assertOAuthLoginOutput(t, output, mockServerURL, "project-123")
 
-	matched, err := regexp.MatchString(expectedPattern, output)
-	if err != nil {
-		t.Fatalf("Regex compilation failed: %v", err)
-	}
-	if !matched {
-		t.Errorf("Output doesn't match expected pattern.\nPattern: %s\nActual output: '%s'", expectedPattern, output)
-	}
-
-	stored, err := testConfig(t).GetStoredCredentials()
-	if err != nil {
-		t.Fatalf("Failed to get stored credentials: %v", err)
-	}
-	if stored.OAuth == nil {
-		t.Fatalf("Expected OAuth credentials, got PAT: %+v", stored)
-	}
-	token, projectID := stored.OAuth, stored.ProjectID
-	if token.AccessToken != "mock-access-token-12345" {
-		t.Errorf("Expected access token 'mock-access-token-12345', got '%s'", token.AccessToken)
-	}
-	if token.RefreshToken != "mock-refresh-token-67890" {
-		t.Errorf("Expected refresh token 'mock-refresh-token-67890', got '%s'", token.RefreshToken)
-	}
-	assertExpiresInAbout(t, token.Expiry)
-	if projectID != "project-123" {
-		t.Errorf("Expected project ID 'project-123', got '%s'", projectID)
-	}
+	stored := assertStoredProject(t, "project-123")
+	assertExpiresInAbout(t, stored.OAuth.Expiry)
 }
 
 func TestAuthLogin_OAuth_MultipleProjects(t *testing.T) {
@@ -387,37 +378,10 @@ func TestAuthLogin_OAuth_MultipleProjects(t *testing.T) {
 		t.Fatalf("Login failed: %v", err)
 	}
 
-	expectedPattern := fmt.Sprintf(`^Auth URL is: %s/oauth/authorize\?client_id=45e1b16d-e435-4049-97b2-8daad150818c&code_challenge=[A-Za-z0-9_-]+&code_challenge_method=S256&redirect_uri=http%%3A%%2F%%2Flocalhost%%3A\d+%%2Fcallback&response_type=code&state=[A-Za-z0-9_-]+\n`+
-		`Opening browser for authentication\.\.\.\n`+
-		`Successfully logged in \(project: project-789\)\n`+
-		regexp.QuoteMeta(nextStepsMessage)+`$`, regexp.QuoteMeta(mockServerURL))
+	assertOAuthLoginOutput(t, output, mockServerURL, "project-789")
 
-	matched, err := regexp.MatchString(expectedPattern, output)
-	if err != nil {
-		t.Fatalf("Regex compilation failed: %v", err)
-	}
-	if !matched {
-		t.Errorf("Output doesn't match expected pattern.\nPattern: %s\nActual output: '%s'", expectedPattern, output)
-	}
-
-	stored, err := testConfig(t).GetStoredCredentials()
-	if err != nil {
-		t.Fatalf("Failed to get stored credentials: %v", err)
-	}
-	if stored.OAuth == nil {
-		t.Fatalf("Expected OAuth credentials, got PAT: %+v", stored)
-	}
-	token, projectID := stored.OAuth, stored.ProjectID
-	if token.AccessToken != "mock-access-token-12345" {
-		t.Errorf("Expected access token 'mock-access-token-12345', got '%s'", token.AccessToken)
-	}
-	if token.RefreshToken != "mock-refresh-token-67890" {
-		t.Errorf("Expected refresh token 'mock-refresh-token-67890', got '%s'", token.RefreshToken)
-	}
-	assertExpiresInAbout(t, token.Expiry)
-	if projectID != "project-789" {
-		t.Errorf("Expected project ID 'project-789', got '%s'", projectID)
-	}
+	stored := assertStoredProject(t, "project-789")
+	assertExpiresInAbout(t, stored.OAuth.Expiry)
 }
 
 // TestAuthLogin_OAuth_ProjectIDFlag verifies --project-id replaces the picker,
@@ -425,12 +389,9 @@ func TestAuthLogin_OAuth_MultipleProjects(t *testing.T) {
 func TestAuthLogin_OAuth_ProjectIDFlag(t *testing.T) {
 	setupOAuthTest(t, testProjects)
 
-	// No TTY: the picker isn't available, and isn't needed
+	// No TTY: the picker isn't available, and isn't needed. If --project-id
+	// were ignored, resolveProjectID's TTY gate would fail the login.
 	stubIsTerminal(t, false)
-	stubSelectProject(t, func(*cobra.Command, []api.Project) (api.Project, error) {
-		t.Error("Project picker should not run when --project-id is set")
-		return api.Project{}, errors.New("unexpected picker")
-	})
 
 	output, err := executeAuthCommand(t.Context(), "auth", "login", "--project-id", "project-456")
 	if err != nil {
@@ -440,16 +401,7 @@ func TestAuthLogin_OAuth_ProjectIDFlag(t *testing.T) {
 		t.Errorf("Unexpected output: %q", output)
 	}
 
-	stored, err := testConfig(t).GetStoredCredentials()
-	if err != nil {
-		t.Fatalf("Failed to get stored credentials: %v", err)
-	}
-	if stored.OAuth == nil {
-		t.Fatalf("Expected OAuth credentials, got PAT: %+v", stored)
-	}
-	if stored.ProjectID != "project-456" {
-		t.Errorf("Expected project ID 'project-456', got '%s'", stored.ProjectID)
-	}
+	assertStoredProject(t, "project-456")
 }
 
 // TestAuthLogin_OAuth_ProjectIDEnvVar verifies TIGER_PROJECT_ID works like the
@@ -468,13 +420,7 @@ func TestAuthLogin_OAuth_ProjectIDEnvVar(t *testing.T) {
 		t.Errorf("Unexpected output: %q", output)
 	}
 
-	stored, err := testConfig(t).GetStoredCredentials()
-	if err != nil {
-		t.Fatalf("Failed to get stored credentials: %v", err)
-	}
-	if stored.ProjectID != "project-789" {
-		t.Errorf("Expected project ID 'project-789', got '%s'", stored.ProjectID)
-	}
+	assertStoredProject(t, "project-789")
 }
 
 func TestAuthLogin_OAuth_ProjectIDFlag_Inaccessible(t *testing.T) {
@@ -512,13 +458,8 @@ func TestAuthLogin_OAuth_ProjectIDEnvVar_Inaccessible(t *testing.T) {
 		t.Errorf("Expected a warning about the ignored env var, got: %q", output)
 	}
 
-	stored, err := testConfig(t).GetStoredCredentials()
-	if err != nil {
-		t.Fatalf("Failed to get stored credentials: %v", err)
-	}
-	if stored.ProjectID != "project-123" {
-		t.Errorf("Expected fallback to the single accessible project, got %q", stored.ProjectID)
-	}
+	// Falls back to the single accessible project
+	assertStoredProject(t, "project-123")
 }
 
 // TestAuthLogin_APIKey_ProjectIDEmptyFlagEnvMismatch verifies an explicitly
@@ -631,19 +572,11 @@ func TestOAuthRefresh_PersistsExpiry(t *testing.T) {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
-	// Store an already-expired OAuth token that still has a valid refresh token.
-	expired := &oauth2.Token{
-		AccessToken:  "stale-access-token",
-		RefreshToken: "mock-refresh-token-67890",
-		Expiry:       time.Now().Add(-time.Hour),
-	}
 	// The config file above points api_url/gateway_url at the mock server, and
 	// carries the test config dir so the refreshed token is persisted there.
-	cfg := testConfig(t)
-	if err := cfg.StoreOAuthCredentials(expired, "project-789"); err != nil {
-		t.Fatalf("Failed to store oauth credentials: %v", err)
-	}
+	storeExpiredOAuthLogin(t, "project-789")
 
+	cfg := testConfig(t)
 	stored, err := cfg.GetStoredCredentials()
 	if err != nil {
 		t.Fatalf("Failed to load stored credentials: %v", err)

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -462,24 +462,6 @@ func TestAuthLogin_OAuth_ProjectIDEnvVar_Inaccessible(t *testing.T) {
 	assertStoredProject(t, "project-123")
 }
 
-// TestAuthLogin_APIKey_ProjectIDEmptyFlagEnvMismatch verifies an explicitly
-// empty --project-id counts as unset, so a mismatched ambient TIGER_PROJECT_ID
-// still only warns (e.g. `--project-id "$PROJ"` in CI with $PROJ unset).
-func TestAuthLogin_APIKey_ProjectIDEmptyFlagEnvMismatch(t *testing.T) {
-	setupAuthTest(t)
-	t.Setenv("TIGER_PROJECT_ID", "some-other-project")
-
-	output, err := executeAuthCommand(t.Context(), "auth", "login",
-		"--public-key", "test-public-key", "--secret-key", "test-secret-key",
-		"--project-id", "")
-	if err != nil {
-		t.Fatalf("Login failed: %v", err)
-	}
-	if !strings.Contains(output, "Warning: ignoring TIGER_PROJECT_ID (some-other-project) - this API key is scoped to project test-project-id") {
-		t.Errorf("Expected a warning about the ignored env var, got: %q", output)
-	}
-}
-
 // TestAuthLogin_OAuth_MultipleProjectsWithoutTTY verifies the error names the
 // non-interactive alternative instead of leaving the user stuck.
 func TestAuthLogin_OAuth_MultipleProjectsWithoutTTY(t *testing.T) {
@@ -519,13 +501,16 @@ func TestAuthLogin_APIKey_ProjectIDMismatch(t *testing.T) {
 
 // TestAuthLogin_APIKey_ProjectIDEnvVarMismatch verifies an ambient
 // TIGER_PROJECT_ID only warns, since it may be set for OAuth logins elsewhere
-// in the environment.
+// in the environment. The explicitly empty --project-id must count as unset
+// (e.g. `--project-id "$PROJ"` in CI with $PROJ unset), so it covers the
+// plain no-flag case too.
 func TestAuthLogin_APIKey_ProjectIDEnvVarMismatch(t *testing.T) {
 	setupAuthTest(t)
 	t.Setenv("TIGER_PROJECT_ID", "some-other-project")
 
 	output, err := executeAuthCommand(t.Context(), "auth", "login",
-		"--public-key", "test-public-key", "--secret-key", "test-secret-key")
+		"--public-key", "test-public-key", "--secret-key", "test-secret-key",
+		"--project-id", "")
 	if err != nil {
 		t.Fatalf("Login failed: %v", err)
 	}

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -430,7 +430,7 @@ func TestAuthLogin_OAuth_ProjectIDFlag_Inaccessible(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected login to fail for an inaccessible project")
 	}
-	if !strings.Contains(err.Error(), `project "project-nope" not found or not accessible`) {
+	if !strings.Contains(err.Error(), "requested project not found or not accessible") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	assertExitCode(t, err, common.ExitInvalidParameters)
@@ -462,6 +462,29 @@ func TestAuthLogin_OAuth_ProjectIDEnvVar_Inaccessible(t *testing.T) {
 	assertStoredProject(t, "project-123")
 }
 
+// TestAuthLogin_ClearsDefaultServiceOnProjectChange verifies a login that
+// lands on a different project clears the stored default service, like
+// `tiger project` does.
+func TestAuthLogin_ClearsDefaultServiceOnProjectChange(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	if err := testConfig(t).Set("service_id", "svc1234567"); err != nil {
+		t.Fatalf("Failed to set default service: %v", err)
+	}
+
+	stubIsTerminal(t, false)
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login", "--project-id", "project-456")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Cleared default service 'svc1234567'") {
+		t.Errorf("Expected output to report the cleared default service, got %q", output)
+	}
+
+	assertServiceIDCleared(t)
+}
+
 // TestAuthLogin_OAuth_MultipleProjectsWithoutTTY verifies the error names the
 // non-interactive alternative instead of leaving the user stuck.
 func TestAuthLogin_OAuth_MultipleProjectsWithoutTTY(t *testing.T) {
@@ -489,7 +512,7 @@ func TestAuthLogin_APIKey_ProjectIDMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected login to fail when --project-id doesn't match the API key's project")
 	}
-	if !strings.Contains(err.Error(), "API key is scoped to project test-project-id, not the requested some-other-project") {
+	if !strings.Contains(err.Error(), "API key is scoped to a different project") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	assertExitCode(t, err, common.ExitInvalidParameters)
@@ -543,13 +566,13 @@ func TestAuthLogin_APIKey_ProjectIDMatches(t *testing.T) {
 	}
 }
 
-// TestOAuthRefresh_PersistsExpiry verifies that when an expired OAuth token is
-// refreshed, the rotated token is persisted with a non-zero Expiry derived from
-// the standard `expires_in` returned by the gateway.
-func TestOAuthRefresh_PersistsExpiry(t *testing.T) {
+// setupOAuthRefreshTest points the config at a mock token server and stores an
+// expired-but-refreshable OAuth login for projectID, returning a client whose
+// next API request refreshes and persists the token.
+func setupOAuthRefreshTest(t *testing.T, projectID string) *api.ClientWithResponses {
+	t.Helper()
 	tmpDir := setupAuthTest(t)
 
-	// Mock server backs the refresh_token grant (returns expires_in=3600).
 	mockServer := startMockOAuthServer(t, nil)
 	configFile := config.GetConfigFile(tmpDir)
 	configContent := fmt.Sprintf("gateway_url: \"%s\"\napi_url: \"%s\"\n", mockServer.URL, mockServer.URL)
@@ -557,24 +580,25 @@ func TestOAuthRefresh_PersistsExpiry(t *testing.T) {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
-	// The config file above points api_url/gateway_url at the mock server, and
-	// carries the test config dir so the refreshed token is persisted there.
-	storeExpiredOAuthLogin(t, "project-789")
-
-	cfg := testConfig(t)
-	stored, err := cfg.GetStoredCredentials()
+	storeExpiredOAuthLogin(t, projectID)
+	stored, err := testConfig(t).GetStoredCredentials()
 	if err != nil {
 		t.Fatalf("Failed to load stored credentials: %v", err)
 	}
-
-	client, err := api.NewTigerClientForCredentials(cfg, stored)
+	client, err := api.NewTigerClientForCredentials(testConfig(t), stored)
 	if err != nil {
 		t.Fatalf("Failed to build client: %v", err)
 	}
+	return client
+}
 
-	// Any request makes the oauth2 transport mint a token first; since the
-	// stored token is expired, that triggers a refresh + persist. The response
-	// status itself is irrelevant — we only care about the persisted token.
+// TestOAuthRefresh_PersistsExpiry verifies that when an expired OAuth token is
+// refreshed, the rotated token is persisted with a non-zero Expiry derived from
+// the standard `expires_in` returned by the gateway.
+func TestOAuthRefresh_PersistsExpiry(t *testing.T) {
+	client := setupOAuthRefreshTest(t, "project-789")
+
+	// The response status is irrelevant — only the persisted token matters.
 	if _, err := client.GetAuthInfoWithResponse(t.Context()); err != nil {
 		t.Fatalf("Request failed: %v", err)
 	}
@@ -590,6 +614,30 @@ func TestOAuthRefresh_PersistsExpiry(t *testing.T) {
 		t.Fatalf("Expected token to be refreshed, got access token %q", reloaded.OAuth.AccessToken)
 	}
 	assertExpiresInAbout(t, reloaded.OAuth.Expiry)
+}
+
+// TestOAuthRefresh_SkipsPersistAfterRelogin verifies a refresh from a client
+// built for an OAuth login doesn't overwrite credentials that a concurrent
+// `auth login` replaced with an API key.
+func TestOAuthRefresh_SkipsPersistAfterRelogin(t *testing.T) {
+	client := setupOAuthRefreshTest(t, "project-789")
+
+	// Another process replaces the login with an API key before the refresh.
+	if err := testConfig(t).StoreCredentials("public:secret", "project-other"); err != nil {
+		t.Fatalf("Failed to store API key credentials: %v", err)
+	}
+
+	if _, err := client.GetAuthInfoWithResponse(t.Context()); err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	reloaded, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to reload credentials: %v", err)
+	}
+	if reloaded.APIKey != "public:secret" || reloaded.ProjectID != "project-other" {
+		t.Errorf("Expected the API key login to survive the refresh, got %+v", reloaded)
+	}
 }
 
 // setupOAuthTest creates a complete OAuth test environment with mock server and browser

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/common"
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
@@ -319,7 +321,7 @@ func TestAuthLogin_APIKeyValidationSuccess(t *testing.T) {
 func TestAuthLogin_OAuth_SingleProject(t *testing.T) {
 	mockServerURL := setupOAuthTest(t, []api.Project{
 		{ID: "project-123", Name: "Test Project"},
-	}, "project-123")
+	})
 
 	// Execute login command - the mocked openBrowser will handle the callback automatically
 	output, err := executeAuthCommand(t.Context(), "auth", "login")
@@ -366,22 +368,17 @@ func TestAuthLogin_OAuth_MultipleProjects(t *testing.T) {
 		{ID: "project-123", Name: "Test Project 1"},
 		{ID: "project-456", Name: "Test Project 2"},
 		{ID: "project-789", Name: "Test Project 3"},
-	}, "project-789")
+	})
 
 	// The picker only runs on a TTY
 	stubIsTerminal(t, true)
 
 	// Mock the project selection to simulate user selecting the third project (index 2)
-	originalSelectProjectInteractively := selectProjectInteractively
-	defer func() {
-		selectProjectInteractively = originalSelectProjectInteractively
-	}()
-
-	selectProjectInteractively = func(_ *cobra.Command, projects []api.Project) (string, error) {
+	stubSelectProject(t, func(_ *cobra.Command, projects []api.Project) (api.Project, error) {
 		t.Logf("Mock project selection - user selects project at index 2: %s", projects[2].ID)
 		// Simulate user pressing down arrow twice and then enter (selects third project)
-		return projects[2].ID, nil
-	}
+		return projects[2], nil
+	})
 
 	// Execute login command - both mocked functions will handle OAuth flow and project selection
 	output, err := executeAuthCommand(t.Context(), "auth", "login")
@@ -420,6 +417,203 @@ func TestAuthLogin_OAuth_MultipleProjects(t *testing.T) {
 	assertExpiresInAbout(t, token.Expiry)
 	if projectID != "project-789" {
 		t.Errorf("Expected project ID 'project-789', got '%s'", projectID)
+	}
+}
+
+// TestAuthLogin_OAuth_ProjectIDFlag verifies --project-id replaces the picker,
+// so a multi-project user can log in without a terminal.
+func TestAuthLogin_OAuth_ProjectIDFlag(t *testing.T) {
+	setupOAuthTest(t, testProjects)
+
+	// No TTY: the picker isn't available, and isn't needed
+	stubIsTerminal(t, false)
+	stubSelectProject(t, func(*cobra.Command, []api.Project) (api.Project, error) {
+		t.Error("Project picker should not run when --project-id is set")
+		return api.Project{}, errors.New("unexpected picker")
+	})
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login", "--project-id", "project-456")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Successfully logged in (project: project-456)") {
+		t.Errorf("Unexpected output: %q", output)
+	}
+
+	stored, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if stored.OAuth == nil {
+		t.Fatalf("Expected OAuth credentials, got PAT: %+v", stored)
+	}
+	if stored.ProjectID != "project-456" {
+		t.Errorf("Expected project ID 'project-456', got '%s'", stored.ProjectID)
+	}
+}
+
+// TestAuthLogin_OAuth_ProjectIDEnvVar verifies TIGER_PROJECT_ID works like the
+// flag, as the API key env vars do.
+func TestAuthLogin_OAuth_ProjectIDEnvVar(t *testing.T) {
+	setupOAuthTest(t, testProjects)
+	t.Setenv("TIGER_PROJECT_ID", "project-789")
+
+	stubIsTerminal(t, false)
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Successfully logged in (project: project-789)") {
+		t.Errorf("Unexpected output: %q", output)
+	}
+
+	stored, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if stored.ProjectID != "project-789" {
+		t.Errorf("Expected project ID 'project-789', got '%s'", stored.ProjectID)
+	}
+}
+
+func TestAuthLogin_OAuth_ProjectIDFlag_Inaccessible(t *testing.T) {
+	setupOAuthTest(t, testProjects)
+
+	_, err := executeAuthCommand(t.Context(), "auth", "login", "--project-id", "project-nope")
+	if err == nil {
+		t.Fatal("Expected login to fail for an inaccessible project")
+	}
+	if !strings.Contains(err.Error(), `project "project-nope" not found or not accessible`) {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	assertExitCode(t, err, common.ExitInvalidParameters)
+
+	// A failed selection stores nothing
+	if _, err := testConfig(t).GetStoredCredentials(); err == nil {
+		t.Error("Credentials should not be stored when project selection fails")
+	}
+}
+
+// TestAuthLogin_OAuth_ProjectIDEnvVar_Inaccessible verifies an ambient
+// TIGER_PROJECT_ID naming a project this account can't see only warns and
+// falls back to normal selection, matching the API-key branch.
+func TestAuthLogin_OAuth_ProjectIDEnvVar_Inaccessible(t *testing.T) {
+	setupOAuthTest(t, testProjects[:1])
+	t.Setenv("TIGER_PROJECT_ID", "project-nope")
+
+	stubIsTerminal(t, false)
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Warning: ignoring TIGER_PROJECT_ID (project-nope) - project not found or not accessible") {
+		t.Errorf("Expected a warning about the ignored env var, got: %q", output)
+	}
+
+	stored, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if stored.ProjectID != "project-123" {
+		t.Errorf("Expected fallback to the single accessible project, got %q", stored.ProjectID)
+	}
+}
+
+// TestAuthLogin_APIKey_ProjectIDEmptyFlagEnvMismatch verifies an explicitly
+// empty --project-id counts as unset, so a mismatched ambient TIGER_PROJECT_ID
+// still only warns (e.g. `--project-id "$PROJ"` in CI with $PROJ unset).
+func TestAuthLogin_APIKey_ProjectIDEmptyFlagEnvMismatch(t *testing.T) {
+	setupAuthTest(t)
+	t.Setenv("TIGER_PROJECT_ID", "some-other-project")
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login",
+		"--public-key", "test-public-key", "--secret-key", "test-secret-key",
+		"--project-id", "")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Warning: ignoring TIGER_PROJECT_ID (some-other-project) - this API key is scoped to project test-project-id") {
+		t.Errorf("Expected a warning about the ignored env var, got: %q", output)
+	}
+}
+
+// TestAuthLogin_OAuth_MultipleProjectsWithoutTTY verifies the error names the
+// non-interactive alternative instead of leaving the user stuck.
+func TestAuthLogin_OAuth_MultipleProjectsWithoutTTY(t *testing.T) {
+	setupOAuthTest(t, testProjects)
+
+	stubIsTerminal(t, false)
+
+	_, err := executeAuthCommand(t.Context(), "auth", "login")
+	if err == nil {
+		t.Fatal("Expected login to fail without a TTY to select a project on")
+	}
+	if !strings.Contains(err.Error(), "pass --project-id or set TIGER_PROJECT_ID") {
+		t.Errorf("Expected the error to name the non-interactive alternative, got: %v", err)
+	}
+}
+
+// TestAuthLogin_APIKey_ProjectIDMismatch verifies --project-id is checked
+// against the key's own project instead of being ignored.
+func TestAuthLogin_APIKey_ProjectIDMismatch(t *testing.T) {
+	setupAuthTest(t)
+
+	_, err := executeAuthCommand(t.Context(), "auth", "login",
+		"--public-key", "test-public-key", "--secret-key", "test-secret-key",
+		"--project-id", "some-other-project")
+	if err == nil {
+		t.Fatal("Expected login to fail when --project-id doesn't match the API key's project")
+	}
+	if !strings.Contains(err.Error(), "API key is scoped to project test-project-id, not the requested some-other-project") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	assertExitCode(t, err, common.ExitInvalidParameters)
+
+	if _, err := testConfig(t).GetStoredCredentials(); err == nil {
+		t.Error("Credentials should not be stored when the requested project doesn't match")
+	}
+}
+
+// TestAuthLogin_APIKey_ProjectIDEnvVarMismatch verifies an ambient
+// TIGER_PROJECT_ID only warns, since it may be set for OAuth logins elsewhere
+// in the environment.
+func TestAuthLogin_APIKey_ProjectIDEnvVarMismatch(t *testing.T) {
+	setupAuthTest(t)
+	t.Setenv("TIGER_PROJECT_ID", "some-other-project")
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login",
+		"--public-key", "test-public-key", "--secret-key", "test-secret-key")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Warning: ignoring TIGER_PROJECT_ID (some-other-project) - this API key is scoped to project test-project-id") {
+		t.Errorf("Expected a warning about the ignored env var, got: %q", output)
+	}
+
+	creds, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if creds.ProjectID != "test-project-id" {
+		t.Errorf("Expected the API key's own project, got %q", creds.ProjectID)
+	}
+}
+
+// TestAuthLogin_APIKey_ProjectIDMatches verifies a matching --project-id is
+// accepted, so a script can pass it whatever the auth method.
+func TestAuthLogin_APIKey_ProjectIDMatches(t *testing.T) {
+	setupAuthTest(t)
+
+	output, err := executeAuthCommand(t.Context(), "auth", "login",
+		"--public-key", "test-public-key", "--secret-key", "test-secret-key",
+		"--project-id", "test-project-id")
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+	if !strings.Contains(output, "Successfully logged in (project: test-project-id)") {
+		t.Errorf("Unexpected output: %q", output)
 	}
 }
 
@@ -481,7 +675,7 @@ func TestOAuthRefresh_PersistsExpiry(t *testing.T) {
 }
 
 // setupOAuthTest creates a complete OAuth test environment with mock server and browser
-func setupOAuthTest(t *testing.T, projects []api.Project, expectedProjectID string) string {
+func setupOAuthTest(t *testing.T, projects []api.Project) string {
 	t.Helper()
 	tmpDir := setupAuthTest(t)
 
@@ -515,6 +709,41 @@ api_url: "%s"
 	})
 
 	return mockServer.URL
+}
+
+// By default the mock mints one fixed, long-lived token, so tests can assert on
+// its value. mockShortLivedRotatingTokens makes it behave like a real IdP —
+// a distinct token per mint, expiring at once — so every request refreshes and
+// every refresh persists.
+// Both are atomic: the cleanup resetting rotatingTokens runs before the mock
+// server closes (t.Cleanup is LIFO), so a straggling in-flight request can
+// still be reading in a handler goroutine while the test goroutine writes.
+var (
+	rotatingTokens     atomic.Bool
+	accessTokenCounter atomic.Int64
+)
+
+func mockShortLivedRotatingTokens(t *testing.T) {
+	t.Helper()
+	rotatingTokens.Store(true)
+	accessTokenCounter.Store(0)
+	t.Cleanup(func() { rotatingTokens.Store(false) })
+}
+
+func mockAccessToken() string {
+	if !rotatingTokens.Load() {
+		return "mock-access-token-12345"
+	}
+	return fmt.Sprintf("mock-access-token-%d", accessTokenCounter.Add(1))
+}
+
+// mockTokenExpiresIn is the expires_in the mock returns: 1 second under
+// rotation, which oauth2 treats as already expired (10s delta).
+func mockTokenExpiresIn() int {
+	if rotatingTokens.Load() {
+		return 1
+	}
+	return 3600
 }
 
 // startMockOAuthServer starts a mock server that handles all OAuth endpoints
@@ -555,9 +784,9 @@ func startMockOAuthServer(t *testing.T, projects []api.Project) *httptest.Server
 		}
 
 		tokenResponse := map[string]interface{}{
-			"access_token":  "mock-access-token-12345",
+			"access_token":  mockAccessToken(),
 			"refresh_token": "mock-refresh-token-67890",
-			"expires_in":    3600,
+			"expires_in":    mockTokenExpiresIn(),
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -572,6 +801,16 @@ func startMockOAuthServer(t *testing.T, projects []api.Project) *httptest.Server
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(projects); err != nil {
 			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		}
+	})
+
+	// Backs the validation common.NewAPIClient runs on API keys from the
+	// environment.
+	mux.HandleFunc("GET /auth/info", func(w http.ResponseWriter, _ *http.Request) {
+		t.Logf("Mock server received GET /auth/info request")
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"type":"apiKey","api_key":{"public_key":"env-public-key","project":{"id":"env-key-project","name":"Env Key Project","plan_type":"free"},"issuing_user":{"id":"1","name":"Test User","email":"test@example.com"},"name":"key","created":"2026-01-01T00:00:00Z"}}`)); err != nil {
+			t.Errorf("Failed to write auth info response: %v", err)
 		}
 	})
 

--- a/internal/cmd/auth_logout.go
+++ b/internal/cmd/auth_logout.go
@@ -30,9 +30,8 @@ func buildLogoutCmd(app *common.App) *cobra.Command {
 				return fmt.Errorf("failed to remove credentials: %w", err)
 			}
 
-			// The default service is anchored to the login's project; left
-			// behind, it would silently apply to whatever project the next
-			// login lands on.
+			// A default service is anchored to the login's project; left
+			// behind it would apply to whatever project logs in next.
 			if err := cfg.Unset("service_id"); err != nil {
 				cmd.PrintErrf("⚠️  Failed to clear the default service: %s\n", err)
 			}

--- a/internal/cmd/auth_logout.go
+++ b/internal/cmd/auth_logout.go
@@ -30,6 +30,13 @@ func buildLogoutCmd(app *common.App) *cobra.Command {
 				return fmt.Errorf("failed to remove credentials: %w", err)
 			}
 
+			// The default service is anchored to the login's project; left
+			// behind, it would silently apply to whatever project the next
+			// login lands on.
+			if err := cfg.Unset("service_id"); err != nil {
+				cmd.PrintErrf("⚠️  Failed to clear the default service: %s\n", err)
+			}
+
 			cmd.Println("Successfully logged out and removed stored credentials")
 			return nil
 		},

--- a/internal/cmd/auth_logout_test.go
+++ b/internal/cmd/auth_logout_test.go
@@ -43,6 +43,26 @@ func TestAuthLogout_Success(t *testing.T) {
 	}
 }
 
+// TestAuthLogout_ClearsDefaultService verifies logout removes the stored
+// default service — anchored to the login's project, it must not carry over
+// to whatever project the next login lands on.
+func TestAuthLogout_ClearsDefaultService(t *testing.T) {
+	setupAuthTest(t)
+
+	if err := testConfig(t).StoreCredentials("test-api-key-logout", "test-project-logout"); err != nil {
+		t.Fatalf("Failed to store credentials: %v", err)
+	}
+	if err := testConfig(t).Set("service_id", "svc1234567"); err != nil {
+		t.Fatalf("Failed to set default service: %v", err)
+	}
+
+	if _, err := executeAuthCommand(t.Context(), "auth", "logout"); err != nil {
+		t.Fatalf("Logout failed: %v", err)
+	}
+
+	assertServiceIDCleared(t)
+}
+
 // TestAuthLogout_OAuthCredentialsStayRemoved guards an edge case in the App's
 // cached client: for an OAuth session that client persists refreshed tokens back
 // to storage, and the analytics event deferred by wrapCommands runs *after*

--- a/internal/cmd/auth_logout_test.go
+++ b/internal/cmd/auth_logout_test.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
-
-	"golang.org/x/oauth2"
 
 	"github.com/timescale/tiger-cli/internal/config"
 )
@@ -44,8 +41,7 @@ func TestAuthLogout_Success(t *testing.T) {
 }
 
 // TestAuthLogout_ClearsDefaultService verifies logout removes the stored
-// default service — anchored to the login's project, it must not carry over
-// to whatever project the next login lands on.
+// default service, so it can't carry over to the next login's project.
 func TestAuthLogout_ClearsDefaultService(t *testing.T) {
 	setupAuthTest(t)
 
@@ -88,15 +84,7 @@ func TestAuthLogout_OAuthCredentialsStayRemoved(t *testing.T) {
 
 	// An expired access token with a refresh token the mock still honors: the
 	// state where a logout triggers a refresh.
-	cfg := testConfig(t)
-	expired := &oauth2.Token{
-		AccessToken:  "stale-access-token",
-		RefreshToken: "mock-refresh-token-67890",
-		Expiry:       time.Now().Add(-time.Hour),
-	}
-	if err := cfg.StoreOAuthCredentials(expired, "project-789"); err != nil {
-		t.Fatalf("Failed to store oauth credentials: %v", err)
-	}
+	storeExpiredOAuthLogin(t, "project-789")
 
 	if _, err := executeAuthCommand(t.Context(), "auth", "logout"); err != nil {
 		t.Fatalf("Logout failed: %v", err)

--- a/internal/cmd/auth_test.go
+++ b/internal/cmd/auth_test.go
@@ -35,6 +35,10 @@ func setupAuthTest(t *testing.T) string {
 	// the test load their config from the test directory
 	os.Setenv("TIGER_CONFIG_DIR", tmpDir)
 
+	// An ambient TIGER_PROJECT_ID would feed into project resolution and fail
+	// against the mocks' project lists
+	os.Unsetenv("TIGER_PROJECT_ID")
+
 	// Disable analytics for auth tests to avoid tracking test events
 	os.Setenv("TIGER_ANALYTICS", "false")
 

--- a/internal/cmd/completion_helper.go
+++ b/internal/cmd/completion_helper.go
@@ -54,37 +54,6 @@ func serviceIDCompletion(app *common.App) cobra.CompletionFunc {
 	})
 }
 
-// projectIDCompletion completes project IDs for `tiger project` and `tiger auth
-// login --project-id`. It needs credentials, so it yields nothing until the user
-// has logged in once.
-func projectIDCompletion(app *common.App) cobra.CompletionFunc {
-	return withAppLoad(app, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// `tiger project` takes one project ID, so nothing is left to complete
-		// once it has one. (As a flag completion, args is always empty.)
-		if len(args) > 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		client, _, err := app.GetClient()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		projects, err := fetchProjects(cmd.Context(), client)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		results := make([]string, 0, len(projects))
-		for _, project := range projects {
-			if strings.HasPrefix(project.ID, toComplete) {
-				results = append(results, cobra.CompletionWithDesc(project.ID, project.Name))
-			}
-		}
-		return results, cobra.ShellCompDirectiveNoFileComp
-	})
-}
-
 func listServices(cmd *cobra.Command, app *common.App) ([]api.Service, error) {
 	client, projectID, err := app.GetClient()
 	if err != nil {

--- a/internal/cmd/completion_helper.go
+++ b/internal/cmd/completion_helper.go
@@ -54,6 +54,37 @@ func serviceIDCompletion(app *common.App) cobra.CompletionFunc {
 	})
 }
 
+// projectIDCompletion completes project IDs for `tiger project` and `tiger auth
+// login --project-id`. It needs credentials, so it yields nothing until the user
+// has logged in once.
+func projectIDCompletion(app *common.App) cobra.CompletionFunc {
+	return withAppLoad(app, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// `tiger project` takes one project ID, so nothing is left to complete
+		// once it has one. (As a flag completion, args is always empty.)
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		client, _, err := app.GetClient()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		projects, err := fetchProjects(cmd.Context(), client)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		results := make([]string, 0, len(projects))
+		for _, project := range projects {
+			if strings.HasPrefix(project.ID, toComplete) {
+				results = append(results, cobra.CompletionWithDesc(project.ID, project.Name))
+			}
+		}
+		return results, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
 func listServices(cmd *cobra.Command, app *common.App) ([]api.Service, error) {
 	client, projectID, err := app.GetClient()
 	if err != nil {

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -633,7 +633,15 @@ func testSaveAndLaunchPsqlWithPassword(
 // It retrieves the password from storage and sets PGPASSWORD environment variable.
 func launchPsql(cfg *config.Config, details *common.ConnectionDetails, psqlPath string, additionalFlags []string, service api.Service, cmd *cobra.Command) error {
 	psqlCmd := buildPsqlCommand(cfg, details, psqlPath, additionalFlags, service, cmd)
-	return psqlCmd.Run()
+	err := psqlCmd.Run()
+	// Carry psql's own exit code as the CLI's. Converting here (rather than
+	// matching *exec.ExitError in main) keeps the code through any fmt.Errorf
+	// wrap on the way up — main.go only extracts common.ExitCodeError.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return common.ExitWithCode(exitErr.ExitCode(), err)
+	}
+	return err
 }
 
 // buildPsqlCommand creates the psql command with proper environment setup

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -634,9 +634,8 @@ func testSaveAndLaunchPsqlWithPassword(
 func launchPsql(cfg *config.Config, details *common.ConnectionDetails, psqlPath string, additionalFlags []string, service api.Service, cmd *cobra.Command) error {
 	psqlCmd := buildPsqlCommand(cfg, details, psqlPath, additionalFlags, service, cmd)
 	err := psqlCmd.Run()
-	// Carry psql's own exit code as the CLI's. Converting here (rather than
-	// matching *exec.ExitError in main) keeps the code through any fmt.Errorf
-	// wrap on the way up — main.go only extracts common.ExitCodeError.
+	// Carry psql's own exit code as the CLI's; converting here keeps it
+	// through any fmt.Errorf wrap, since main.go only extracts ExitCodeError.
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		return common.ExitWithCode(exitErr.ExitCode(), err)

--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -44,6 +45,35 @@ func stubReadPassword(t *testing.T, password string) {
 	t.Cleanup(func() { util.ReadPassword = original })
 }
 
+// stubSelectProject replaces the interactive project picker with fn.
+func stubSelectProject(t *testing.T, fn func(*cobra.Command, []api.Project) (api.Project, error)) {
+	t.Helper()
+	original := selectProjectInteractively
+	selectProjectInteractively = fn
+	t.Cleanup(func() { selectProjectInteractively = original })
+}
+
+// testProjects is the project list the mock API serves.
+var testProjects = []api.Project{
+	{ID: "project-123", Name: "Test Project 1"},
+	{ID: "project-456", Name: "Test Project 2"},
+	{ID: "project-789", Name: "Test Project 3"},
+}
+
+// assertExitCode checks that err carries the expected CLI exit code.
+func assertExitCode(t *testing.T, err error, expected int) {
+	t.Helper()
+
+	var exitErr common.ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("Expected a common.ExitCodeError, got: %v", err)
+		return
+	}
+	if exitErr.ExitCode() != expected {
+		t.Errorf("Expected exit code %d, got %d (%v)", expected, exitErr.ExitCode(), err)
+	}
+}
+
 func TestMain(m *testing.M) {
 	// Clean up any global state before tests
 	code := m.Run()
@@ -61,6 +91,9 @@ func setupTestCommand(t *testing.T) (string, func()) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
+
+	// Isolate the test from the developer's real config file
+	t.Setenv("TIGER_CONFIG_DIR", tmpDir)
 
 	// Disable analytics for root tests to avoid tracking test events
 	os.Setenv("TIGER_ANALYTICS", "false")

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -80,9 +80,7 @@ Examples:
 				return fmt.Errorf("failed to store credentials: %w", err)
 			}
 
-			if err := clearStaleDefaultService(cmd, cfg, currentProjectID, project.ID); err != nil {
-				return err
-			}
+			clearStaleDefaultService(cmd, cfg, currentProjectID, project.ID)
 
 			// Later readers in this invocation — the trailing analytics event
 			// in particular — see the new project.

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -34,7 +34,7 @@ Examples:
 		Args: cobra.MaximumNArgs(1),
 		// The argument is a project ID, which analytics excludes.
 		Annotations:       map[string]string{analytics.OmitArgsAnnotation: "true"},
-		ValidArgsFunction: projectIDCompletion(app),
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -80,25 +80,13 @@ Examples:
 				return fmt.Errorf("failed to store credentials: %w", err)
 			}
 
-			// The default service belongs to the project we just left. Unset
-			// clears only the config file, so a flag or env var wins again
-			// after the reload.
-			if previous := cfg.ServiceID; previous != "" {
-				if err := cfg.Unset("service_id"); err != nil {
-					return fmt.Errorf("failed to clear default service: %w", err)
-				}
-				if cfg.ServiceID != "" {
-					cmd.PrintErrf("⚠️  Default service '%s' comes from a flag or environment variable and still points at the previous project.\n", cfg.ServiceID)
-				} else {
-					cmd.PrintErrf("🎯 Cleared default service '%s' - it belongs to the previous project.\n", previous)
-				}
-			}
-
-			// Reload so later readers in this invocation — the trailing
-			// analytics event in particular — see the new project.
-			if _, _, _, err := app.Load(cmd.Context()); err != nil {
+			if err := clearStaleDefaultService(cmd, cfg, currentProjectID, project.ID); err != nil {
 				return err
 			}
+
+			// Later readers in this invocation — the trailing analytics event
+			// in particular — see the new project.
+			app.SetClient(client, project.ID)
 
 			cmd.Printf("Switched to project %s\n", describeProject(project))
 			return nil

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -81,9 +81,8 @@ Examples:
 			}
 
 			// The default service belongs to the project we just left. Unset
-			// clears only the config file, so a flag or env var wins again after
-			// the reload. (`auth login --project-id` deliberately doesn't clear
-			// it: a fresh login isn't a switch.)
+			// clears only the config file, so a flag or env var wins again
+			// after the reload.
 			if previous := cfg.ServiceID; previous != "" {
 				if err := cfg.Unset("service_id"); err != nil {
 					return fmt.Errorf("failed to clear default service: %w", err)

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/timescale/tiger-cli/internal/analytics"
+	"github.com/timescale/tiger-cli/internal/common"
+)
+
+func buildProjectCmd(app *common.App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "project [project-id]",
+		Aliases: []string{"projects", "proj"},
+		Short:   "Switch the active Tiger Cloud project",
+		Long: `Switch the Tiger Cloud project that subsequent commands operate on.
+
+Without an argument, the accessible projects are listed for you to pick from. Pass a project ID
+to switch without the prompt, which is what you want when no terminal is available.
+
+Switching projects requires an OAuth login ('tiger auth login' without --public-key/--secret-key),
+because an API key is scoped to a single project.
+
+The default service (config key service_id) belongs to the project it was set in, so it is cleared
+when you switch away.
+
+Examples:
+  # Pick a project interactively
+  tiger project
+
+  # Switch to a specific project
+  tiger project rp1pz7uyae`,
+		Args: cobra.MaximumNArgs(1),
+		// The argument is a project ID, which analytics excludes.
+		Annotations:       map[string]string{analytics.OmitArgsAnnotation: "true"},
+		ValidArgsFunction: projectIDCompletion(app),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			// Refuse credentials a switch can't move, before GetAll can fail
+			// validating them and bury this explanation under a generic error.
+			if _, fromEnv := common.EnvAPIKey(); fromEnv {
+				return fmt.Errorf("cannot switch projects while TIGER_PUBLIC_KEY/TIGER_SECRET_KEY are set: those credentials take precedence over the stored login, and an API key is scoped to a single project")
+			}
+
+			// GetAll's error already carries the auth exit code and login hint.
+			cfg, client, currentProjectID, err := app.GetAll()
+			if err != nil {
+				return err
+			}
+			stored, err := cfg.GetStoredCredentials()
+			if err != nil {
+				return err
+			}
+			if stored.OAuth == nil {
+				return fmt.Errorf("switching projects requires an OAuth login: an API key is scoped to a single project. Run 'tiger auth login' without --public-key/--secret-key")
+			}
+
+			projects, err := fetchProjects(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+
+			var requested string
+			if len(args) > 0 {
+				requested = args[0]
+			}
+			project, err := resolveProjectID(cmd, projects, requested, "pass the project ID as an argument")
+			if err != nil {
+				return err
+			}
+
+			if project.ID == currentProjectID {
+				cmd.Printf("Already using project %s\n", describeProject(project))
+				return nil
+			}
+
+			if err := cfg.SwitchProject(project.ID); err != nil {
+				return fmt.Errorf("failed to store credentials: %w", err)
+			}
+
+			// The default service belongs to the project we just left. Unset
+			// clears only the config file, so a flag or env var wins again after
+			// the reload. (`auth login --project-id` deliberately doesn't clear
+			// it: a fresh login isn't a switch.)
+			if previous := cfg.ServiceID; previous != "" {
+				if err := cfg.Unset("service_id"); err != nil {
+					return fmt.Errorf("failed to clear default service: %w", err)
+				}
+				if cfg.ServiceID != "" {
+					cmd.PrintErrf("⚠️  Default service '%s' comes from a flag or environment variable and still points at the previous project.\n", cfg.ServiceID)
+				} else {
+					cmd.PrintErrf("🎯 Cleared default service '%s' - it belongs to the previous project.\n", previous)
+				}
+			}
+
+			// Reload so later readers in this invocation — the trailing
+			// analytics event in particular — see the new project.
+			if _, _, _, err := app.Load(cmd.Context()); err != nil {
+				return err
+			}
+
+			cmd.Printf("Switched to project %s\n", describeProject(project))
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/project_helper.go
+++ b/internal/cmd/project_helper.go
@@ -71,8 +71,7 @@ func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, non
 // clearStaleDefaultService unsets the config-file service_id when the stored
 // login moves between projects — a default service belongs to the project it
 // was set in. Only the config file is touched, so a flag or env var still
-// wins. Failures only warn: callers run this after the project change has
-// persisted, and an error would report that change as not having happened.
+// wins; failures only warn, since the project change has already persisted.
 func clearStaleDefaultService(cmd *cobra.Command, cfg *config.Config, previousProjectID, newProjectID string) {
 	if previousProjectID == "" || previousProjectID == newProjectID {
 		return

--- a/internal/cmd/project_helper.go
+++ b/internal/cmd/project_helper.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -9,9 +10,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 
-	"github.com/timescale/tiger-cli/internal/analytics"
 	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
+	"github.com/timescale/tiger-cli/internal/config"
 	"github.com/timescale/tiger-cli/internal/util"
 )
 
@@ -46,11 +47,10 @@ func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, non
 				return project, nil
 			}
 		}
-		// RedactError keeps the requested ID out of the analytics error property
+		// No project ID in the message — analytics records error text verbatim,
+		// and the user just typed the ID themselves.
 		return api.Project{}, common.ExitWithCode(common.ExitInvalidParameters,
-			analytics.RedactError(
-				fmt.Errorf("project %q not found or not accessible", requested),
-				"project not found or not accessible"))
+			errors.New("requested project not found or not accessible"))
 	}
 
 	switch len(projects) {
@@ -66,6 +66,28 @@ func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, non
 
 		return selectProjectInteractively(cmd, projects)
 	}
+}
+
+// clearStaleDefaultService unsets the config-file service_id when the stored
+// login moves between projects — a default service belongs to the project it
+// was set in. Only the config file is touched, so a flag or env var still wins.
+func clearStaleDefaultService(cmd *cobra.Command, cfg *config.Config, previousProjectID, newProjectID string) error {
+	if previousProjectID == "" || previousProjectID == newProjectID {
+		return nil
+	}
+
+	// An empty flag can hide a config-file default, so Unset runs regardless.
+	previous := cfg.ServiceID
+	if err := cfg.Unset("service_id"); err != nil {
+		return fmt.Errorf("failed to clear default service: %w", err)
+	}
+	switch {
+	case cfg.ServiceID != "":
+		cmd.PrintErrf("⚠️  Default service '%s' comes from a flag or environment variable and still points at the previous project.\n", cfg.ServiceID)
+	case previous != "":
+		cmd.PrintErrf("🎯 Cleared default service '%s' - it belongs to the previous project.\n", previous)
+	}
+	return nil
 }
 
 // describeProject renders a project for human-readable output.

--- a/internal/cmd/project_helper.go
+++ b/internal/cmd/project_helper.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/timescale/tiger-cli/internal/analytics"
+	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/common"
+	"github.com/timescale/tiger-cli/internal/util"
+)
+
+// selectProjectInteractively can be overridden for testing
+var selectProjectInteractively = selectProjectInteractivelyImpl
+
+// fetchProjects lists the projects the caller can access: every project an
+// OAuth user belongs to, or the single project a PAT is scoped to.
+func fetchProjects(ctx context.Context, client api.ClientWithResponsesInterface) ([]api.Project, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	resp, err := client.GetProjectsWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user projects: %w", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, common.ExitWithErrorFromStatusCode(resp.StatusCode(), resp.JSON4XX)
+	}
+
+	return *resp.JSON200, nil
+}
+
+// resolveProjectID picks the project to use. A requested ID (from --project-id
+// or a positional argument) is validated against the accessible ones; otherwise
+// a lone project is used as-is and a choice between several is made
+// interactively. nonInteractiveHint names how the calling command takes a
+// project ID without a prompt, for the error raised when there's no terminal.
+func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, nonInteractiveHint string) (api.Project, error) {
+	if requested != "" {
+		for _, project := range projects {
+			if project.ID == requested {
+				return project, nil
+			}
+		}
+		return api.Project{}, common.ExitWithCode(common.ExitInvalidParameters,
+			analytics.RedactError(
+				fmt.Errorf("project %q not found or not accessible.%s", requested, accessibleProjectsHint(projects)),
+				"project not found or not accessible"))
+	}
+
+	switch len(projects) {
+	case 0:
+		return api.Project{}, fmt.Errorf("user has no accessible projects")
+	case 1:
+		return projects[0], nil
+	default:
+		if !util.IsTerminal(cmd.InOrStdin()) || !util.IsTerminal(cmd.ErrOrStderr()) {
+			return api.Project{}, analytics.RedactError(
+				fmt.Errorf("TTY not detected - cannot select between %d projects. To choose one, %s.%s",
+					len(projects), nonInteractiveHint, accessibleProjectsHint(projects)),
+				fmt.Sprintf("TTY not detected - cannot select between %d projects", len(projects)))
+		}
+
+		return selectProjectInteractively(cmd, projects)
+	}
+}
+
+// accessibleProjectsHint lists the caller's projects for an error message, so a
+// misspelled project ID doesn't need a second command to fix.
+func accessibleProjectsHint(projects []api.Project) string {
+	if len(projects) == 0 {
+		return ""
+	}
+
+	described := make([]string, 0, len(projects))
+	for _, project := range projects {
+		described = append(described, describeProject(project))
+	}
+	return " Accessible projects: " + strings.Join(described, ", ")
+}
+
+// describeProject renders a project for human-readable output.
+func describeProject(project api.Project) string {
+	if project.Name == "" {
+		return project.ID
+	}
+	return fmt.Sprintf("%s (%s)", project.Name, project.ID)
+}
+
+// selectProjectInteractivelyImpl is the default implementation for project selection using Bubble Tea
+func selectProjectInteractivelyImpl(cmd *cobra.Command, projects []api.Project) (api.Project, error) {
+	model := projectSelectModel{
+		projects: projects,
+		cursor:   0,
+	}
+
+	program := tea.NewProgram(model,
+		tea.WithInput(cmd.InOrStdin()),
+		tea.WithOutput(cmd.ErrOrStderr()),
+		tea.WithContext(cmd.Context()),
+		tea.WithoutSignalHandler())
+	finalModel, err := program.Run()
+	if err != nil {
+		return api.Project{}, fmt.Errorf("failed to run project selection: %w", err)
+	}
+
+	result := finalModel.(projectSelectModel)
+	if result.selected.ID == "" {
+		return api.Project{}, fmt.Errorf("no project selected")
+	}
+
+	return result.selected, nil
+}
+
+type projectSelectModel struct {
+	projects     []api.Project
+	cursor       int
+	selected     api.Project
+	numberBuffer string
+}
+
+func (m projectSelectModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m projectSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		case "up", "k":
+			// Clear buffer when using arrows
+			m.numberBuffer = ""
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			// Clear buffer when using arrows
+			m.numberBuffer = ""
+			if m.cursor < len(m.projects)-1 {
+				m.cursor++
+			}
+		case "enter", "space":
+			m.selected = m.projects[m.cursor]
+			return m, tea.Quit
+		case "backspace":
+			// Handle backspace to remove last character from buffer
+			if len(m.numberBuffer) > 0 {
+				m.updateNumberBuffer(m.numberBuffer[:len(m.numberBuffer)-1])
+			}
+		case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+			// Add digit to buffer and update cursor position
+			m.updateNumberBuffer(m.numberBuffer + msg.String())
+		case "ctrl+w", "esc":
+			// Clear buffer on escape
+			m.numberBuffer = ""
+		}
+	}
+	return m, nil
+}
+
+// updateNumberBuffer moves the cursor to the project matching the number buffer
+func (m *projectSelectModel) updateNumberBuffer(newBuffer string) {
+	if newBuffer == "" {
+		m.numberBuffer = newBuffer
+		return
+	}
+
+	// Parse the buffer as a number
+	num, err := strconv.Atoi(newBuffer)
+	if err != nil {
+		return
+	}
+
+	// Convert from 1-based to 0-based index and validate bounds
+	index := num - 1
+	if index >= 0 && index < len(m.projects) {
+		m.numberBuffer = newBuffer
+		m.cursor = index
+	}
+}
+
+func (m projectSelectModel) View() tea.View {
+	s := "Select a project:\n\n"
+
+	for i, project := range m.projects {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+		s += fmt.Sprintf("%s %d. %s (%s)\n", cursor, i+1, project.Name, project.ID)
+	}
+
+	// Show the current number buffer if user is typing
+	if m.numberBuffer != "" {
+		s += fmt.Sprintf("\nTyping: %s", m.numberBuffer)
+	}
+
+	s += "\nUse ↑/↓ arrows or number keys to navigate, enter to select, q to quit"
+	return tea.NewView(s)
+}

--- a/internal/cmd/project_helper.go
+++ b/internal/cmd/project_helper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -48,9 +47,10 @@ func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, non
 				return project, nil
 			}
 		}
+		// RedactError keeps the requested ID out of the analytics error property
 		return api.Project{}, common.ExitWithCode(common.ExitInvalidParameters,
 			analytics.RedactError(
-				fmt.Errorf("project %q not found or not accessible.%s", requested, accessibleProjectsHint(projects)),
+				fmt.Errorf("project %q not found or not accessible", requested),
 				"project not found or not accessible"))
 	}
 
@@ -61,28 +61,12 @@ func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, non
 		return projects[0], nil
 	default:
 		if !util.IsTerminal(cmd.InOrStdin()) || !util.IsTerminal(cmd.ErrOrStderr()) {
-			return api.Project{}, analytics.RedactError(
-				fmt.Errorf("TTY not detected - cannot select between %d projects. To choose one, %s.%s",
-					len(projects), nonInteractiveHint, accessibleProjectsHint(projects)),
-				fmt.Sprintf("TTY not detected - cannot select between %d projects", len(projects)))
+			return api.Project{}, fmt.Errorf("TTY not detected - cannot select between %d projects. To choose one, %s",
+				len(projects), nonInteractiveHint)
 		}
 
 		return selectProjectInteractively(cmd, projects)
 	}
-}
-
-// accessibleProjectsHint lists the caller's projects for an error message, so a
-// misspelled project ID doesn't need a second command to fix.
-func accessibleProjectsHint(projects []api.Project) string {
-	if len(projects) == 0 {
-		return ""
-	}
-
-	described := make([]string, 0, len(projects))
-	for _, project := range projects {
-		described = append(described, describeProject(project))
-	}
-	return " Accessible projects: " + strings.Join(described, ", ")
 }
 
 // describeProject renders a project for human-readable output.

--- a/internal/cmd/project_helper.go
+++ b/internal/cmd/project_helper.go
@@ -35,11 +35,10 @@ func fetchProjects(ctx context.Context, client api.ClientWithResponsesInterface)
 	return *resp.JSON200, nil
 }
 
-// resolveProjectID picks the project to use. A requested ID (from --project-id
-// or a positional argument) is validated against the accessible ones; otherwise
-// a lone project is used as-is and a choice between several is made
-// interactively. nonInteractiveHint names how the calling command takes a
-// project ID without a prompt, for the error raised when there's no terminal.
+// resolveProjectID picks the project to use: a requested ID (from --project-id
+// or a positional argument) is validated against the accessible ones, a lone
+// project is used as-is, and several prompt interactively. nonInteractiveHint
+// names the calling command's promptless alternative for the no-TTY error.
 func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, nonInteractiveHint string) (api.Project, error) {
 	if requested != "" {
 		for _, project := range projects {
@@ -120,13 +119,11 @@ func (m projectSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		case "up", "k":
-			// Clear buffer when using arrows
 			m.numberBuffer = ""
 			if m.cursor > 0 {
 				m.cursor--
 			}
 		case "down", "j":
-			// Clear buffer when using arrows
 			m.numberBuffer = ""
 			if m.cursor < len(m.projects)-1 {
 				m.cursor++
@@ -135,15 +132,12 @@ func (m projectSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.selected = m.projects[m.cursor]
 			return m, tea.Quit
 		case "backspace":
-			// Handle backspace to remove last character from buffer
 			if len(m.numberBuffer) > 0 {
 				m.updateNumberBuffer(m.numberBuffer[:len(m.numberBuffer)-1])
 			}
 		case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
-			// Add digit to buffer and update cursor position
 			m.updateNumberBuffer(m.numberBuffer + msg.String())
 		case "ctrl+w", "esc":
-			// Clear buffer on escape
 			m.numberBuffer = ""
 		}
 	}
@@ -157,13 +151,12 @@ func (m *projectSelectModel) updateNumberBuffer(newBuffer string) {
 		return
 	}
 
-	// Parse the buffer as a number
 	num, err := strconv.Atoi(newBuffer)
 	if err != nil {
 		return
 	}
 
-	// Convert from 1-based to 0-based index and validate bounds
+	// The list is displayed 1-based
 	index := num - 1
 	if index >= 0 && index < len(m.projects) {
 		m.numberBuffer = newBuffer
@@ -182,7 +175,6 @@ func (m projectSelectModel) View() tea.View {
 		s += fmt.Sprintf("%s %d. %s (%s)\n", cursor, i+1, project.Name, project.ID)
 	}
 
-	// Show the current number buffer if user is typing
 	if m.numberBuffer != "" {
 		s += fmt.Sprintf("\nTyping: %s", m.numberBuffer)
 	}

--- a/internal/cmd/project_helper.go
+++ b/internal/cmd/project_helper.go
@@ -70,16 +70,19 @@ func resolveProjectID(cmd *cobra.Command, projects []api.Project, requested, non
 
 // clearStaleDefaultService unsets the config-file service_id when the stored
 // login moves between projects — a default service belongs to the project it
-// was set in. Only the config file is touched, so a flag or env var still wins.
-func clearStaleDefaultService(cmd *cobra.Command, cfg *config.Config, previousProjectID, newProjectID string) error {
+// was set in. Only the config file is touched, so a flag or env var still
+// wins. Failures only warn: callers run this after the project change has
+// persisted, and an error would report that change as not having happened.
+func clearStaleDefaultService(cmd *cobra.Command, cfg *config.Config, previousProjectID, newProjectID string) {
 	if previousProjectID == "" || previousProjectID == newProjectID {
-		return nil
+		return
 	}
 
 	// An empty flag can hide a config-file default, so Unset runs regardless.
 	previous := cfg.ServiceID
 	if err := cfg.Unset("service_id"); err != nil {
-		return fmt.Errorf("failed to clear default service: %w", err)
+		cmd.PrintErrf("⚠️  Failed to clear the default service, which belongs to the previous project: %s\n", err)
+		return
 	}
 	switch {
 	case cfg.ServiceID != "":
@@ -87,7 +90,6 @@ func clearStaleDefaultService(cmd *cobra.Command, cfg *config.Config, previousPr
 	case previous != "":
 		cmd.PrintErrf("🎯 Cleared default service '%s' - it belongs to the previous project.\n", previous)
 	}
-	return nil
 }
 
 // describeProject renders a project for human-readable output.

--- a/internal/cmd/project_test.go
+++ b/internal/cmd/project_test.go
@@ -1,0 +1,330 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+
+	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/common"
+	"github.com/timescale/tiger-cli/internal/config"
+)
+
+// setupProjectTest sets up the OAuth login tests' mock environment, and stores
+// an OAuth login for currentProjectID — pass "" to store nothing.
+func setupProjectTest(t *testing.T, projects []api.Project, currentProjectID string) {
+	t.Helper()
+
+	setupOAuthTest(t, projects)
+
+	if currentProjectID != "" {
+		if err := testConfig(t).StoreOAuthCredentials(testOAuthToken(), currentProjectID); err != nil {
+			t.Fatalf("Failed to store oauth credentials: %v", err)
+		}
+	}
+}
+
+// testOAuthToken returns a valid token matching what the mock server mints;
+// tests that need a refresh adjust the copy.
+func testOAuthToken() *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  "mock-access-token-12345",
+		RefreshToken: "mock-refresh-token-67890",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+}
+
+// assertStoredProject checks the stored credentials still hold an OAuth session
+// and name the expected project.
+func assertStoredProject(t *testing.T, expectedProjectID string) {
+	t.Helper()
+
+	stored, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if stored.OAuth == nil {
+		t.Fatalf("Expected OAuth credentials to remain stored, got: %+v", stored)
+	}
+	if stored.OAuth.AccessToken != "mock-access-token-12345" {
+		t.Errorf("Expected access token to be preserved, got %q", stored.OAuth.AccessToken)
+	}
+	if stored.OAuth.RefreshToken != "mock-refresh-token-67890" {
+		t.Errorf("Expected refresh token to be preserved, got %q", stored.OAuth.RefreshToken)
+	}
+	if stored.ProjectID != expectedProjectID {
+		t.Errorf("Expected project ID %q, got %q", expectedProjectID, stored.ProjectID)
+	}
+}
+
+func TestProject_SwitchByArgument(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	output, err := executeAuthCommand(t.Context(), "project", "project-456")
+	if err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
+	}
+
+	expected := "Switched to project Test Project 2 (project-456)\n"
+	if output != expected {
+		t.Errorf("Expected output %q, got %q", expected, output)
+	}
+
+	assertStoredProject(t, "project-456")
+}
+
+// TestProject_PreservesRefreshedToken covers a token that rotates mid-command:
+// listing projects refreshes the expired access token, so the switch must store
+// that rotated token rather than the stale copy it read on the way in.
+func TestProject_PreservesRefreshedToken(t *testing.T) {
+	setupProjectTest(t, testProjects, "")
+
+	expired := testOAuthToken()
+	expired.AccessToken = "stale-access-token"
+	expired.Expiry = time.Now().Add(-time.Hour)
+	if err := testConfig(t).StoreOAuthCredentials(expired, "project-123"); err != nil {
+		t.Fatalf("Failed to store oauth credentials: %v", err)
+	}
+
+	if _, err := executeAuthCommand(t.Context(), "project", "project-456"); err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
+	}
+
+	// assertStoredProject expects the refreshed token, so this fails if the
+	// stale access token was written back.
+	assertStoredProject(t, "project-456")
+}
+
+// TestProject_SurvivesPostSwitchRefresh covers a refresh that happens after the
+// switch is stored: the API client persists rotated tokens under the project ID
+// it was built for, so it has to be rebuilt or the refresh writes the old
+// project back.
+func TestProject_SurvivesPostSwitchRefresh(t *testing.T) {
+	setupProjectTest(t, testProjects, "")
+
+	// Every mint refreshes and rotates the token, so any request persists one,
+	// and analytics fires one after the switch is stored.
+	mockShortLivedRotatingTokens(t)
+	t.Setenv("TIGER_ANALYTICS", "true")
+
+	expired := testOAuthToken()
+	expired.AccessToken = "stale-access-token"
+	expired.Expiry = time.Now().Add(-time.Hour)
+	if err := testConfig(t).StoreOAuthCredentials(expired, "project-123"); err != nil {
+		t.Fatalf("Failed to store oauth credentials: %v", err)
+	}
+
+	if _, err := executeAuthCommand(t.Context(), "project", "project-456"); err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
+	}
+
+	stored, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if stored.ProjectID != "project-456" {
+		t.Errorf("Expected the switch to survive a later token refresh, got project %q", stored.ProjectID)
+	}
+}
+
+func TestProject_ClearsDefaultService(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	if err := testConfig(t).Set("service_id", "svc1234567"); err != nil {
+		t.Fatalf("Failed to set default service: %v", err)
+	}
+
+	output, err := executeAuthCommand(t.Context(), "project", "project-789")
+	if err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
+	}
+
+	if !strings.Contains(output, "Cleared default service 'svc1234567'") {
+		t.Errorf("Expected output to report the cleared default service, got %q", output)
+	}
+	assertStoredProject(t, "project-789")
+
+	cfg, err := config.LoadForOutput(testConfigDir(t), false, true)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	if cfg.ServiceID != nil {
+		t.Errorf("Expected service_id to be removed from the config file, got %q", *cfg.ServiceID)
+	}
+}
+
+// TestProject_DefaultServiceFromEnvironment covers a default service that Unset
+// can't remove, because it comes from the environment rather than the config
+// file: the command must not claim to have cleared it.
+func TestProject_DefaultServiceFromEnvironment(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+	t.Setenv("TIGER_SERVICE_ID", "envsvc1234")
+
+	output, err := executeAuthCommand(t.Context(), "project", "project-456")
+	if err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
+	}
+
+	if strings.Contains(output, "Cleared default service") {
+		t.Errorf("Expected no claim of clearing an environment default, got %q", output)
+	}
+	if !strings.Contains(output, "Default service 'envsvc1234' comes from a flag or environment variable") {
+		t.Errorf("Expected a warning that the default service is unchanged, got %q", output)
+	}
+}
+
+func TestProject_AlreadyCurrent(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-456")
+
+	output, err := executeAuthCommand(t.Context(), "project", "project-456")
+	if err != nil {
+		t.Fatalf("Expected success for a no-op switch, got: %v", err)
+	}
+
+	expected := "Already using project Test Project 2 (project-456)\n"
+	if output != expected {
+		t.Errorf("Expected output %q, got %q", expected, output)
+	}
+
+	assertStoredProject(t, "project-456")
+}
+
+func TestProject_UnknownProject(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	_, err := executeAuthCommand(t.Context(), "project", "project-does-not-exist")
+	if err == nil {
+		t.Fatal("Expected switching to an inaccessible project to fail")
+	}
+	if !strings.Contains(err.Error(), `project "project-does-not-exist" not found or not accessible`) {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	// The error lists what the user can switch to instead.
+	if !strings.Contains(err.Error(), "Test Project 2 (project-456)") {
+		t.Errorf("Expected error to list accessible projects, got: %v", err)
+	}
+
+	assertExitCode(t, err, common.ExitInvalidParameters)
+
+	// The stored project is unchanged
+	assertStoredProject(t, "project-123")
+}
+
+func TestProject_SelectsInteractively(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	// The picker only runs on a TTY
+	stubIsTerminal(t, true)
+
+	stubSelectProject(t, func(_ *cobra.Command, projects []api.Project) (api.Project, error) {
+		if len(projects) != len(testProjects) {
+			t.Errorf("Expected %d projects in the picker, got %d", len(testProjects), len(projects))
+		}
+		return projects[2], nil
+	})
+
+	output, err := executeAuthCommand(t.Context(), "project")
+	if err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
+	}
+
+	expected := "Switched to project Test Project 3 (project-789)\n"
+	if output != expected {
+		t.Errorf("Expected output %q, got %q", expected, output)
+	}
+
+	assertStoredProject(t, "project-789")
+}
+
+func TestProject_NoArgumentWithoutTTY(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	stubIsTerminal(t, false)
+
+	_, err := executeAuthCommand(t.Context(), "project")
+	if err == nil {
+		t.Fatal("Expected a bare switch to fail without a TTY")
+	}
+	if !strings.Contains(err.Error(), "pass the project ID as an argument") {
+		t.Errorf("Expected the error to name the non-interactive alternative, got: %v", err)
+	}
+
+	assertStoredProject(t, "project-123")
+}
+
+func TestProject_SingleProject(t *testing.T) {
+	setupProjectTest(t, testProjects[:1], "project-123")
+
+	// No prompt is needed to pick from one project, so this works without a TTY
+	stubIsTerminal(t, false)
+
+	output, err := executeAuthCommand(t.Context(), "project")
+	if err != nil {
+		t.Fatalf("Expected success with a single project, got: %v", err)
+	}
+
+	expected := "Already using project Test Project 1 (project-123)\n"
+	if output != expected {
+		t.Errorf("Expected output %q, got %q", expected, output)
+	}
+}
+
+func TestProject_RejectsAPIKeyCredentials(t *testing.T) {
+	setupProjectTest(t, testProjects, "")
+
+	if err := testConfig(t).StoreCredentials("public:secret", "project-123"); err != nil {
+		t.Fatalf("Failed to store credentials: %v", err)
+	}
+
+	_, err := executeAuthCommand(t.Context(), "project", "project-456")
+	if err == nil {
+		t.Fatal("Expected switching projects to fail for an API key login")
+	}
+	if !strings.Contains(err.Error(), "switching projects requires an OAuth login") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// The API key login is left untouched
+	stored, err := testConfig(t).GetStoredCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get stored credentials: %v", err)
+	}
+	if stored.APIKey != "public:secret" || stored.ProjectID != "project-123" {
+		t.Errorf("Expected stored API key credentials to be unchanged, got %+v", stored)
+	}
+}
+
+func TestProject_RejectsEnvironmentAPIKeys(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	// These take precedence over the stored login, so a switch wouldn't stick.
+	t.Setenv("TIGER_PUBLIC_KEY", "env-public-key")
+	t.Setenv("TIGER_SECRET_KEY", "env-secret-key")
+
+	_, err := executeAuthCommand(t.Context(), "project", "project-456")
+	if err == nil {
+		t.Fatal("Expected switching projects to fail with API keys in the environment")
+	}
+	if !strings.Contains(err.Error(), "cannot switch projects while TIGER_PUBLIC_KEY/TIGER_SECRET_KEY are set") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	assertStoredProject(t, "project-123")
+}
+
+func TestProject_NotLoggedIn(t *testing.T) {
+	setupProjectTest(t, testProjects, "")
+
+	_, err := executeAuthCommand(t.Context(), "project", "project-456")
+	if err == nil {
+		t.Fatal("Expected switching projects to fail when not logged in")
+	}
+	if !strings.Contains(err.Error(), "authentication required") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	assertExitCode(t, err, common.ExitAuthenticationError)
+}

--- a/internal/cmd/project_test.go
+++ b/internal/cmd/project_test.go
@@ -74,6 +74,19 @@ func assertStoredProject(t *testing.T, expectedProjectID string) *config.Credent
 	return stored
 }
 
+// assertServiceIDCleared checks the config file no longer holds a service_id.
+func assertServiceIDCleared(t *testing.T) {
+	t.Helper()
+
+	cfg, err := config.LoadForOutput(testConfigDir(t), false, true)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	if cfg.ServiceID != nil {
+		t.Errorf("Expected service_id to be removed from the config file, got %q", *cfg.ServiceID)
+	}
+}
+
 func TestProject_SwitchByArgument(t *testing.T) {
 	setupProjectTest(t, testProjects, "project-123")
 
@@ -149,14 +162,23 @@ func TestProject_ClearsDefaultService(t *testing.T) {
 		t.Errorf("Expected output to report the cleared default service, got %q", output)
 	}
 	assertStoredProject(t, "project-789")
+	assertServiceIDCleared(t)
+}
 
-	cfg, err := config.LoadForOutput(testConfigDir(t), false, true)
-	if err != nil {
-		t.Fatalf("Failed to load config: %v", err)
+// TestProject_ClearsDefaultService_EmptyServiceIDFlag verifies an explicitly
+// empty --service-id flag can't hide the config-file default from the clearing.
+func TestProject_ClearsDefaultService_EmptyServiceIDFlag(t *testing.T) {
+	setupProjectTest(t, testProjects, "project-123")
+
+	if err := testConfig(t).Set("service_id", "svc1234567"); err != nil {
+		t.Fatalf("Failed to set default service: %v", err)
 	}
-	if cfg.ServiceID != nil {
-		t.Errorf("Expected service_id to be removed from the config file, got %q", *cfg.ServiceID)
+
+	if _, err := executeAuthCommand(t.Context(), "project", "project-456", "--service-id", ""); err != nil {
+		t.Fatalf("Switching projects failed: %v", err)
 	}
+
+	assertServiceIDCleared(t)
 }
 
 // TestProject_DefaultServiceFromEnvironment covers a default service that Unset
@@ -202,7 +224,7 @@ func TestProject_UnknownProject(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected switching to an inaccessible project to fail")
 	}
-	if !strings.Contains(err.Error(), `project "project-does-not-exist" not found or not accessible`) {
+	if !strings.Contains(err.Error(), "requested project not found or not accessible") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 

--- a/internal/cmd/project_test.go
+++ b/internal/cmd/project_test.go
@@ -202,10 +202,6 @@ func TestProject_UnknownProject(t *testing.T) {
 	if !strings.Contains(err.Error(), `project "project-does-not-exist" not found or not accessible`) {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	// The error lists what the user can switch to instead.
-	if !strings.Contains(err.Error(), "Test Project 2 (project-456)") {
-		t.Errorf("Expected error to list accessible projects, got: %v", err)
-	}
 
 	assertExitCode(t, err, common.ExitInvalidParameters)
 

--- a/internal/cmd/project_test.go
+++ b/internal/cmd/project_test.go
@@ -37,9 +37,22 @@ func testOAuthToken() *oauth2.Token {
 	}
 }
 
-// assertStoredProject checks the stored credentials still hold an OAuth session
-// and name the expected project.
-func assertStoredProject(t *testing.T, expectedProjectID string) {
+// storeExpiredOAuthLogin stores an OAuth login for projectID whose access
+// token is expired but still refreshable, so any API request mints a new one.
+func storeExpiredOAuthLogin(t *testing.T, projectID string) {
+	t.Helper()
+
+	expired := testOAuthToken()
+	expired.AccessToken = "stale-access-token"
+	expired.Expiry = time.Now().Add(-time.Hour)
+	if err := testConfig(t).StoreOAuthCredentials(expired, projectID); err != nil {
+		t.Fatalf("Failed to store oauth credentials: %v", err)
+	}
+}
+
+// assertStoredProject checks the stored credentials hold an OAuth session with
+// the mock's tokens and the expected project, returning them for extra checks.
+func assertStoredProject(t *testing.T, expectedProjectID string) *config.Credentials {
 	t.Helper()
 
 	stored, err := testConfig(t).GetStoredCredentials()
@@ -47,17 +60,18 @@ func assertStoredProject(t *testing.T, expectedProjectID string) {
 		t.Fatalf("Failed to get stored credentials: %v", err)
 	}
 	if stored.OAuth == nil {
-		t.Fatalf("Expected OAuth credentials to remain stored, got: %+v", stored)
+		t.Fatalf("Expected OAuth credentials to be stored, got: %+v", stored)
 	}
 	if stored.OAuth.AccessToken != "mock-access-token-12345" {
-		t.Errorf("Expected access token to be preserved, got %q", stored.OAuth.AccessToken)
+		t.Errorf("Expected the mock's access token, got %q", stored.OAuth.AccessToken)
 	}
 	if stored.OAuth.RefreshToken != "mock-refresh-token-67890" {
-		t.Errorf("Expected refresh token to be preserved, got %q", stored.OAuth.RefreshToken)
+		t.Errorf("Expected the mock's refresh token, got %q", stored.OAuth.RefreshToken)
 	}
 	if stored.ProjectID != expectedProjectID {
 		t.Errorf("Expected project ID %q, got %q", expectedProjectID, stored.ProjectID)
 	}
+	return stored
 }
 
 func TestProject_SwitchByArgument(t *testing.T) {
@@ -81,13 +95,7 @@ func TestProject_SwitchByArgument(t *testing.T) {
 // that rotated token rather than the stale copy it read on the way in.
 func TestProject_PreservesRefreshedToken(t *testing.T) {
 	setupProjectTest(t, testProjects, "")
-
-	expired := testOAuthToken()
-	expired.AccessToken = "stale-access-token"
-	expired.Expiry = time.Now().Add(-time.Hour)
-	if err := testConfig(t).StoreOAuthCredentials(expired, "project-123"); err != nil {
-		t.Fatalf("Failed to store oauth credentials: %v", err)
-	}
+	storeExpiredOAuthLogin(t, "project-123")
 
 	if _, err := executeAuthCommand(t.Context(), "project", "project-456"); err != nil {
 		t.Fatalf("Switching projects failed: %v", err)
@@ -110,12 +118,7 @@ func TestProject_SurvivesPostSwitchRefresh(t *testing.T) {
 	mockShortLivedRotatingTokens(t)
 	t.Setenv("TIGER_ANALYTICS", "true")
 
-	expired := testOAuthToken()
-	expired.AccessToken = "stale-access-token"
-	expired.Expiry = time.Now().Add(-time.Hour)
-	if err := testConfig(t).StoreOAuthCredentials(expired, "project-123"); err != nil {
-		t.Fatalf("Failed to store oauth credentials: %v", err)
-	}
+	storeExpiredOAuthLogin(t, "project-123")
 
 	if _, err := executeAuthCommand(t.Context(), "project", "project-456"); err != nil {
 		t.Fatalf("Switching projects failed: %v", err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -82,6 +82,7 @@ tiger auth login
 	cmd.AddCommand(buildUpgradeCmd(app))
 	cmd.AddCommand(buildConfigCmd(app))
 	cmd.AddCommand(buildAuthCmd(app))
+	cmd.AddCommand(buildProjectCmd(app))
 	cmd.AddCommand(buildServiceCmd(app))
 	cmd.AddCommand(buildDbCmd(app))
 	cmd.AddCommand(buildMCPCmd(app))
@@ -132,13 +133,18 @@ func wrapCommands(cmd *cobra.Command, app *common.App, skipUpdateCheck *bool) {
 			defer func() {
 				cfg, client, projectID := app.TryGetAll()
 				a := analytics.New(cfg, client, projectID)
-				a.Track(
-					fmt.Sprintf("Run %s", c.CommandPath()),
-					analytics.Property("args", args), // NOTE: Safe right now, but might need allow-list in the future if some args end up containing sensitive info
+				options := make([]analytics.Option, 0, 4)
+				options = append(options,
 					analytics.Property("elapsed_seconds", time.Since(start).Seconds()),
 					analytics.FlagSet(c.Flags()),
 					analytics.Error(runErr),
 				)
+				// NOTE: Args are safe for most commands; the rest opt out with
+				// analytics.OmitArgsAnnotation.
+				if c.Annotations[analytics.OmitArgsAnnotation] != "true" {
+					options = append(options, analytics.Property("args", args))
+				}
+				a.Track(fmt.Sprintf("Run %s", c.CommandPath()), options...)
 			}()
 
 			return originalRunE(c, args)

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -27,6 +27,17 @@ var (
 	validatedAPIKeyCache = map[string]*api.AuthInfo{}
 )
 
+// EnvAPIKey returns the API key formed from TIGER_PUBLIC_KEY/TIGER_SECRET_KEY,
+// and whether either was set. These take priority over stored credentials.
+func EnvAPIKey() (string, bool) {
+	publicKey := os.Getenv("TIGER_PUBLIC_KEY")
+	secretKey := os.Getenv("TIGER_SECRET_KEY")
+	if publicKey == "" && secretKey == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s:%s", publicKey, secretKey), true
+}
+
 // NewAPIClient initializes a [api.ClientWithResponses] and returns it along
 // with the current project ID. Credentials are pulled from the environment (if
 // present), or loaded from storage (either the keyring or fallback file). When
@@ -37,11 +48,10 @@ var (
 // have already been performed via `tiger auth login`.
 func NewAPIClient(ctx context.Context, cfg *config.Config) (*api.ClientWithResponses, string, error) {
 	// Credentials in the environment take priority
-	publicKey := os.Getenv("TIGER_PUBLIC_KEY")
-	secretKey := os.Getenv("TIGER_SECRET_KEY")
+	apiKey, fromEnv := EnvAPIKey()
 
 	// If there were no credentials in the environment, try to load stored credentials
-	if publicKey == "" && secretKey == "" {
+	if !fromEnv {
 		stored, err := GetStoredCredentials(cfg)
 		if err != nil {
 			return nil, "", ExitWithCode(ExitAuthenticationError, fmt.Errorf("authentication required: %w. Please run 'tiger auth login'", err))
@@ -58,7 +68,6 @@ func NewAPIClient(ctx context.Context, cfg *config.Config) (*api.ClientWithRespo
 	}
 
 	// Create API client
-	apiKey := fmt.Sprintf("%s:%s", publicKey, secretKey)
 	client, err := api.NewTigerClient(cfg, apiKey)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create API client: %w", err)

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -88,6 +88,21 @@ func (c *Config) StoreOAuthCredentials(token *oauth2.Token, projectID string) er
 	})
 }
 
+// SwitchProject repoints the stored login at projectID, keeping its OAuth
+// session. The read and write live together here so a token refreshed in
+// between isn't lost — token and project ID share one record. An API key is
+// scoped to the project it was issued for, so this refuses one.
+func (c *Config) SwitchProject(projectID string) error {
+	creds, err := c.GetStoredCredentials()
+	if err != nil {
+		return err
+	}
+	if creds.OAuth == nil {
+		return fmt.Errorf("stored credentials are an API key, which is scoped to a single project")
+	}
+	return c.StoreOAuthCredentials(creds.OAuth, projectID)
+}
+
 // StoreCredentialsToFile stores credentials to file (test helper)
 func (c *Config) StoreCredentialsToFile(apiKey, projectID string) error {
 	creds := storedCredentials{
@@ -109,8 +124,16 @@ func (c *Config) storeCredentials(creds storedCredentials) error {
 		return fmt.Errorf("failed to marshal credentials: %w", err)
 	}
 
-	if err := storeToKeyring(string(credentialsJSON)); err == nil {
+	keyringErr := storeToKeyring(string(credentialsJSON))
+	if keyringErr == nil {
 		return nil
+	}
+	// loadCredentialsBlob prefers the keyring, so an entry we can read but
+	// not overwrite would shadow the file fallback on every later read.
+	if _, err := keyring.Get(GetServiceName(), keyringUsername); err == nil {
+		if err := keyring.Delete(GetServiceName(), keyringUsername); err != nil {
+			return fmt.Errorf("failed to store credentials in keyring (%v) or to remove the stale keyring entry shadowing the file fallback: %w", keyringErr, err)
+		}
 	}
 	return c.storeToFile(string(credentialsJSON))
 }

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -89,9 +89,8 @@ func (c *Config) StoreOAuthCredentials(token *oauth2.Token, projectID string) er
 }
 
 // SwitchProject repoints the stored login at projectID, keeping its OAuth
-// session. The read and write live together here so a token refreshed in
-// between isn't lost — token and project ID share one record. An API key is
-// scoped to the project it was issued for, so this refuses one.
+// session — read and write sit together so a token refreshed in between isn't
+// lost. An API key is scoped to one project, so this refuses one.
 func (c *Config) SwitchProject(projectID string) error {
 	creds, err := c.GetStoredCredentials()
 	if err != nil {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -127,14 +127,17 @@ func (c *Config) storeCredentials(creds storedCredentials) error {
 	if keyringErr == nil {
 		return nil
 	}
-	// loadCredentialsBlob prefers the keyring, so an entry we can read but
-	// not overwrite would shadow the file fallback on every later read.
+	if err := c.storeToFile(string(credentialsJSON)); err != nil {
+		return err
+	}
+	// A readable-but-unwritable keyring entry would shadow the file just
+	// written; deleted only now so a failure never destroys the sole copy.
 	if _, err := keyring.Get(GetServiceName(), keyringUsername); err == nil {
 		if err := keyring.Delete(GetServiceName(), keyringUsername); err != nil {
 			return fmt.Errorf("failed to store credentials in keyring (%v) or to remove the stale keyring entry shadowing the file fallback: %w", keyringErr, err)
 		}
 	}
-	return c.storeToFile(string(credentialsJSON))
+	return nil
 }
 
 func storeToKeyring(credentials string) error {
@@ -216,14 +219,23 @@ func (c *Config) loadCredentialsBlob() (string, error) {
 
 // RemoveCredentials removes stored credentials from keyring and file fallback
 func (c *Config) RemoveCredentials() error {
-	// Remove from keyring (ignore errors as it might not exist)
-	removeCredentialsFromKeyring()
+	if err := removeCredentialsFromKeyring(); err != nil {
+		return err
+	}
 	return c.removeCredentialsFile()
 }
 
-// removeCredentialsFromKeyring removes credentials from keyring (test helper)
-func removeCredentialsFromKeyring() {
-	keyring.Delete(GetServiceName(), keyringUsername)
+// removeCredentialsFromKeyring deletes the keyring entry. An entry still
+// readable after a failed delete would keep authenticating, so that errors.
+func removeCredentialsFromKeyring() error {
+	err := keyring.Delete(GetServiceName(), keyringUsername)
+	if err == nil {
+		return nil
+	}
+	if _, getErr := keyring.Get(GetServiceName(), keyringUsername); getErr == nil {
+		return fmt.Errorf("failed to remove credentials from keyring: %w", err)
+	}
+	return nil
 }
 
 // removeCredentialsFile removes credentials file

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -132,10 +132,12 @@ func (c *Config) storeCredentials(creds storedCredentials) error {
 	}
 	// A readable-but-unwritable keyring entry would shadow the file just
 	// written; deleted only now so a failure never destroys the sole copy.
-	if _, err := keyring.Get(GetServiceName(), keyringUsername); err == nil {
-		if err := keyring.Delete(GetServiceName(), keyringUsername); err != nil {
-			return fmt.Errorf("failed to store credentials in keyring (%v) or to remove the stale keyring entry shadowing the file fallback: %w", keyringErr, err)
-		}
+	if err := removeCredentialsFromKeyring(); err != nil {
+		// Don't leave the new credentials latent behind the surviving entry:
+		// they'd silently take over whenever the keyring stops being readable.
+		return errors.Join(
+			fmt.Errorf("failed to store credentials in keyring: %w", keyringErr),
+			err, c.removeCredentialsFile())
 	}
 	return nil
 }
@@ -217,19 +219,21 @@ func (c *Config) loadCredentialsBlob() (string, error) {
 	return string(data), nil
 }
 
-// RemoveCredentials removes stored credentials from keyring and file fallback
+// RemoveCredentials removes stored credentials from keyring and file fallback.
+// The file is removed even when the keyring delete fails, so a failed logout
+// never leaves the fallback copy behind.
 func (c *Config) RemoveCredentials() error {
-	if err := removeCredentialsFromKeyring(); err != nil {
-		return err
-	}
-	return c.removeCredentialsFile()
+	return errors.Join(removeCredentialsFromKeyring(), c.removeCredentialsFile())
 }
 
-// removeCredentialsFromKeyring deletes the keyring entry. An entry still
-// readable after a failed delete would keep authenticating, so that errors.
+// removeCredentialsFromKeyring deletes the keyring entry. It errors only when
+// an entry provably survives (still readable) — reads prefer the keyring, so
+// it would keep authenticating. An unreadable backend (no keyring daemon,
+// locked collection) can't serve the entry either, and treating it as fatal
+// would break logout on every keyring-less system.
 func removeCredentialsFromKeyring() error {
 	err := keyring.Delete(GetServiceName(), keyringUsername)
-	if err == nil {
+	if err == nil || errors.Is(err, keyring.ErrNotFound) {
 		return nil
 	}
 	if _, getErr := keyring.Get(GetServiceName(), keyringUsername); getErr == nil {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -220,17 +220,15 @@ func (c *Config) loadCredentialsBlob() (string, error) {
 }
 
 // RemoveCredentials removes stored credentials from keyring and file fallback.
-// The file is removed even when the keyring delete fails, so a failed logout
-// never leaves the fallback copy behind.
+// The file is removed even when the keyring delete fails.
 func (c *Config) RemoveCredentials() error {
 	return errors.Join(removeCredentialsFromKeyring(), c.removeCredentialsFile())
 }
 
-// removeCredentialsFromKeyring deletes the keyring entry. It errors only when
-// an entry provably survives (still readable) — reads prefer the keyring, so
-// it would keep authenticating. An unreadable backend (no keyring daemon,
-// locked collection) can't serve the entry either, and treating it as fatal
-// would break logout on every keyring-less system.
+// removeCredentialsFromKeyring deletes the keyring entry, erroring only when
+// an entry provably survives (still readable — it would keep authenticating).
+// An unreadable backend can't serve the entry either, and treating it as
+// fatal would break logout on every keyring-less system.
 func removeCredentialsFromKeyring() error {
 	err := keyring.Delete(GetServiceName(), keyringUsername)
 	if err == nil || errors.Is(err, keyring.ErrNotFound) {


### PR DESCRIPTION
Adds `tiger project [project-id]` to switch the stored OAuth login between projects, with an interactive picker and a shared project resolution path reused by `auth login --project-id`/`TIGER_PROJECT_ID`.

The `service_id` default is anchored to the project it was set in, so any project change clears it: `tiger project`, `tiger auth login` landing on a different project, and `tiger auth logout` (clearing failures warn rather than fail, since the credential change has already persisted).

Hardening that came out of review:
- Exit codes survive error wrapping: `main.go` extracts `common.ExitCodeError` via `errors.As`, and `launchPsql` converts psql's `*exec.ExitError` into it at the source
- Sensitive values stay out of error messages entirely (the analytics `error` property records error text verbatim); stderr warnings, which analytics never sees, still name them
- Credential writes never destroy the only stored copy: the file fallback is written before a shadowing keyring entry is removed, a failed store removes the file it just wrote, and logout removes the fallback file even when the keyring delete fails
- A token refresh persists under the project stored at write time, so a concurrent `tiger project` switch isn't reverted; a login replaced by an API key isn't overwritten, and a transient keyring read failure doesn't drop a rotated one-time refresh token
- The TIGER_PUBLIC_KEY/TIGER_SECRET_KEY guard runs before client validation so its explanation isn't buried; an ambient TIGER_PROJECT_ID naming an inaccessible project warns and falls back instead of failing an interactive login
- Test hygiene: env isolation (TIGER_PROJECT_ID, TIGER_CONFIG_DIR), race-safe mock token rotation, shared test helpers

Known deferred items: the credentials blob has no cross-process atomic read-modify-write (a concurrent refresh and switch can still race in a microsecond window), and an OAuth-to-OAuth relogin during a long-running command can still be overwritten by that command's token refresh — both need session-identity/locking machinery beyond this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)