### PR TITLE
Device code login auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tiger mcp install
 Tiger CLI provides the following commands:
 
 - `tiger auth` - Authentication management
-  - `login` - Log in to your Tiger account
+  - `login` - Log in to your Tiger account (use `--headless` to authorize with a short code in a browser on any machine)
   - `logout` - Log out from your Tiger account
   - `status` - Show current authentication status and project ID (alias: `whoami`)
 - `tiger project` - Project management

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -497,12 +497,12 @@ func (l *oauthLogin) getTokenViaBrowser(ctx context.Context) (*oauth2.Token, err
 	l.cmd.PrintErrf("Auth URL is: %s\n", authURL)
 	l.cmd.PrintErrln("Opening browser for authentication...")
 
-	if err := openBrowser(authURL); err != nil {
-		l.cmd.PrintErrf("Failed to open browser: %s\n", err)
-		return nil, errBrowserOpenFailed
-	}
+	browserErr := openBrowserAsync(authURL)
 
 	select {
+	case err := <-browserErr:
+		l.cmd.PrintErrf("Failed to open browser: %s\n", err)
+		return nil, errBrowserOpenFailed
 	case result := <-server.resultChan:
 		return result.token, result.err
 	case <-time.After(browserAuthTimeout):
@@ -723,6 +723,11 @@ func (c *oauthCallback) sendError(err error) {
 	c.resultChan <- oauthResult{err: err}
 }
 
+// openBrowserImpl waits for the launcher to exit, which is how a browser that
+// can't be opened at all -- xdg-open with no display, say -- reports itself
+// rather than looking like a success. It usually exits as soon as the page is
+// handed off, but some Linux configurations keep it running for the life of the
+// browser, so call it through openBrowserAsync rather than directly.
 func openBrowserImpl(url string) error {
 	var cmd *exec.Cmd
 
@@ -736,7 +741,24 @@ func openBrowserImpl(url string) error {
 		cmd = exec.Command("xdg-open", url)
 	}
 
-	return cmd.Start()
+	return cmd.Run()
+}
+
+// openBrowserAsync opens the URL in a goroutine and returns a channel that
+// receives an error if the launcher fails. It exists so the login can wait for
+// the callback and for a failure to open at the same time, without blocking on
+// a launcher that runs for the life of the browser.
+func openBrowserAsync(url string) <-chan error {
+	errCh := make(chan error, 1)
+	// Read the var before the goroutine starts, so a test restoring it in
+	// t.Cleanup doesn't race this call.
+	open := openBrowser
+	go func() {
+		if err := open(url); err != nil {
+			errCh <- err
+		}
+	}()
+	return errCh
 }
 
 func (l *oauthLogin) selectProjectID(ctx context.Context, client *api.ClientWithResponses) (string, error) {

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -47,6 +47,19 @@ func nextSteps(readOnlySet bool) string {
 	return nextStepsMessage + readOnlyNextStep
 }
 
+// browserAuthTimeout is how long the redirect flow waits for the callback.
+const browserAuthTimeout = 5 * time.Minute
+
+var (
+	// defaultDeviceCodeTTL bounds polling when the gateway omits expires_in.
+	// Overridden in tests.
+	defaultDeviceCodeTTL = 15 * time.Minute
+)
+
+// errBrowserOpenFailed means the redirect flow never started, which is the one
+// condition the device code stands in for.
+var errBrowserOpenFailed = errors.New("failed to open browser")
+
 var (
 	// openBrowser can be overridden for testing
 	openBrowser = openBrowserImpl
@@ -63,6 +76,7 @@ type credentials struct {
 func buildLoginCmd(app *common.App) *cobra.Command {
 	var flags credentials
 	var projectID string
+	var headless bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -74,6 +88,9 @@ The OAuth flow will:
 - Open your browser for authentication
 - Let you select a project (if you have multiple)
 - Store an OAuth session for the selected project
+
+If the browser cannot be opened, the command prints a short code to enter in a browser on
+any other machine instead. Use --headless to go straight to that flow.
 
 Use --project-id to pick the project up front and skip the interactive selection. After
 logging in, you can switch projects with 'tiger project use'.
@@ -93,6 +110,9 @@ Examples:
 
   # OAuth login without the interactive project selection
   tiger auth login --project-id my-project-id
+
+  # Login from a machine the browser redirect cannot reach (SSH session, container)
+  tiger auth login --headless
 
   # Login with keys (project ID will be auto-detected)
   tiger auth login --public-key your-public-key --secret-key your-secret-key
@@ -122,12 +142,14 @@ Examples:
 
 			if creds.publicKey == "" && creds.secretKey == "" {
 				l := &oauthLogin{
-					cfg:        cfg,
-					authURL:    cfg.ConsoleURL + "/oauth/authorize",
-					tokenURL:   cfg.GatewayURL + "/idp/external/cli/token",
-					successURL: cfg.ConsoleURL + "/oauth/code/success",
-					projectID:  projectID,
-					cmd:        cmd,
+					cfg:           cfg,
+					authURL:       cfg.ConsoleURL + "/oauth/authorize",
+					tokenURL:      cfg.GatewayURL + "/idp/external/cli/token",
+					deviceCodeURL: cfg.GatewayURL + "/idp/external/cli/device/code",
+					successURL:    cfg.ConsoleURL + "/oauth/code/success",
+					headless:      headless,
+					projectID:     projectID,
+					cmd:           cmd,
 				}
 
 				token, client, projectID, err := l.loginWithOAuth(cmd.Context())
@@ -186,6 +208,7 @@ Examples:
 	cmd.Flags().StringVar(&flags.publicKey, "public-key", "", "Public key for authentication")
 	cmd.Flags().StringVar(&flags.secretKey, "secret-key", "", "Secret key for authentication")
 	cmd.Flags().StringVar(&projectID, "project-id", "", "Project ID to log in to (skips interactive project selection)")
+	cmd.Flags().BoolVar(&headless, "headless", false, "Authorize by entering a code in a browser on any machine, instead of waiting for a redirect back to this one")
 
 	return cmd
 }
@@ -396,12 +419,14 @@ func promptForCredentials(cmd *cobra.Command, consoleURL string, creds credentia
 }
 
 type oauthLogin struct {
-	cfg        *config.Config
-	authURL    string
-	tokenURL   string
-	successURL string
-	projectID  string // from --project-id; empty means select interactively
-	cmd        *cobra.Command
+	cfg           *config.Config
+	authURL       string
+	tokenURL      string
+	deviceCodeURL string
+	successURL    string
+	headless      bool   // go straight to the device flow
+	projectID     string // from --project-id; empty means select interactively
+	cmd           *cobra.Command
 }
 
 func (l *oauthLogin) loginWithOAuth(ctx context.Context) (*oauth2.Token, *api.ClientWithResponses, string, error) {
@@ -426,6 +451,30 @@ func (l *oauthLogin) loginWithOAuth(ctx context.Context) (*oauth2.Token, *api.Cl
 }
 
 func (l *oauthLogin) getOAuthToken(ctx context.Context) (*oauth2.Token, error) {
+	if l.headless {
+		return l.getTokenViaDeviceFlow(ctx)
+	}
+	token, err := l.getTokenViaBrowser(ctx)
+	if errors.Is(err, errBrowserOpenFailed) {
+		l.cmd.PrintErrln("Falling back to device authorization...")
+		return l.getTokenViaDeviceFlow(ctx)
+	}
+	return token, err
+}
+
+// getTokenViaDeviceFlow authorizes with a code the user enters in a browser on
+// any machine, for when this one has no browser to redirect back from.
+func (l *oauthLogin) getTokenViaDeviceFlow(ctx context.Context) (*oauth2.Token, error) {
+	oauthCfg, da, err := l.startDeviceAuth(ctx)
+	if err != nil {
+		return nil, common.ExitWithCode(common.ExitAuthenticationError, err)
+	}
+	return l.pollDeviceToken(ctx, oauthCfg, da)
+}
+
+// getTokenViaBrowser runs the redirect flow. An open browser owns the login
+// until it finishes: that is where the user is authorizing.
+func (l *oauthLogin) getTokenViaBrowser(ctx context.Context) (*oauth2.Token, error) {
 	codeVerifier := oauth2.GenerateVerifier()
 
 	// Random state guards against CSRF on the OAuth callback.
@@ -447,18 +496,116 @@ func (l *oauthLogin) getOAuthToken(ctx context.Context) (*oauth2.Token, error) {
 	authURL := server.oauthCfg.AuthCodeURL(state, oauth2.S256ChallengeOption(codeVerifier))
 	l.cmd.PrintErrf("Auth URL is: %s\n", authURL)
 	l.cmd.PrintErrln("Opening browser for authentication...")
+
 	if err := openBrowser(authURL); err != nil {
-		l.cmd.PrintErrf("Failed to open browser: %s\nPlease manually navigate to the Auth URL.", err)
+		l.cmd.PrintErrf("Failed to open browser: %s\n", err)
+		return nil, errBrowserOpenFailed
 	}
 
 	select {
 	case result := <-server.resultChan:
 		return result.token, result.err
-	case <-time.After(5 * time.Minute):
-		return nil, fmt.Errorf("authorization timeout - no callback received within 5 minutes")
+	case <-time.After(browserAuthTimeout):
+		return nil, fmt.Errorf("authorization timeout - no callback received within %v", browserAuthTimeout)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// deviceFlowContext installs api.HTTPClient for the device flow's oauth2
+// requests: it stamps the CLI User-Agent and applies our 30s timeout.
+func deviceFlowContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, api.HTTPClient)
+}
+
+// startDeviceAuth asks the gateway for a code pair and tells the user where
+// to enter the short one. The redeemable device_code stays in this process.
+func (l *oauthLogin) startDeviceAuth(ctx context.Context) (oauth2.Config, *oauth2.DeviceAuthResponse, error) {
+	oauthCfg := oauth2.Config{
+		ClientID: config.TigerCLIClientID,
+		Endpoint: oauth2.Endpoint{
+			DeviceAuthURL: l.deviceCodeURL,
+			// Same endpoint as the redirect flow, different grant type.
+			TokenURL:  l.tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	da, err := oauthCfg.DeviceAuth(deviceFlowContext(ctx))
+	if err != nil {
+		return oauth2.Config{}, nil, fmt.Errorf("failed to start device authorization: %w", err)
+	}
+
+	// DeviceAccessToken derives its polling deadline only from a non-zero
+	// Expiry, so a gateway that omits expires_in would be polled forever.
+	if da.Expiry.IsZero() {
+		da.Expiry = time.Now().Add(defaultDeviceCodeTTL)
+	}
+
+	l.cmd.PrintErrf("\nTo authenticate, visit: %s\nand enter code: %s\n\n", da.VerificationURI, da.UserCode)
+	l.cmd.PrintErrln("Waiting for authorization (this can take a few seconds after you enter the code)...")
+
+	return oauthCfg, da, nil
+}
+
+// pollDeviceToken waits for the authorization to be decided. DeviceAccessToken
+// polls on its own and returns only once the gateway has answered either way
+// or the codes have expired.
+func (l *oauthLogin) pollDeviceToken(ctx context.Context, oauthCfg oauth2.Config, da *oauth2.DeviceAuthResponse) (*oauth2.Token, error) {
+	token, err := oauthCfg.DeviceAccessToken(deviceFlowContext(ctx), da)
+	if err == nil {
+		return token, nil
+	}
+
+	// A non-2XX with an unparseable body is a RetrieveError too, so the error
+	// code, not the type, marks a verdict.
+	if retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
+		if isServerFailure(retrieveErr) {
+			return nil, common.ExitWithCode(common.ExitAuthenticationError,
+				errors.New("the authorization service is unavailable - try again in a moment"))
+		}
+		if retrieveErr.ErrorCode != "" {
+			return nil, deviceAuthFailure(retrieveErr.ErrorCode, retrieveErr.ErrorDescription)
+		}
+	}
+	// The codes ran out. Asking the clock, rather than reading it off the
+	// error: a request that times out on its own reports the same thing.
+	if !time.Now().Before(da.Expiry) {
+		return nil, deviceAuthFailure("expired_token", "")
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return nil, common.ExitWithCode(common.ExitAuthenticationError,
+		fmt.Errorf("failed to check authorization: %w", err))
+}
+
+// isServerFailure reports whether a reply came back 5xx: a failure to answer
+// rather than a verdict, whether or not an OAuth error code came with it.
+func isServerFailure(err *oauth2.RetrieveError) bool {
+	return err.Response != nil && err.Response.StatusCode >= http.StatusInternalServerError
+}
+
+// deviceAuthFailure turns the server's OAuth error into what the user sees.
+// All of these are terminal, and a fresh code is the fix for every one.
+func deviceAuthFailure(code, description string) error {
+	var msg string
+	switch code {
+	case "expired_token":
+		msg = "the code expired before it was authorized"
+	case "access_denied":
+		msg = "the authorization request was denied"
+	case "invalid_request", "invalid_grant":
+		// FusionAuth's answer for a code already redeemed, or never issued.
+		msg = "the code is no longer valid"
+	default:
+		msg = "authorization failed: " + code
+		if description != "" {
+			msg = "authorization failed: " + description
+		}
+	}
+	return common.ExitWithCode(common.ExitAuthenticationError,
+		errors.New(msg+" - run 'tiger auth login' again for a new code"))
 }
 
 func (l *oauthLogin) generateRandomState(length int) (string, error) {

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,6 +43,7 @@ func TestAuthLoginCmd(t *testing.T) {
 		{ID: "project-789", Name: "Test Project 3"},
 	})
 	noProjects := startMockOAuthServer(t, []api.Project{})
+	staleStateErr := "failed to authenticate via OAuth: invalid state parameter"
 	oauthOpts := func(serverURL string, extra ...runOption) []runOption {
 		return append([]runOption{
 			withConfig(oauthURLs(serverURL)),
@@ -167,6 +169,16 @@ func TestAuthLoginCmd(t *testing.T) {
 			wantStdout: "Successfully logged in (project: project-123)\n" + nextSteps(true),
 			wantStderr: matchOAuthStderr(singleProject.URL, ""),
 			checks:     []checkFunc{checkStoredOAuthCredentials("project-123")},
+		},
+		{
+			// A callback that isn't ours -- a stale tab from an earlier login --
+			// is refused, and the login ends rather than accepting its code.
+			name:       "callback with a stale state is refused",
+			args:       []string{"auth", "login"},
+			opts:       []runOption{withConfig(oauthURLs(singleProject.URL)), withOpenBrowser(callbackWithBadState(t))},
+			wantErr:    staleStateErr,
+			wantStderr: matchOAuthStderr(singleProject.URL, regexp.QuoteMeta("Error: "+staleStateErr+"\n")),
+			checks:     []checkFunc{checkNoStoredCredentials},
 		},
 		{
 			// The picker only runs on a TTY.
@@ -505,6 +517,23 @@ func mockOpenBrowser(t *testing.T) func(string) error {
 	}
 }
 
+// callbackWithBadState answers the auth URL with a callback carrying the wrong
+// state, as a stale tab from an earlier login does.
+func callbackWithBadState(t *testing.T) func(string) error {
+	t.Helper()
+	return func(authURL string) error {
+		parsed, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Get(parsed.Query().Get("redirect_uri") + "?code=test-auth-code&state=stale")
+		if err != nil {
+			return fmt.Errorf("callback request failed: %w", err)
+		}
+		return resp.Body.Close()
+	}
+}
+
 // withSelectReadOnlyMode stubs the post-login read-only menu to return the
 // given answer (chose=false means dismissed without choosing).
 func withSelectReadOnlyMode(mode config.ReadOnlyMode, chose bool) runOption {
@@ -644,4 +673,336 @@ func TestReadOnlyModel_KeySelection(t *testing.T) {
 			}
 		})
 	}
+}
+
+// deviceReply is one canned token-endpoint response for a device poll.
+type deviceReply struct {
+	status int
+	// body is marshalled as JSON; nil sends a short text body instead.
+	body map[string]any
+}
+
+var (
+	devicePending = deviceReply{
+		status: http.StatusBadRequest,
+		body: map[string]any{
+			"error":             "authorization_pending",
+			"error_description": "The authorization request is still pending.",
+		},
+	}
+	deviceExpired = deviceReply{
+		status: http.StatusBadRequest,
+		body: map[string]any{
+			"error":             "expired_token",
+			"error_description": "The device code has expired.",
+		},
+	}
+	// FusionAuth's answer for a code already redeemed, or never issued.
+	deviceConsumed = deviceReply{
+		status: http.StatusBadRequest,
+		body: map[string]any{
+			"error":             "invalid_request",
+			"error_description": "invalid_device_code",
+		},
+	}
+	// A 502 with a non-OAuth body: a 5xx is terminal whether or not an OAuth
+	// error came with it.
+	deviceBadGateway = deviceReply{status: http.StatusBadGateway}
+	// A 429: neither a verdict nor a 5xx, so it has no message of its own.
+	deviceRateLimited = deviceReply{status: http.StatusTooManyRequests}
+	// An OAuth-shaped 500: the error code describes a failure to answer, not a
+	// verdict on the device flow.
+	deviceServerError = deviceReply{
+		status: http.StatusInternalServerError,
+		body: map[string]any{
+			"error":             "server_error",
+			"error_description": "Failed to exchange device code",
+		},
+	}
+	deviceTokens = deviceReply{
+		status: http.StatusOK,
+		body: map[string]any{
+			"access_token":  "mock-access-token-12345",
+			"refresh_token": "mock-refresh-token-67890",
+			"expires_in":    3600,
+		},
+	}
+)
+
+// deviceVerificationURI is what the mock code endpoint reports.
+const deviceVerificationURI = "https://console.example.com/oauth/device"
+
+// deviceInstructions is the device flow's stderr.
+const deviceInstructions = "\nTo authenticate, visit: " + deviceVerificationURI + "\n" +
+	"and enter code: K7QP3XVR\n\n" +
+	"Waiting for authorization (this can take a few seconds after you enter the code)...\n"
+
+// startMockDeviceServer backs the device flow: the code endpoint, the token
+// endpoint (answering polls from replies in order, the last repeating), and
+// the project listing. expiresIn becomes DeviceAccessToken's deadline, so a
+// small value exercises a code that runs out on its own.
+func startMockDeviceServer(t *testing.T, projects []api.Project, expiresIn int, replies ...deviceReply) *httptest.Server {
+	t.Helper()
+
+	var mu sync.Mutex
+	polls := 0
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /idp/external/cli/device/code", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "failed to parse form", http.StatusBadRequest)
+			return
+		}
+		if got := r.FormValue("client_id"); got != config.TigerCLIClientID {
+			t.Errorf("device code client_id = %q, want %q", got, config.TigerCLIClientID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"device_code":      "mock-device-code",
+			"user_code":        "K7QP3XVR",
+			"verification_uri": deviceVerificationURI,
+			"expires_in":       expiresIn,
+			"interval":         1,
+		})
+	})
+
+	mux.HandleFunc("POST /idp/external/cli/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "failed to parse form", http.StatusBadRequest)
+			return
+		}
+		if got := r.FormValue("grant_type"); got != "urn:ietf:params:oauth:grant-type:device_code" {
+			t.Errorf("token grant_type = %q, want the device code grant", got)
+			http.Error(w, "unsupported grant", http.StatusBadRequest)
+			return
+		}
+		// The redeemable half must be presented, and the client identified.
+		if got := r.FormValue("device_code"); got != "mock-device-code" {
+			t.Errorf("device_code = %q, want %q", got, "mock-device-code")
+		}
+		if got := r.FormValue("client_id"); got != config.TigerCLIClientID {
+			t.Errorf("token client_id = %q, want %q", got, config.TigerCLIClientID)
+		}
+		if ua := r.Header.Get("User-Agent"); !strings.HasPrefix(ua, "tiger-cli/") {
+			t.Errorf("device poll User-Agent = %q, want \"tiger-cli/\" prefix", ua)
+		}
+
+		mu.Lock()
+		reply := replies[min(polls, len(replies)-1)]
+		polls++
+		mu.Unlock()
+
+		if reply.body == nil {
+			http.Error(w, strings.ToLower(http.StatusText(reply.status)), reply.status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(reply.status)
+		json.NewEncoder(w).Encode(reply.body)
+	})
+
+	mux.HandleFunc("GET /projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(projects)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// withDeviceCodeTTL shrinks the bound the CLI supplies when the gateway omits
+// expires_in, so a test doesn't sit out its production duration.
+func withDeviceCodeTTL(ttl time.Duration) runOption {
+	return withSetup(func(t *testing.T) {
+		original := defaultDeviceCodeTTL
+		defaultDeviceCodeTTL = ttl
+		t.Cleanup(func() { defaultDeviceCodeTTL = original })
+	})
+}
+
+// withNoBrowserOpen fails the test if the login tries to open a browser.
+func withNoBrowserOpen() runOption {
+	return withSetup(func(t *testing.T) {
+		original := openBrowser
+		openBrowser = func(url string) error {
+			t.Errorf("unexpected browser open: %s", url)
+			return nil
+		}
+		t.Cleanup(func() { openBrowser = original })
+	})
+}
+
+// TestAuthLoginDeviceFlow covers --headless, the fallback from a browser that
+// won't open, and each ending the server can hand back. Polls cost 1s each.
+func TestAuthLoginDeviceFlow(t *testing.T) {
+	projects := []api.Project{{ID: "project-123", Name: "Test Project"}}
+
+	const ttl = 900 // seconds, as configured on the tenant
+
+	success := startMockDeviceServer(t, projects, ttl, deviceTokens)
+	pendingThenTokens := startMockDeviceServer(t, projects, ttl, devicePending, deviceTokens)
+	expired := startMockDeviceServer(t, projects, ttl, deviceExpired)
+	consumed := startMockDeviceServer(t, projects, ttl, deviceConsumed)
+	throttled := startMockDeviceServer(t, projects, ttl, deviceRateLimited)
+	badGateway := startMockDeviceServer(t, projects, ttl, deviceBadGateway)
+	unavailable := startMockDeviceServer(t, projects, ttl, deviceServerError)
+	// A code too short-lived to use: DeviceAccessToken hits its own deadline
+	// first. Nonzero matters -- expires_in=0 takes the fallback deadline below.
+	stale := startMockDeviceServer(t, projects, 1, devicePending)
+	// No expires_in at all, so x/oauth2 has no deadline of its own to install.
+	noExpiry := startMockDeviceServer(t, projects, 0, devicePending)
+	// A gateway that can't issue a code pair at all.
+	noCode := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(noCode.Close)
+
+	loggedIn := "Successfully logged in (project: project-123)\n" + nextSteps(true)
+
+	// Every failure below reaches the user through loginWithOAuth's wrapper.
+	const authFailed = "failed to authenticate via OAuth: "
+	expiredErr := authFailed + "the code expired before it was authorized - run 'tiger auth login' again for a new code"
+	consumedErr := authFailed + "the code is no longer valid - run 'tiger auth login' again for a new code"
+	unavailableErr := authFailed + "the authorization service is unavailable - try again in a moment"
+	unansweredErr := authFailed + "failed to check authorization: " +
+		"oauth2: cannot fetch token: 429 Too Many Requests\nResponse: too many requests\n"
+	noCodeErr := authFailed + "failed to start device authorization: " +
+		"oauth2: cannot fetch token: 404 Not Found\nResponse: 404 page not found\n"
+
+	runCmdTests(t, []cmdTest{
+		{
+			// No browser is touched, and the code and URL are the whole output.
+			name:       "headless prints the code and stores the session",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(success.URL)), withNoBrowserOpen()},
+			wantStdout: loggedIn,
+			wantStderr: deviceInstructions,
+			checks:     []checkFunc{checkStoredOAuthCredentials("project-123")},
+		},
+		{
+			// authorization_pending is a flow state: x/oauth2 polls on, silently.
+			name:       "headless keeps polling while authorization is pending",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(pendingThenTokens.URL)), withNoBrowserOpen()},
+			wantStdout: loggedIn,
+			wantStderr: deviceInstructions,
+			checks:     []checkFunc{checkStoredOAuthCredentials("project-123")},
+		},
+		{
+			// No code pair, no flow -- and still an authentication failure, so
+			// callers branching on the exit code classify it with the rest.
+			name:       "device code request failure ends the login",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(noCode.URL)), withNoBrowserOpen()},
+			wantErr:    noCodeErr,
+			wantStderr: "Error: " + noCodeErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			name:       "expired code ends the login with guidance",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(expired.URL)), withNoBrowserOpen()},
+			wantErr:    expiredErr,
+			wantStderr: deviceInstructions + "Error: " + expiredErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// The codes ran out before the server said so; same message either way.
+			name:       "code that expires locally ends the login the same way",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(stale.URL)), withNoBrowserOpen()},
+			wantErr:    expiredErr,
+			wantStderr: deviceInstructions + "Error: " + expiredErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// Without expires_in there is nothing to poll against, so the CLI
+			// supplies the bound rather than waiting on the codes forever.
+			name: "missing expires_in still bounds the wait",
+			args: []string{"auth", "login", "--headless"},
+			opts: []runOption{
+				withConfig(oauthURLs(noExpiry.URL)),
+				withNoBrowserOpen(),
+				withDeviceCodeTTL(2 * time.Second),
+			},
+			wantErr:    expiredErr,
+			wantStderr: deviceInstructions + "Error: " + expiredErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// A consumed or unknown device_code, as a second racing poll gets.
+			name:       "consumed or unknown code ends the login immediately",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(consumed.URL)), withNoBrowserOpen()},
+			wantErr:    consumedErr,
+			wantStderr: deviceInstructions + "Error: " + consumedErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// A reply that is neither a verdict nor a 5xx says nothing about the
+			// code, so the login ends reporting what came back.
+			name:       "poll that is never answered ends the login",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(throttled.URL)), withNoBrowserOpen()},
+			wantErr:    unansweredErr,
+			wantStderr: deviceInstructions + "Error: " + unansweredErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// An OAuth-shaped 500 ends the login, but as a service failure: the
+			// code was never the problem, so it isn't blamed.
+			name:       "server failure ends the login without blaming the code",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(unavailable.URL)), withNoBrowserOpen()},
+			wantErr:    unavailableErr,
+			wantStderr: deviceInstructions + "Error: " + unavailableErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// A 5xx with no OAuth error in it says the same thing, so it ends the
+			// login the same way.
+			name:       "non-OAuth 5xx ends the login too",
+			args:       []string{"auth", "login", "--headless"},
+			opts:       []runOption{withConfig(oauthURLs(badGateway.URL)), withNoBrowserOpen()},
+			wantErr:    unavailableErr,
+			wantStderr: deviceInstructions + "Error: " + unavailableErr + "\n",
+			checks: []checkFunc{
+				checkExitCode(common.ExitAuthenticationError),
+				checkNoStoredCredentials,
+			},
+		},
+		{
+			// The one condition the device code stands in for: no browser to
+			// redirect back from.
+			name:       "failed browser open falls back to the device flow",
+			args:       []string{"auth", "login"},
+			opts:       []runOption{withConfig(oauthURLs(success.URL))},
+			wantStdout: loggedIn,
+			wantStderr: matchOAuthStderr(success.URL, regexp.QuoteMeta(
+				"Failed to open browser: browser disabled in tests\n"+
+					"Falling back to device authorization...\n"+deviceInstructions)),
+			checks: []checkFunc{checkStoredOAuthCredentials("project-123")},
+		},
+	})
 }

--- a/internal/cmd/auth_login_test.go
+++ b/internal/cmd/auth_login_test.go
@@ -171,6 +171,16 @@ func TestAuthLoginCmd(t *testing.T) {
 			checks:     []checkFunc{checkStoredOAuthCredentials("project-123")},
 		},
 		{
+			// Some launchers run for the life of the browser, so the login
+			// watches for a failure to open rather than waiting on the command.
+			name:       "browser that outlives the handoff doesn't stall the login",
+			args:       []string{"auth", "login"},
+			opts:       []runOption{withConfig(oauthURLs(singleProject.URL)), withOpenBrowser(browserThatStaysOpen(t))},
+			wantStdout: "Successfully logged in (project: project-123)\n" + nextSteps(true),
+			wantStderr: matchOAuthStderr(singleProject.URL, ""),
+			checks:     []checkFunc{checkStoredOAuthCredentials("project-123")},
+		},
+		{
 			// A callback that isn't ours -- a stale tab from an earlier login --
 			// is refused, and the login ends rather than accepting its code.
 			name:       "callback with a stale state is refused",
@@ -514,6 +524,22 @@ func mockOpenBrowser(t *testing.T) func(string) error {
 			return fmt.Errorf("callback request failed: %w", err)
 		}
 		return resp.Body.Close()
+	}
+}
+
+// browserThatStaysOpen hands the callback over and then keeps running, as a
+// launcher that exits only when the browser closes does.
+func browserThatStaysOpen(t *testing.T) func(string) error {
+	t.Helper()
+	complete := mockOpenBrowser(t)
+	closed := make(chan struct{})
+	t.Cleanup(func() { close(closed) })
+	return func(authURL string) error {
+		if err := complete(authURL); err != nil {
+			return err
+		}
+		<-closed
+		return nil
 	}
 }
 


### PR DESCRIPTION
`tiger auth login` only works where the CLI and the browser sit on the same machine: the redirect goes to `http://localhost:<port>/callback`, so on an SSH session, in a container, or on any host without a browser there is nothing to redirect back to — and pasting the auth URL into a browser elsewhere doesn't help, since that URL redirects to a port on the machine running the CLI.

This adds the RFC 8628 device authorization grant as a second way in: the CLI prints a short code, the user enters it in a browser on whatever machine they do have one, and the CLI polls until it's authorized. `--headless` goes straight there; otherwise the redirect flow runs as before and the device code stands in for exactly one condition — the browser couldn't be opened at all.

Needs the server halves: timescale/savannah-gateway#1948 and timescale/savannah-users#573.