### PR TITLE
Add tiger project list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Tiger CLI provides the following commands:
   - `logout` - Log out from your Tiger account
   - `status` - Show current authentication status and project ID (alias: `whoami`)
 - `tiger project` - Project management
+  - `list` - List all projects you have access to, marking the active one (alias: `ls`)
   - `use` - Switch the active project (requires an OAuth login; clears the default `service_id`, since it belonged to the previous project) (alias: `switch`)
 - `tiger service` - Service lifecycle management (aliases: `services`, `svc`)
   - `list` - List all services (alias: `ls`)

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -13,6 +13,7 @@ func buildProjectCmd(app *common.App) *cobra.Command {
 		Long:  `Manage Tiger Cloud projects.`,
 	}
 
+	cmd.AddCommand(buildProjectListCmd(app))
 	cmd.AddCommand(buildProjectUseCmd(app))
 
 	return cmd

--- a/internal/cmd/project_list.go
+++ b/internal/cmd/project_list.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/timescale/tiger-cli/internal/api"
+	"github.com/timescale/tiger-cli/internal/common"
+	"github.com/timescale/tiger-cli/internal/util"
+)
+
+// OutputProject is a project plus the locally-derived fields the API doesn't
+// return.
+type OutputProject struct {
+	api.Project
+
+	// Current reports whether this is the active project, i.e. the one
+	// subsequent commands operate on.
+	Current bool `json:"current"`
+}
+
+// buildProjectListCmd represents the list command under project
+func buildProjectListCmd(app *common.App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all projects",
+		Long: `List the Tiger Cloud projects you have access to.
+
+The active project — the one subsequent commands operate on — is marked in the
+output. Use 'tiger project use' to switch to another one.`,
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		SilenceUsage:      true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, client, projectID, err := app.GetAll()
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetProjectsWithResponse(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("failed to list projects: %w", err)
+			}
+
+			if resp.StatusCode() != http.StatusOK {
+				return common.ExitWithErrorFromStatusCode(resp.StatusCode(), resp.JSON4XX)
+			}
+
+			if resp.JSON200 == nil {
+				return fmt.Errorf("empty response from API")
+			}
+			projects := *resp.JSON200
+
+			return outputProjects(cmd, projects, projectID, cfg.Output)
+		},
+	}
+
+	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")
+
+	return cmd
+}
+
+// outputProjects formats and outputs the projects list based on the specified format
+func outputProjects(cmd *cobra.Command, projects []api.Project, currentProjectID string, format string) error {
+	outputProjects := prepareProjectsForOutput(projects, currentProjectID)
+
+	outputWriter := cmd.OutOrStdout()
+
+	switch strings.ToLower(format) {
+	case "json":
+		return util.SerializeToJSON(outputWriter, outputProjects)
+	case "yaml":
+		return util.SerializeToYAML(outputWriter, outputProjects)
+	case "env":
+		// Not reachable through --output (outputFlag rejects it at parse time),
+		// but TIGER_OUTPUT and the config file aren't validated on load.
+		return fmt.Errorf("environment variable output is not supported for multiple projects")
+	default: // table format (default)
+		return outputProjectsTable(outputProjects, outputWriter)
+	}
+}
+
+// prepareProjectsForOutput marks the active project among the ones listed
+func prepareProjectsForOutput(projects []api.Project, currentProjectID string) []OutputProject {
+	prepared := make([]OutputProject, len(projects))
+	for i, project := range projects {
+		prepared[i] = OutputProject{
+			Project: project,
+			Current: project.ID == currentProjectID,
+		}
+	}
+	return prepared
+}
+
+// outputProjectsTable outputs projects in a formatted table using tablewriter
+func outputProjectsTable(projects []OutputProject, output io.Writer) error {
+	table := tablewriter.NewWriter(output)
+	table.Header("CURRENT", "PROJECT ID", "NAME")
+
+	for _, project := range projects {
+		current := ""
+		if project.Current {
+			current = "*"
+		}
+		table.Append(current, project.ID, project.Name)
+	}
+
+	return table.Render()
+}

--- a/internal/cmd/project_list.go
+++ b/internal/cmd/project_list.go
@@ -101,14 +101,14 @@ func prepareProjectsForOutput(projects []api.Project, currentProjectID string) [
 // outputProjectsTable outputs projects in a formatted table using tablewriter
 func outputProjectsTable(projects []OutputProject, output io.Writer) error {
 	table := tablewriter.NewWriter(output)
-	table.Header("CURRENT", "PROJECT ID", "NAME")
+	table.Header("PROJECT ID", "NAME", "CURRENT")
 
 	for _, project := range projects {
 		current := ""
 		if project.Current {
 			current = "*"
 		}
-		table.Append(current, project.ID, project.Name)
+		table.Append(project.ID, project.Name, current)
 	}
 
 	return table.Render()

--- a/internal/cmd/project_list_test.go
+++ b/internal/cmd/project_list_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/timescale/tiger-cli/internal/api"
+)
+
+func TestProjectList_Table(t *testing.T) {
+	setupProjectTest(t, []api.Project{
+		{ID: "project-old", Name: "Old Project"},
+		{ID: "project-new", Name: "New Project"},
+	}, "project-old", "")
+
+	output, err := executeAuthCommand(t.Context(), "project", "list")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	for _, want := range []string{"CURRENT", "PROJECT ID", "NAME", "project-old", "Old Project", "project-new", "New Project"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("Expected output to contain %q, got: %q", want, output)
+		}
+	}
+
+	// Only the active project is marked.
+	for line := range strings.SplitSeq(output, "\n") {
+		if !strings.Contains(line, "project-old") && !strings.Contains(line, "project-new") {
+			continue
+		}
+		marked := strings.Contains(line, "*")
+		if strings.Contains(line, "project-old") && !marked {
+			t.Errorf("Expected the active project to be marked, got: %q", line)
+		}
+		if strings.Contains(line, "project-new") && marked {
+			t.Errorf("Expected non-active project to be unmarked, got: %q", line)
+		}
+	}
+}
+
+func TestProjectList_JSON(t *testing.T) {
+	setupProjectTest(t, []api.Project{
+		{ID: "project-old", Name: "Old Project"},
+		{ID: "project-new", Name: "New Project"},
+	}, "project-new", "")
+
+	output, err := executeAuthCommand(t.Context(), "project", "list", "--output", "json")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	var projects []OutputProject
+	if err := json.Unmarshal([]byte(output), &projects); err != nil {
+		t.Fatalf("Failed to parse JSON output %q: %v", output, err)
+	}
+
+	if len(projects) != 2 {
+		t.Fatalf("Expected 2 projects, got %d: %+v", len(projects), projects)
+	}
+	if projects[0].ID != "project-old" || projects[0].Current {
+		t.Errorf("Unexpected first project: %+v", projects[0])
+	}
+	if projects[1].ID != "project-new" || !projects[1].Current {
+		t.Errorf("Unexpected second project: %+v", projects[1])
+	}
+}
+
+func TestProjectList_Alias(t *testing.T) {
+	setupProjectTest(t, []api.Project{
+		{ID: "project-old", Name: "Old Project"},
+	}, "project-old", "")
+
+	output, err := executeAuthCommand(t.Context(), "project", "ls")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if !strings.Contains(output, "project-old") {
+		t.Errorf("Expected project in output, got: %q", output)
+	}
+}
+
+func TestProjectList_EnvFormatRejected(t *testing.T) {
+	setupProjectTest(t, []api.Project{
+		{ID: "project-old", Name: "Old Project"},
+	}, "project-old", "")
+	// --output rejects env at parse time, but TIGER_OUTPUT isn't validated on load.
+	t.Setenv("TIGER_OUTPUT", "env")
+
+	_, err := executeAuthCommand(t.Context(), "project", "list")
+	if err == nil {
+		t.Fatal("Expected error for env output format")
+	}
+	if !strings.Contains(err.Error(), "environment variable output is not supported for multiple projects") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestProjectList_NotLoggedIn(t *testing.T) {
+	setupAuthTest(t)
+
+	_, err := executeAuthCommand(t.Context(), "project", "list")
+	if err == nil {
+		t.Fatal("Expected error when not logged in")
+	}
+	if !strings.Contains(err.Error(), "authentication required") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
  `tiger project list` shows the projects the caller has access to, marking the active one. It follows tiger service list: NoArgs, and an `ls` alias.

  The /projects response carries only an id and a name per project, so a bare list gives no way to tell which one subsequent commands operate on. `OutputProject` wraps `api.Project` with a locally-derived. Current field, set by comparing each id against the project ID the App already resolved when it built the API client — no extra lookup, so the marked row is by construction the project every other command in the same invocation targets. It renders as a * in the CURRENT column and as "current": true in JSON and YAML, so all three formats agree.

  No MCP counterpart here: tiger project has no MCP surface today, and project use is deliberately excluded from it. A read-only `project_list` tool would be safe to add later, since it switches nothing.

