### PR TITLE
Simplify shared HTTP client and remove redundant timeouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,10 @@ ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 defer cancel()
 ```
 
+If a request needs a longer timeout, clone `api.HTTPClient` and override its
+`Timeout` rather than building a new `http.Client` from scratch — this keeps
+the User-Agent (see `upgradeHTTPClient` in `internal/cmd/upgrade.go`).
+
 ### Configuration System
 
 The CLI uses a layered configuration approach:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,21 @@ Tiger CLI is a Go-based command-line interface for managing Tiger, the modern da
   - Log fetching with pagination (FetchServiceLogs)
 - **Utilities**: `internal/util/` - Small utility functions with minimal dependencies (formatting, validation, password generation)
 
+### HTTP Requests
+
+All outgoing HTTP requests should use the shared `api.HTTPClient` defined in
+`internal/api/client_util.go`. This client has a built-in 30-second request
+timeout and sets the CLI's User-Agent on every request. `NewTigerClient` and
+`NewTigerClientWithToken` use it automatically. If you need to make HTTP
+requests outside of the API client, use `api.HTTPClient` directly rather than
+`http.DefaultClient` or creating a new `http.Client`.
+
+If a request needs a shorter timeout, set one via the context:
+```go
+ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+defer cancel()
+```
+
 ### Configuration System
 
 The CLI uses a layered configuration approach:

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"sync"
+	"runtime"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -13,38 +13,39 @@ import (
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
-// Shared HTTP client with resource limits to prevent resource exhaustion under load
-var (
-	httpClientOnce   sync.Once
-	sharedHTTPClient *http.Client
-)
+// HTTPClient is the shared HTTP client all outgoing requests should use,
+// giving every request a 30-second timeout and the CLI's User-Agent by
+// default. A call that needs a shorter bound should layer a
+// context.WithTimeout over the call rather than build a separate client; a
+// call that needs a longer one (e.g. downloading a large release archive) is
+// a legitimate reason to use a dedicated client instead.
+var HTTPClient = &http.Client{
+	Timeout:   30 * time.Second,
+	Transport: userAgentTransport{},
+}
 
-// getHTTPClient returns a singleton HTTP client with essential resource limits
-// Focuses on preventing resource leaks while using reasonable Go defaults elsewhere
-func getHTTPClient() *http.Client {
-	httpClientOnce.Do(func() {
-		// Clone default transport to inherit sensible defaults, then customize key settings
-		transport := http.DefaultTransport.(*http.Transport).Clone()
+// userAgentTransport stamps the CLI's User-Agent onto every outgoing request.
+// It's HTTPClient's Transport, so anything built on HTTPClient gets it for
+// free — including a Bearer-authenticated client's requests and its token
+// refreshes, both of which route through this same Transport (see
+// NewTigerClientWithToken).
+type userAgentTransport struct{}
 
-		// Essential resource limits to prevent exhaustion
-		transport.MaxIdleConns = 100                 // Limit total idle connections
-		transport.MaxIdleConnsPerHost = 10           // Limit per-host idle connections
-		transport.IdleConnTimeout = 90 * time.Second // Clean up idle connections
+func (userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", userAgent())
+	return http.DefaultTransport.RoundTrip(req)
+}
 
-		sharedHTTPClient = &http.Client{
-			Transport: transport,
-			Timeout:   30 * time.Second, // Overall request timeout
-		}
-	})
-	return sharedHTTPClient
+// userAgent returns the User-Agent the CLI sends on HTTP requests.
+func userAgent() string {
+	return fmt.Sprintf("tiger-cli/%s (%s/%s)", config.Version, runtime.GOOS, runtime.GOARCH)
 }
 
 // apiKey must be in "publicKey:secretKey" format.
 func NewTigerClient(cfg *config.Config, apiKey string) (*ClientWithResponses, error) {
 	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(apiKey))
-	client, err := NewClientWithResponses(cfg.APIURL, WithHTTPClient(getHTTPClient()), WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
+	client, err := NewClientWithResponses(cfg.APIURL, WithHTTPClient(HTTPClient), WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", authHeader)
-		req.Header.Set("User-Agent", config.UserAgent())
 		return nil
 	}))
 	if err != nil {
@@ -70,8 +71,11 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 		},
 	}
 
-	// Stash our pooled client in the context.
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, getHTTPClient())
+	// Stash our shared client in the context: oauth2 uses it both for token
+	// refresh requests and to seed the Base transport (and Timeout) of the
+	// *http.Client returned by oauth2.NewClient below, so the returned
+	// client's ordinary API requests get our 30s timeout and User-Agent too.
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, HTTPClient)
 
 	var src oauth2.TokenSource = oauthCfg.TokenSource(ctx, token)
 	if persist != nil {
@@ -79,12 +83,8 @@ func NewTigerClientWithToken(cfg *config.Config, token *oauth2.Token, persist fu
 	}
 
 	httpClient := oauth2.NewClient(ctx, src)
-	httpClient.Timeout = 30 * time.Second
 
-	client, err := NewClientWithResponses(cfg.APIURL, WithHTTPClient(httpClient), WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
-		req.Header.Set("User-Agent", config.UserAgent())
-		return nil
-	}))
+	client, err := NewClientWithResponses(cfg.APIURL, WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API client: %w", err)
 	}

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -32,6 +32,7 @@ var HTTPClient = &http.Client{
 type userAgentTransport struct{}
 
 func (userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
 	req.Header.Set("User-Agent", userAgent())
 	return http.DefaultTransport.RoundTrip(req)
 }

--- a/internal/api/client_util_test.go
+++ b/internal/api/client_util_test.go
@@ -2,8 +2,10 @@ package api_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 
 	"github.com/timescale/tiger-cli/internal/api"
@@ -50,7 +52,7 @@ func TestNewTigerClientUserAgent(t *testing.T) {
 	}
 
 	// Verify the User-Agent header was set correctly
-	expectedUserAgent := config.UserAgent()
+	expectedUserAgent := fmt.Sprintf("tiger-cli/%s (%s/%s)", config.Version, runtime.GOOS, runtime.GOARCH)
 	if capturedUserAgent != expectedUserAgent {
 		t.Errorf("Expected User-Agent %q, got %q", expectedUserAgent, capturedUserAgent)
 	}

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -335,14 +335,6 @@ type oauthCallback struct {
 	resultChan    chan<- oauthResult
 }
 
-// userAgentTransport sets the CLI User-Agent on outgoing requests.
-type userAgentTransport struct{}
-
-func (userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", config.UserAgent())
-	return http.DefaultTransport.RoundTrip(req)
-}
-
 func (c *oauthCallback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
@@ -364,9 +356,9 @@ func (c *oauthCallback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The exchange's User-Agent is recorded as the CLI session's user_agent.
-	ctx := context.WithValue(r.Context(), oauth2.HTTPClient,
-		&http.Client{Transport: userAgentTransport{}})
+	// api.HTTPClient already stamps the CLI's User-Agent (recorded server-side
+	// as the session's user_agent) and applies our 30s timeout.
+	ctx := context.WithValue(r.Context(), oauth2.HTTPClient, api.HTTPClient)
 	token, err := c.oauthCfg.Exchange(ctx, code, oauth2.VerifierOption(c.codeVerifier))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/cmd/auth_logout.go
+++ b/internal/cmd/auth_logout.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -56,14 +54,11 @@ func revokeOAuthSession(cmd *cobra.Command, app *common.App, cfg *config.Config)
 	}
 	app.SetClient(client, stored.ProjectID)
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
-	defer cancel()
-
 	body := api.LogoutJSONRequestBody{}
 	if rt := stored.OAuth.RefreshToken; rt != "" {
 		body.RefreshToken = &rt
 	}
-	if _, err := client.LogoutWithResponse(ctx, body); err != nil {
+	if _, err := client.LogoutWithResponse(cmd.Context(), body); err != nil {
 		cmd.PrintErrf("warning: server-side logout failed: %v\n", err)
 	}
 }

--- a/internal/cmd/auth_status.go
+++ b/internal/cmd/auth_status.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -39,10 +37,7 @@ func buildStatusCmd(app *common.App) *cobra.Command {
 			}
 
 			// Make API call to get auth information
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
-			resp, err := client.GetAuthInfoWithResponse(ctx)
+			resp, err := client.GetAuthInfoWithResponse(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("failed to get auth information: %w", err)
 			}

--- a/internal/cmd/completion_helper.go
+++ b/internal/cmd/completion_helper.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -61,10 +59,7 @@ func listServices(cmd *cobra.Command, app *common.App) ([]api.Service, error) {
 	}
 
 	// Make API call to list services
-	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.GetServicesWithResponse(ctx, projectID)
+	resp, err := client.GetServicesWithResponse(cmd.Context(), projectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list services: %w", err)
 	}

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-	"time"
-
 	"github.com/spf13/cobra"
 
 	"github.com/timescale/tiger-cli/internal/api"
@@ -47,9 +44,7 @@ func lookupConnectionTarget(cmd *cobra.Command, app *common.App, args []string) 
 
 	// The API resolves both primary and read replica IDs via GetService; a read
 	// replica comes back linked to its parent, whose credentials it shares.
-	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-	defer cancel()
-	return common.ResolveConnectionTarget(ctx, client, projectID, service)
+	return common.ResolveConnectionTarget(cmd.Context(), client, projectID, service)
 }
 
 // warnReplicaPooler prints the replica pooler-fallback warning to stderr, if
@@ -80,10 +75,7 @@ func getServiceDetails(cmd *cobra.Command, app *common.App, args []string) (api.
 		return api.Service{}, err
 	}
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-	defer cancel()
-
-	service, err := common.GetService(ctx, client, projectID, serviceID)
+	service, err := common.GetService(cmd.Context(), client, projectID, serviceID)
 	if err != nil {
 		return api.Service{}, err
 	}

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -228,9 +228,6 @@ func connectableReplicas(replicas []api.ReadReplicaSet) []api.ReadReplicaSet {
 
 // fetchReplicaSets retrieves the read replica sets for a service.
 func fetchReplicaSets(ctx context.Context, client api.ClientWithResponsesInterface, projectID, serviceID string) ([]api.ReadReplicaSet, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	resp, err := client.GetReplicaSetsWithResponse(ctx, projectID, serviceID)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -172,7 +172,7 @@ func versionCheck(cmd *cobra.Command, cfg *config.Config, skipUpdateCheck bool) 
 	}
 	resultCh := make(chan checkResult, 1)
 	go func() {
-		result, err := version.CheckForUpdate(cfg)
+		result, err := version.CheckForUpdate(cmd.Context(), cfg)
 		resultCh <- checkResult{result: result, err: err}
 	}()
 

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -139,16 +138,13 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			}
 
 			// Make API call to create service
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
 			// All status messages go to stderr
 			if cmd.Flags().Changed("name") {
 				cmd.PrintErrf("🚀 Creating service '%s'...\n", createServiceName)
 			} else {
 				cmd.PrintErrf("🚀 Creating service '%s' (auto-generated name)...\n", createServiceName)
 			}
-			resp, err := client.CreateServiceWithResponse(ctx, projectID, serviceCreateReq)
+			resp, err := client.CreateServiceWithResponse(cmd.Context(), projectID, serviceCreateReq)
 			if err != nil {
 				return fmt.Errorf("failed to create Service: %w", err)
 			}

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -114,9 +113,6 @@ Examples:
 				return err
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
 			// Use provided custom values, validate against allowed combinations
 			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(forkCPU, forkMemory)
 			if err != nil {
@@ -169,7 +165,7 @@ Examples:
 			}
 
 			// Make API call to fork service
-			forkResp, err := client.ForkServiceWithResponse(ctx, projectID, serviceID, forkReq)
+			forkResp, err := client.ForkServiceWithResponse(cmd.Context(), projectID, serviceID, forkReq)
 			if err != nil {
 				return fmt.Errorf("failed to fork Service: %w", err)
 			}

--- a/internal/cmd/service_get.go
+++ b/internal/cmd/service_get.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -53,10 +51,7 @@ Examples:
 			}
 
 			// Make API call to get service details
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
-			resp, err := client.GetServiceWithResponse(ctx, projectID, serviceID)
+			resp, err := client.GetServiceWithResponse(cmd.Context(), projectID, serviceID)
 			if err != nil {
 				return fmt.Errorf("failed to get service details: %w", err)
 			}

--- a/internal/cmd/service_list.go
+++ b/internal/cmd/service_list.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -35,10 +33,7 @@ func buildServiceListCmd(app *common.App) *cobra.Command {
 			}
 
 			// Make API call to list services
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
-			resp, err := client.GetServicesWithResponse(ctx, projectID)
+			resp, err := client.GetServicesWithResponse(cmd.Context(), projectID)
 			if err != nil {
 				return fmt.Errorf("failed to list services: %w", err)
 			}

--- a/internal/cmd/service_logs.go
+++ b/internal/cmd/service_logs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"strings"
 	"time"
 
@@ -83,10 +82,7 @@ Examples:
 			}
 
 			// Fetch logs with pagination support
-			ctx, cancel := context.WithTimeout(cmd.Context(), time.Minute)
-			defer cancel()
-
-			logs, err := common.FetchServiceLogs(ctx, common.FetchServiceLogsArgs{
+			logs, err := common.FetchServiceLogs(cmd.Context(), common.FetchServiceLogsArgs{
 				Client:    client,
 				ProjectID: projectID,
 				ServiceID: serviceID,

--- a/internal/cmd/service_metrics_available_series.go
+++ b/internal/cmd/service_metrics_available_series.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -33,10 +31,7 @@ func buildServiceMetricsAvailableSeriesCmd(app *common.App) *cobra.Command {
 				return err
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
-			resp, err := client.GetServiceMetricsAvailableSeriesWithResponse(ctx, projectID, serviceID)
+			resp, err := client.GetServiceMetricsAvailableSeriesWithResponse(cmd.Context(), projectID, serviceID)
 			if err != nil {
 				return fmt.Errorf("failed to list metric series: %w", err)
 			}

--- a/internal/cmd/service_metrics_series.go
+++ b/internal/cmd/service_metrics_series.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -97,10 +96,7 @@ Examples:
 				body.Filters = &labelFilters
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
-			resp, err := client.GetServiceMetricsSeriesWithResponse(ctx, projectID, serviceID, body)
+			resp, err := client.GetServiceMetricsSeriesWithResponse(cmd.Context(), projectID, serviceID, body)
 			if err != nil {
 				return fmt.Errorf("failed to fetch metric series: %w", err)
 			}

--- a/internal/cmd/service_resize.go
+++ b/internal/cmd/service_resize.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -96,10 +95,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			}
 
 			// Make API call to resize service
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
-
-			resp, err := client.ResizeServiceWithResponse(ctx, projectID, serviceID, resizeReq)
+			resp, err := client.ResizeServiceWithResponse(cmd.Context(), projectID, serviceID, resizeReq)
 			if err != nil {
 				return fmt.Errorf("failed to resize service: %w", err)
 			}

--- a/internal/cmd/service_update_password.go
+++ b/internal/cmd/service_update_password.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -80,8 +78,7 @@ Examples:
 				return fmt.Errorf("cannot use --auto-generate and --new-password together")
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-			defer cancel()
+			ctx := cmd.Context()
 
 			// Fetch service details
 			serviceResp, err := client.GetServiceWithResponse(ctx, projectID, serviceID)

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -20,14 +20,22 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
+	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/common"
 	"github.com/timescale/tiger-cli/internal/version"
 )
 
-// upgradeHTTPClient is used to download release archives and checksums. It uses
-// a generous timeout because release archives are much larger than the small
-// latest.txt fetch performed by the version package's 5s client.
-var upgradeHTTPClient = &http.Client{Timeout: 3 * time.Minute}
+// upgradeHTTPClient is used to download release archives and checksums. It's
+// cloned from api.HTTPClient (so it still sends our User-Agent) with a longer
+// timeout, since release archives are much larger than the small latest.txt
+// fetch performed by the version package's 5s client.
+var upgradeHTTPClient = newUpgradeHTTPClient()
+
+func newUpgradeHTTPClient() *http.Client {
+	client := *api.HTTPClient
+	client.Timeout = 3 * time.Minute
+	return &client
+}
 
 // binaryFilename is the name of the tiger executable inside a release archive
 // (and on disk), with the platform-appropriate extension. Note that the binary

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -95,7 +95,7 @@ func runUpgrade(cmd *cobra.Command, app *common.App, requestedVersion string, fo
 		return err
 	}
 
-	result, err := version.CheckForUpdate(cfg)
+	result, err := version.CheckForUpdate(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to check for latest version: %w", err)
 	}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -46,7 +46,7 @@ func buildVersionCmd(app *common.App) *cobra.Command {
 
 			updateAvailable := false
 			if checkVersion {
-				result, err := version.CheckForUpdate(cfg)
+				result, err := version.CheckForUpdate(cmd.Context(), cfg)
 				if err != nil {
 					// A failed check shouldn't fail the version command; warn and
 					// continue printing the local version info.

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/timescale/tiger-cli/internal/analytics"
 	"github.com/timescale/tiger-cli/internal/api"
@@ -84,9 +83,6 @@ func NewAPIClient(ctx context.Context, cfg *config.Config) (*api.ClientWithRespo
 // analytics. Only PAT credentials reach this path, so the response always
 // carries the apiKey branch.
 func ValidateAPIKey(ctx context.Context, cfg *config.Config, client api.ClientWithResponsesInterface) (*api.AuthInfo, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	resp, err := client.GetAuthInfoWithResponse(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("API call failed: %w", err)
@@ -128,9 +124,6 @@ func IdentifyOAuthUser(ctx context.Context, cfg *config.Config, client api.Clien
 	if !a.Enabled() {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
 
 	resp, err := client.GetAuthInfoWithResponse(ctx)
 	if err != nil || resp.JSON200 == nil || resp.JSON200.Oauth == nil {

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,17 +1,7 @@
 package config
 
-import (
-	"fmt"
-	"runtime"
-)
-
 // These variables are set at build time via ldflags in the GoReleaser pipeline
 // for production releases. Default values are used for local development builds.
 var Version = "dev"
 var BuildTime = "unknown"
 var GitCommit = "unknown"
-
-// UserAgent returns the User-Agent the CLI sends on HTTP requests.
-func UserAgent() string {
-	return fmt.Sprintf("tiger-cli/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
-}

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
@@ -58,8 +59,8 @@ func (s *Server) registerDocsProxy(ctx context.Context) {
 		return
 	}
 
-	// Create timeout for establishing proxy
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	// Create timeout for establishing proxy (matches Ghost)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	proxyClient, err := NewProxyClient(ctx, cfg.DocsMCPURL, s.logger)
@@ -109,7 +110,8 @@ type ProxyClient struct {
 // NewProxyClient creates a new proxy client for the given remote server configuration
 func NewProxyClient(ctx context.Context, url string, logger *slog.Logger) (*ProxyClient, error) {
 	transport := &mcp.StreamableClientTransport{
-		Endpoint: url,
+		Endpoint:   url,
+		HTTPClient: api.HTTPClient,
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{

--- a/internal/mcp/service_create.go
+++ b/internal/mcp/service_create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -143,10 +142,7 @@ func (s *Server) handleServiceCreate(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	// Make API call to create service
-	createCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	resp, err := client.CreateServiceWithResponse(createCtx, projectID, serviceCreateReq)
+	resp, err := client.CreateServiceWithResponse(ctx, projectID, serviceCreateReq)
 	if err != nil {
 		return nil, ServiceCreateOutput{}, fmt.Errorf("failed to create service: %w", err)
 	}

--- a/internal/mcp/service_fork.go
+++ b/internal/mcp/service_fork.go
@@ -155,10 +155,7 @@ func (s *Server) handleServiceFork(ctx context.Context, req *mcp.CallToolRequest
 	}
 
 	// Make API call to fork service
-	forkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	resp, err := client.ForkServiceWithResponse(forkCtx, projectID, input.ServiceID, forkReq)
+	resp, err := client.ForkServiceWithResponse(ctx, projectID, input.ServiceID, forkReq)
 	if err != nil {
 		return nil, ServiceForkOutput{}, fmt.Errorf("failed to fork service: %w", err)
 	}

--- a/internal/mcp/service_get.go
+++ b/internal/mcp/service_get.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -65,9 +64,6 @@ func (s *Server) handleServiceGet(ctx context.Context, req *mcp.CallToolRequest,
 		slog.String("service_id", input.ServiceID))
 
 	// Make API call to get service details
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	resp, err := client.GetServiceWithResponse(ctx, projectID, input.ServiceID)
 	if err != nil {
 		return nil, ServiceGetOutput{}, fmt.Errorf("failed to get service details: %w", err)

--- a/internal/mcp/service_list.go
+++ b/internal/mcp/service_list.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -74,9 +73,6 @@ func (s *Server) handleServiceList(ctx context.Context, req *mcp.CallToolRequest
 	s.logger.Info("MCP: Listing services", slog.String("project_id", projectID))
 
 	// Make API call to list services
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	resp, err := client.GetServicesWithResponse(ctx, projectID)
 	if err != nil {
 		return nil, ServiceListOutput{}, fmt.Errorf("failed to list services: %w", err)

--- a/internal/mcp/service_logs.go
+++ b/internal/mcp/service_logs.go
@@ -90,10 +90,7 @@ func (s *Server) handleServiceLogs(ctx context.Context, req *mcp.CallToolRequest
 	)
 
 	// Fetch logs with pagination support
-	logsCtx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	entries, err := common.FetchServiceLogs(logsCtx, common.FetchServiceLogsArgs{
+	entries, err := common.FetchServiceLogs(ctx, common.FetchServiceLogsArgs{
 		Client:    client,
 		ProjectID: projectID,
 		ServiceID: input.ServiceID,

--- a/internal/mcp/service_metrics_available.go
+++ b/internal/mcp/service_metrics_available.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -61,9 +60,6 @@ func (s *Server) handleServiceMetricsAvailable(ctx context.Context, req *mcp.Cal
 		slog.String("project_id", projectID),
 		slog.String("service_id", input.ServiceID),
 	)
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 
 	resp, err := client.GetServiceMetricsAvailableSeriesWithResponse(ctx, projectID, input.ServiceID)
 	if err != nil {

--- a/internal/mcp/service_metrics_series.go
+++ b/internal/mcp/service_metrics_series.go
@@ -145,9 +145,6 @@ func (s *Server) handleServiceMetricsSeries(ctx context.Context, req *mcp.CallTo
 		body.Filters = &filters
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	resp, err := client.GetServiceMetricsSeriesWithResponse(ctx, projectID, input.ServiceID, body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch metric series: %w", err)

--- a/internal/mcp/service_resize.go
+++ b/internal/mcp/service_resize.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -100,9 +99,6 @@ func (s *Server) handleServiceResize(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	// Make API call to resize service
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	resp, err := client.ResizeServiceWithResponse(ctx, projectID, input.ServiceID, resizeReq)
 	if err != nil {
 		return nil, ServiceResizeOutput{}, fmt.Errorf("failed to resize service: %w", err)

--- a/internal/mcp/service_start.go
+++ b/internal/mcp/service_start.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -78,10 +77,7 @@ func (s *Server) handleServiceStart(ctx context.Context, req *mcp.CallToolReques
 		slog.String("service_id", input.ServiceID))
 
 	// Make API call to start service
-	startCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	resp, err := client.StartServiceWithResponse(startCtx, projectID, input.ServiceID)
+	resp, err := client.StartServiceWithResponse(ctx, projectID, input.ServiceID)
 	if err != nil {
 		return nil, ServiceStartOutput{}, fmt.Errorf("failed to start service: %w", err)
 	}

--- a/internal/mcp/service_stop.go
+++ b/internal/mcp/service_stop.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -78,10 +77,7 @@ func (s *Server) handleServiceStop(ctx context.Context, req *mcp.CallToolRequest
 		slog.String("service_id", input.ServiceID))
 
 	// Make API call to stop service
-	stopCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	resp, err := client.StopServiceWithResponse(stopCtx, projectID, input.ServiceID)
+	resp, err := client.StopServiceWithResponse(ctx, projectID, input.ServiceID)
 	if err != nil {
 		return nil, ServiceStopOutput{}, fmt.Errorf("failed to stop service: %w", err)
 	}

--- a/internal/mcp/service_update_password.go
+++ b/internal/mcp/service_update_password.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -79,9 +78,6 @@ func (s *Server) handleServiceUpdatePassword(ctx context.Context, req *mcp.CallT
 	updateReq := api.UpdatePasswordInput{
 		Password: input.Password,
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 
 	// Fetch first so we can reject read replicas and reuse the service for
 	// password storage below.

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/cli/safeexec"
 	"github.com/fatih/color"
+	"github.com/timescale/tiger-cli/internal/api"
 	"github.com/timescale/tiger-cli/internal/config"
 	"github.com/timescale/tiger-cli/internal/util"
 )
@@ -39,13 +41,18 @@ type CheckResult struct {
 	UpdateCommand   string
 }
 
-// FetchLatestVersion downloads the latest version string from the given URL
-func fetchLatestVersion(checkURL string) (string, error) {
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-	}
+// FetchLatestVersion downloads the latest version string from the given URL.
+// Bounded to 5 seconds (shorter than api.HTTPClient's default) since this
+// runs in the background on every command invocation and shouldn't be felt.
+func fetchLatestVersion(ctx context.Context, checkURL string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 
-	resp, err := client.Get(checkURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checkURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build request: %w", err)
+	}
+	resp, err := api.HTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch latest version: %w", err)
 	}
@@ -181,8 +188,8 @@ func getUpdateCommand(method InstallMethod) string {
 	}
 }
 
-func checkVersionForUpdate(version string, cfg *config.Config) (*CheckResult, error) {
-	latestVersion, err := fetchLatestVersion(cfg.ReleasesURL + "/latest.txt")
+func checkVersionForUpdate(ctx context.Context, version string, cfg *config.Config) (*CheckResult, error) {
+	latestVersion, err := fetchLatestVersion(ctx, cfg.ReleasesURL+"/latest.txt")
 	if err != nil {
 		return nil, err
 	}
@@ -214,8 +221,8 @@ func checkVersionForUpdate(version string, cfg *config.Config) (*CheckResult, er
 // Note: CheckResult.LatestVersion has its leading "v" trimmed (for display and
 // comparison). Callers that need the release tag used in download paths (e.g.
 // releases/v1.2.3/) must re-add the "v" prefix.
-func CheckForUpdate(cfg *config.Config) (*CheckResult, error) {
-	return checkVersionForUpdate(config.Version, cfg)
+func CheckForUpdate(ctx context.Context, cfg *config.Config) (*CheckResult, error) {
+	return checkVersionForUpdate(ctx, config.Version, cfg)
 }
 
 // PrintUpdateWarning writes a warning to output if an update is available.

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -233,7 +234,7 @@ func TestFetchLatestVersion(t *testing.T) {
 			defer server.Close()
 
 			// Test fetchLatestVersion
-			got, err := fetchLatestVersion(server.URL)
+			got, err := fetchLatestVersion(context.Background(), server.URL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fetchLatestVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -285,7 +286,7 @@ func TestCheckForUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := checkVersionForUpdate(tt.currentVersion, cfg)
+			result, err := checkVersionForUpdate(context.Background(), tt.currentVersion, cfg)
 			if err != nil {
 				t.Errorf("checkVersionForUpdate() error = %v", err)
 				return


### PR DESCRIPTION
## Summary

Our custom HTTP client already enforces a 30-second timeout on every outgoing API request, which made a lot of the `context.WithTimeout(ctx, 30*time.Second)` calls sprinkled through commands and MCP tools redundant — they were just re-imposing a limit the client already had. This PR cleans that up and consolidates how we build and share HTTP clients, using Ghost's approach as a reference point throughout.

## What changed

- **Removed redundant timeouts.** Dropped ~20 `context.WithTimeout(ctx, 30*time.Second)` calls that were wrapping single API calls already covered by the client's own timeout.
- **Simplified the shared HTTP client's transport settings.** Two of the three custom settings (`MaxIdleConns`, `IdleConnTimeout`) were just restating Go's own default values, so they weren't doing anything. The third (`MaxIdleConnsPerHost`) was quietly set higher than Go's default (10 vs. the built-in default of 2) despite its comment claiming to "limit" it, but this wasn't really buying us anything anyways (we don't make a lot of concurrent requests to the same host, and definitely don't need to keep 10 idle connections open). We removed all three and now just rely on Go's defaults.
- **Simplified how the shared client is constructed**, dropping the `sync.Once`-based lazy construction in favor of a plain package variable.
- **Consolidated the CLI's User-Agent header** into one place (the shared client), rather than setting it separately in a couple of different spots. `tiger upgrade`'s release/checksum downloader needs a longer timeout than the shared client allows, so it now clones the shared client and overrides just the timeout, rather than building an entirely separate client that would've missed out on the User-Agent.
- **Widened a couple of timeouts that were arbitrarily shorter** than the client's default (10s) with no real reason to be, so they're no longer unnecessarily prone to premature timeouts (and just to keep things consistent throughout for simplicity's sake).
- **Extended the shared client to a couple of other call sites** (the docs MCP proxy connection, the version-update check) that were previously making HTTP requests through their own separate, ad hoc clients.
- **Updated CLAUDE.md** with a short section describing this pattern, so future work follows it automatically.

## Why

Mainly to cut down on repetitive, easy-to-get-wrong boilerplate and make our HTTP client behavior more consistent and predictable across the codebase — one shared client with one well-understood timeout, rather than each call site making its own (often copy-pasted) decision.