### PR TITLE
Small command and flag improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Place a helper by who calls it, working down this list until one matches:
 4. **A genuine standalone utility** — small and isolated, with no notion of a command → `internal/util`. Anything shaped around the CLI stays in `cmd` even if its signature looks generic.
 5. **Used by both CLI and MCP** → `internal/common`.
 
-Exception: all shell completion functions — both `ValidArgsFunction` completions and flag-value completions — live in `completion_helper.go`, however many commands use them.
+Exception: all shell completion functions — both `ValidArgsFunction` completions and flag-value completions — live in `completion_helper.go`, however many commands use them. Register a flag's completion with `registerFlagCompletion`, which panics on the programming errors cobra reports by returning an error. A flag that takes a path is the one case that needs a completion just to opt back in to filenames: register `dirCompletion` or `fileCompletion(extensions...)`.
 
 ## Configuration
 
@@ -104,8 +104,8 @@ It's an env var **only**: deliberately not a config key, not a flag, and hidden 
 All cobra commands must:
 
 1. Set `SilenceUsage: true` as a literal field on the `cobra.Command` struct of every leaf command (one with a `RunE`), so a bad flag or argument prints only the one-line error rather than a wall of usage text — and because it's on the struct literal, it's already set when cobra reports flag-parsing errors before `RunE` runs. Parent/group commands don't set it: their "unknown command" errors usefully show the available subcommands. `SilenceErrors` is separate and rarely needed — set it only on a command that already reports its own errors (`mcp start http` logs failures through slog).
-2. Set `ValidArgsFunction` or `ValidArgs` for shell completions — `ValidArgsFunction` for dynamic completions (e.g. service IDs), `ValidArgs` for static lists, and `cobra.NoFileCompletions` when no completions apply. The important thing is that one of these is always set, so completion never falls back to filenames.
-3. Register a completion for every flag whose values come from a known set, with `cmd.RegisterFlagCompletionFunc` alongside the flag's definition — `outputCompletion()` for `--output` is the one nearly every command with structured output needs.
+2. Set `ValidArgsFunction` or `ValidArgs` when the command's arguments have completions to offer — `ValidArgsFunction` for dynamic ones (e.g. service IDs), `ValidArgs` for static lists. A command whose arguments have neither sets nothing: `buildRootCmd` sets the tree's default shell completion directive to `NoFileComp`, so anything without a registered completion — every argument and every flag — offers nothing rather than falling back to filenames.
+3. Register a completion for every flag whose values come from a known set, with `registerFlagCompletion` alongside the flag's definition — `outputCompletion()` for `--output` is the one nearly every command with structured output needs. A flag that takes a path registers one too, to opt back in to the filenames the default directive suppresses.
 4. Use `RunE`, not `Run` (see [Command Architecture](#command-architecture)).
 5. Print through the command — `cmd.Print*` for stdout, `cmd.PrintErr*` for stderr — and read via `cmd.InOrStdin()`. Never use `fmt.Print*` (it bypasses the command's writers, so tests can't capture it) or `os.Stdin`/`os.Stdout`/`os.Stderr` directly — the sole exception is `buildRootCmd` wiring stdout and stderr onto the root command (see [Streams](#streams)). Reach for `cmd.OutOrStdout()`/`cmd.ErrOrStderr()` only where an `io.Writer` is genuinely required (serializers, `tablewriter`, `tea.WithOutput`, helpers in other packages).
 6. Pass `cmd.Context()` down into any long-running or cancellable operation, so commands exit promptly on Ctrl+C or SIGTERM.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Place a helper by who calls it, working down this list until one matches:
 4. **A genuine standalone utility** — small and isolated, with no notion of a command → `internal/util`. Anything shaped around the CLI stays in `cmd` even if its signature looks generic.
 5. **Used by both CLI and MCP** → `internal/common`.
 
-Exception: all shell completion functions — both `ValidArgsFunction` completions and flag-value completions — live in `completion_helper.go`, however many commands use them. Register a flag's completion with `registerFlagCompletion`, which panics on the programming errors cobra reports by returning an error. A flag that takes a path is the one case that needs a completion just to opt back in to filenames: register `dirCompletion` or `fileCompletion(extensions...)`.
+Exception: all shell completion functions — both `ValidArgsFunction` completions and flag-value completions — live in `completion_helper.go`, however many commands use them. Register a flag's completion with `registerFlagCompletion`, which panics on the programming errors cobra reports by returning an error. A flag that takes a path is the one case that needs a completion just to opt back in to filenames: register `dirCompletion`, or `fileCompletion` with the extensions to filter by (or none, for any file).
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Further conventions:
 - **Boolean flags** follow the GitHub CLI pattern: the positive behavior is the default (no flag needed), and an explicit `--no-<feature>` flag disables it. Don't create mutually exclusive `--enable-X`/`--disable-X` pairs.
 - **Destructive operations** (delete, password rotation) require an explicit service ID with no default fallback, prompt the user to type the resource ID to confirm, and offer a `--confirm` flag to skip the prompt for automation. The prompt must be TTY-gated (see [Reading Stdin](#reading-stdin)), and the help text should include a "Note for AI agents: always confirm with the user before performing this destructive operation" warning.
 - **Long-running operations** wait for completion by default, with `--no-wait` to return immediately and `--wait-timeout` (a duration) to bound the wait; a timeout exits with code 2 (`common.ExitTimeout`). Use `common.WaitForService`, which shows a spinner on a TTY and plain progress lines otherwise, writing progress to stderr.
-- **Help text** should document the default behavior, explain how to override it, and include examples of common usage.
+- **Help text** should document the default behavior and explain how to override it, with examples of common usage in the command's `Example` field rather than in `Long`.
 
 ## Output
 

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -85,10 +85,8 @@ service (config key service_id) is cleared, since it belongs to the project it w
 You may also provide API keys via flags or environment variables, in which case they will be used
 directly. The CLI will prompt for any missing information.
 
-You can find your API credentials at: https://console.cloud.tigerdata.com/dashboard/settings
-
-Examples:
-  # Interactive login with OAuth (opens browser)
+You can find your API credentials at: https://console.cloud.tigerdata.com/dashboard/settings`,
+		Example: `  # Interactive login with OAuth (opens browser)
   tiger auth login
 
   # OAuth login without the interactive project selection

--- a/internal/cmd/auth_login.go
+++ b/internal/cmd/auth_login.go
@@ -99,9 +99,8 @@ You can find your API credentials at: https://console.cloud.tigerdata.com/dashbo
   export TIGER_PUBLIC_KEY="your-public-key"
   export TIGER_SECRET_KEY="your-secret-key"
   tiger auth login`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := app.GetConfig()
 

--- a/internal/cmd/auth_logout.go
+++ b/internal/cmd/auth_logout.go
@@ -12,12 +12,11 @@ import (
 
 func buildLogoutCmd(app *common.App) *cobra.Command {
 	return &cobra.Command{
-		Use:               "logout",
-		Short:             "Remove stored credentials",
-		Long:              `Remove stored credentials. For OAuth logins, also revokes the refresh token server-side.`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Use:          "logout",
+		Short:        "Remove stored credentials",
+		Long:         `Remove stored credentials. For OAuth logins, also revokes the refresh token server-side.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := app.GetConfig()
 

--- a/internal/cmd/auth_status.go
+++ b/internal/cmd/auth_status.go
@@ -20,13 +20,12 @@ import (
 func buildStatusCmd(app *common.App) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:               "status",
-		Aliases:           []string{"whoami"},
-		Short:             "Show current authentication status and project ID",
-		Long:              "Displays whether you are logged in and shows your currently configured project ID.",
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Use:          "status",
+		Aliases:      []string{"whoami"},
+		Short:        "Show current authentication status and project ID",
+		Long:         "Displays whether you are logged in and shows your currently configured project ID.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, _, err := app.GetAll()
 			if err != nil {
@@ -59,7 +58,7 @@ func buildStatusCmd(app *common.App) *cobra.Command {
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/completion_helper.go
+++ b/internal/cmd/completion_helper.go
@@ -23,12 +23,16 @@ func registerFlagCompletion(cmd *cobra.Command, flag string, f cobra.CompletionF
 	}
 }
 
-// dirCompletion completes directory names, and fileCompletion file names with
-// the given extensions. Completion defaults to offering nothing at all (see
-// buildRootCmd), so a flag that takes a path has to ask for these.
+// dirCompletion completes directory names, and fileCompletion file names —
+// filtered to the given extensions, or any file when called with none.
+// Completion defaults to offering nothing at all (see buildRootCmd), so a flag
+// that takes a path has to ask for these.
 var dirCompletion = cobra.FixedCompletions(nil, cobra.ShellCompDirectiveFilterDirs)
 
 func fileCompletion(extensions ...string) cobra.CompletionFunc {
+	if len(extensions) == 0 {
+		return cobra.FixedCompletions(nil, cobra.ShellCompDirectiveDefault)
+	}
 	return cobra.FixedCompletions(extensions, cobra.ShellCompDirectiveFilterFileExt)
 }
 

--- a/internal/cmd/completion_helper.go
+++ b/internal/cmd/completion_helper.go
@@ -13,6 +13,25 @@ import (
 	"github.com/timescale/tiger-cli/internal/mcp"
 )
 
+// registerFlagCompletion registers a shell completion function for a flag. A
+// failure means the flag doesn't exist or already has a completion — either is
+// a programming error in the command tree that would otherwise go unnoticed
+// until someone pressed Tab.
+func registerFlagCompletion(cmd *cobra.Command, flag string, f cobra.CompletionFunc) {
+	if err := cmd.RegisterFlagCompletionFunc(flag, f); err != nil {
+		panic(fmt.Sprintf("%s: %v", cmd.CommandPath(), err))
+	}
+}
+
+// dirCompletion completes directory names, and fileCompletion file names with
+// the given extensions. Completion defaults to offering nothing at all (see
+// buildRootCmd), so a flag that takes a path has to ask for these.
+var dirCompletion = cobra.FixedCompletions(nil, cobra.ShellCompDirectiveFilterDirs)
+
+func fileCompletion(extensions ...string) cobra.CompletionFunc {
+	return cobra.FixedCompletions(extensions, cobra.ShellCompDirectiveFilterFileExt)
+}
+
 // withAppLoad wraps a completion function, loading the config and API client
 // before invoking it. The App is only loaded automatically for wrapped commands
 // (see wrapCommands), not for the __complete command that drives live tab

--- a/internal/cmd/completion_helper_test.go
+++ b/internal/cmd/completion_helper_test.go
@@ -16,8 +16,9 @@ import (
 //
 // Cobra writes the candidates to stdout, one "value\tdescription" line each,
 // followed by a ":<directive>" line — 4 is ShellCompDirectiveNoFileComp, which
-// every completion here returns so shells don't fall back to filenames. The
-// trailing human-readable directive line goes to stderr.
+// nearly every completion here returns so shells don't fall back to filenames;
+// 8 and 16 filter to files and directories. The trailing human-readable
+// directive line goes to stderr.
 //
 // A completion that can't produce candidates (not logged in, API error) must
 // return none rather than an error: a broken completion should be invisible at
@@ -172,6 +173,37 @@ func TestCompletion(t *testing.T) {
 			opts:       noDocsProxy(nil),
 			wantStdout: "service_list\nservice_logs\n" + noFileComp,
 			wantStderr: directive,
+		},
+		{
+			// The root command's default directive, which is what keeps every
+			// flag without a registered completion from offering filenames.
+			name:       "a flag with no completion offers nothing",
+			args:       []string{"__complete", "service", "create", "--name", ""},
+			wantStdout: noFileComp,
+			wantStderr: directive,
+			checks:     []checkFunc{checkNotLoaded},
+		},
+		{
+			name:       "a command with no argument completion offers nothing",
+			args:       []string{"__complete", "service", "list", ""},
+			wantStdout: noFileComp,
+			wantStderr: directive,
+			checks:     []checkFunc{checkNotLoaded},
+		},
+		{
+			name:       "--config-dir completes directories",
+			args:       []string{"__complete", "service", "get", "--config-dir", ""},
+			wantStdout: ":16\n",
+			wantStderr: "Completion ended with directive: ShellCompDirectiveFilterDirs\n",
+			checks:     []checkFunc{checkNotLoaded},
+		},
+		{
+			// The candidates are the extensions to filter by, not completions.
+			name:       "--config-path completes config files",
+			args:       []string{"__complete", "mcp", "install", "--config-path", ""},
+			wantStdout: "json\ntoml\n:8\n",
+			wantStderr: "Completion ended with directive: ShellCompDirectiveFilterFileExt\n",
+			checks:     []checkFunc{checkNotLoaded},
 		},
 	})
 

--- a/internal/cmd/completion_helper_test.go
+++ b/internal/cmd/completion_helper_test.go
@@ -198,11 +198,20 @@ func TestCompletion(t *testing.T) {
 			checks:     []checkFunc{checkNotLoaded},
 		},
 		{
-			// The candidates are the extensions to filter by, not completions.
-			name:       "--config-path completes config files",
+			// A client's config file can be named anything, so this asks for
+			// the shell's unfiltered file completion.
+			name:       "--config-path completes any file",
 			args:       []string{"__complete", "mcp", "install", "--config-path", ""},
-			wantStdout: "json\ntoml\n:8\n",
-			wantStderr: "Completion ended with directive: ShellCompDirectiveFilterFileExt\n",
+			wantStdout: ":0\n",
+			wantStderr: "Completion ended with directive: ShellCompDirectiveDefault\n",
+			checks:     []checkFunc{checkNotLoaded},
+		},
+		{
+			// Same for a SQL file.
+			name:       "--file completes any file",
+			args:       []string{"__complete", "db", "query", "--file", ""},
+			wantStdout: ":0\n",
+			wantStderr: "Completion ended with directive: ShellCompDirectiveDefault\n",
 			checks:     []checkFunc{checkNotLoaded},
 		},
 	})

--- a/internal/cmd/config_reset.go
+++ b/internal/cmd/config_reset.go
@@ -10,13 +10,12 @@ import (
 
 func buildConfigResetCmd(app *common.App) *cobra.Command {
 	return &cobra.Command{
-		Use:               "reset",
-		Aliases:           []string{"clear"},
-		Short:             "Reset to defaults",
-		Long:              `Reset all configuration settings to their default values`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Use:          "reset",
+		Aliases:      []string{"clear"},
+		Short:        "Reset to defaults",
+		Long:         `Reset all configuration settings to their default values`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := app.GetConfig()
 

--- a/internal/cmd/config_show.go
+++ b/internal/cmd/config_show.go
@@ -17,13 +17,12 @@ func buildConfigShowCmd(app *common.App) *cobra.Command {
 	var withEnv bool
 
 	cmd := &cobra.Command{
-		Use:               "show",
-		Aliases:           []string{"list", "ls"},
-		Short:             "Show current configuration",
-		Long:              `Display the current CLI configuration settings`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Use:          "show",
+		Aliases:      []string{"list", "ls"},
+		Short:        "Show current configuration",
+		Long:         `Display the current CLI configuration settings`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := app.GetConfig()
 
@@ -48,7 +47,7 @@ func buildConfigShowCmd(app *common.App) *cobra.Command {
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 	cmd.Flags().BoolVar(&noDefaults, "no-defaults", false, "do not show default values for unset fields")
 	cmd.Flags().BoolVar(&withEnv, "with-env", false, "apply environment variable overrides")
 

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -56,10 +56,8 @@ requested service. The prompt is automatically skipped when stdin is not a
 terminal (e.g. in scripts) or when the service has no read replicas.
 
 You can also pass a read replica set ID to connect straight to that replica,
-skipping the prompt. Read replicas share the primary's credentials.
-
-Examples:
-  # Connect to default service
+skipping the prompt. Read replicas share the primary's credentials.`,
+		Example: `  # Connect to default service
   tiger db connect
   tiger db psql
 

--- a/internal/cmd/db_connect.go
+++ b/internal/cmd/db_connect.go
@@ -21,10 +21,10 @@ import (
 )
 
 func buildDbConnectCmd(app *common.App) *cobra.Command {
-	var dbConnectPooled bool
-	var dbConnectRole string
-	var dbConnectReadOnly bool
-	var dbConnectNoReplicaPrompt bool
+	var pooled bool
+	var role string
+	var readOnly bool
+	var noReplicaPrompt bool
 
 	cmd := &cobra.Command{
 		Use:     "connect [service-id]",
@@ -114,14 +114,14 @@ skipping the prompt. Read replicas share the primary's credentials.`,
 			}
 
 			opts := common.ConnectionDetailsOptions{
-				Pooled:   dbConnectPooled,
-				Role:     dbConnectRole,
-				ReadOnly: dbConnectReadOnly,
+				Pooled:   pooled,
+				Role:     role,
+				ReadOnly: readOnly,
 			}
 
 			// Connects straight to a replica named by ID, or offers the interactive
 			// replica menu for a primary. Returns nil details if the user cancels.
-			details, err := selectConnection(cmd.Context(), cmd, cfg, client, projectID, target, opts, dbConnectNoReplicaPrompt)
+			details, err := selectConnection(cmd.Context(), cmd, cfg, client, projectID, target, opts, noReplicaPrompt)
 			if err != nil {
 				return err
 			}
@@ -136,10 +136,10 @@ skipping the prompt. Read replicas share the primary's credentials.`,
 	}
 
 	// Add flags for db connect command (works for both connect and psql)
-	cmd.Flags().BoolVar(&dbConnectPooled, "pooled", false, "Use connection pooling")
-	cmd.Flags().StringVar(&dbConnectRole, "role", "tsdbadmin", "Database role/username")
-	cmd.Flags().BoolVar(&dbConnectReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
-	cmd.Flags().BoolVar(&dbConnectNoReplicaPrompt, "no-replica-prompt", false, "Don't prompt to connect to a read replica")
+	cmd.Flags().BoolVar(&pooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&role, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
+	cmd.Flags().BoolVar(&noReplicaPrompt, "no-replica-prompt", false, "Don't prompt to connect to a read replica")
 
 	return cmd
 }

--- a/internal/cmd/db_connection_string.go
+++ b/internal/cmd/db_connection_string.go
@@ -34,10 +34,8 @@ Cloud's immutable read-only mode (writes and DDL are rejected by the server).
 The global read_only config option (or TIGER_READ_ONLY) also forces this
 behavior: read_only=all makes every connection string read-only, and
 read_only=prod makes those for services tagged PROD read-only while leaving DEV
-services writable.
-
-Examples:
-  # Get connection string for default service
+services writable.`,
+		Example: `  # Get connection string for default service
   tiger db connection-string
 
   # Get connection string for specific service

--- a/internal/cmd/db_connection_string.go
+++ b/internal/cmd/db_connection_string.go
@@ -9,10 +9,10 @@ import (
 )
 
 func buildDbConnectionStringCmd(app *common.App) *cobra.Command {
-	var dbConnectionStringPooled bool
-	var dbConnectionStringRole string
-	var dbConnectionStringWithPassword bool
-	var dbConnectionStringReadOnly bool
+	var pooled bool
+	var role string
+	var withPassword bool
+	var readOnly bool
 
 	cmd := &cobra.Command{
 		Use:     "connection-string [service-id]",
@@ -71,19 +71,19 @@ services writable.`,
 				return err
 			}
 
-			warnReplicaPooler(cmd, target, dbConnectionStringPooled)
+			warnReplicaPooler(cmd, target, pooled)
 
 			details, err := target.Details(cfg, common.ConnectionDetailsOptions{
-				Pooled:       dbConnectionStringPooled,
-				Role:         dbConnectionStringRole,
-				WithPassword: dbConnectionStringWithPassword,
-				ReadOnly:     dbConnectionStringReadOnly || common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(target.ConnectionService)) != nil,
+				Pooled:       pooled,
+				Role:         role,
+				WithPassword: withPassword,
+				ReadOnly:     readOnly || common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(target.ConnectionService)) != nil,
 			})
 			if err != nil {
 				return err
 			}
 
-			if dbConnectionStringWithPassword && details.Password == "" {
+			if withPassword && details.Password == "" {
 				return fmt.Errorf("password not available to include in connection string")
 			}
 
@@ -93,10 +93,10 @@ services writable.`,
 	}
 
 	// Add flags for db connection-string command
-	cmd.Flags().BoolVar(&dbConnectionStringPooled, "pooled", false, "Use connection pooling")
-	cmd.Flags().StringVar(&dbConnectionStringRole, "role", "tsdbadmin", "Database role/username")
-	cmd.Flags().BoolVar(&dbConnectionStringWithPassword, "with-password", false, "Include password in connection string (less secure)")
-	cmd.Flags().BoolVar(&dbConnectionStringReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
+	cmd.Flags().BoolVar(&pooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&role, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().BoolVar(&withPassword, "with-password", false, "Include password in connection string (less secure)")
+	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
 
 	return cmd
 }

--- a/internal/cmd/db_create_role.go
+++ b/internal/cmd/db_create_role.go
@@ -42,10 +42,8 @@ Read-Only Mode for AI Agents:
 The --read-only flag enables permanent read-only enforcement at the PostgreSQL level
 using the tsdb_admin.read_only_role extension setting. This is designed to provide
 safe database access for AI agents and automated tools that need to read production
-data without risk of modification.
-
-Examples:
-  # Create a role with global database access (uses default service, auto-generates password)
+data without risk of modification.`,
+		Example: `  # Create a role with global database access (uses default service, auto-generates password)
   tiger db create role --name ai_analyst --from tsdbadmin
 
   # Create a role for specific service

--- a/internal/cmd/db_create_role.go
+++ b/internal/cmd/db_create_role.go
@@ -15,11 +15,11 @@ import (
 )
 
 func buildDbCreateRoleCmd(app *common.App) *cobra.Command {
-	var roleName string
+	var name string
 	var readOnly bool
-	var fromRoles []string
+	var from []string
 	var statementTimeout time.Duration
-	var passwordFlag string
+	var password string
 
 	cmd := &cobra.Command{
 		Use:     "role [service-id]",
@@ -42,7 +42,21 @@ Read-Only Mode for AI Agents:
 The --read-only flag enables permanent read-only enforcement at the PostgreSQL level
 using the tsdb_admin.read_only_role extension setting. This is designed to provide
 safe database access for AI agents and automated tools that need to read production
-data without risk of modification.`,
+data without risk of modification.
+
+Technical Details:
+This command executes PostgreSQL statements in a transaction to create and configure the role.
+
+CREATE ROLE Options Used:
+  - LOGIN: Always enabled to allow the role to connect
+  - PASSWORD: Always set (from flag, env var, or auto-generated)
+  - IN ROLE: Added when --from flag is provided to inherit grants from existing roles
+
+PostgreSQL Configuration Parameters That May Be Set:
+  - tsdb_admin.read_only_role: Set to 'true' when --read-only flag is used
+    (enforces permanent read-only mode for the role)
+  - statement_timeout: Set when --statement-timeout flag is provided
+    (kills queries that exceed the specified duration, in milliseconds)`,
 		Example: `  # Create a role with global database access (uses default service, auto-generates password)
   tiger db create role --name ai_analyst --from tsdbadmin
 
@@ -65,27 +79,13 @@ data without risk of modification.`,
   tiger db create role --name ai_analyst --password=my-secure-password
 
   # Create a role with password from environment variable
-  TIGER_NEW_PASSWORD=my-secure-password tiger db create role --name ai_analyst
-
-Technical Details:
-This command executes PostgreSQL statements in a transaction to create and configure the role.
-
-CREATE ROLE Options Used:
-  - LOGIN: Always enabled to allow the role to connect
-  - PASSWORD: Always set (from flag, env var, or auto-generated)
-  - IN ROLE: Added when --from flag is provided to inherit grants from existing roles
-
-PostgreSQL Configuration Parameters That May Be Set:
-  - tsdb_admin.read_only_role: Set to 'true' when --read-only flag is used
-    (enforces permanent read-only mode for the role)
-  - statement_timeout: Set when --statement-timeout flag is provided
-    (kills queries that exceed the specified duration, in milliseconds)`,
+  TIGER_NEW_PASSWORD=my-secure-password tiger db create role --name ai_analyst`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate arguments
-			if roleName == "" {
+			if name == "" {
 				return fmt.Errorf("--name is required")
 			}
 
@@ -116,7 +116,7 @@ PostgreSQL Configuration Parameters That May Be Set:
 			}
 
 			// Get password
-			rolePassword, err := getPasswordForRole(passwordFlag)
+			rolePassword, err := getPasswordForRole(password)
 			if err != nil {
 				return fmt.Errorf("failed to determine password: %w", err)
 			}
@@ -142,12 +142,12 @@ PostgreSQL Configuration Parameters That May Be Set:
 			defer conn.Close(ctx)
 
 			// Create the role with all options in a transaction
-			if err := createRoleWithOptions(ctx, conn, roleName, rolePassword, readOnly, statementTimeout, fromRoles); err != nil {
+			if err := createRoleWithOptions(ctx, conn, name, rolePassword, readOnly, statementTimeout, from); err != nil {
 				return fmt.Errorf("failed to create role: %w", err)
 			}
 
 			// Save password to storage with the new role name
-			result, err := common.SavePasswordWithResult(cfg, *service, rolePassword, roleName)
+			result, err := common.SavePasswordWithResult(cfg, *service, rolePassword, name)
 			if err != nil {
 				cmd.PrintErrf("⚠️  Warning: %s\n", result.Message)
 			} else if !result.Success {
@@ -155,16 +155,16 @@ PostgreSQL Configuration Parameters That May Be Set:
 			}
 
 			// Output result in requested format
-			return outputCreateRoleResult(cmd, roleName, readOnly, statementTimeout, fromRoles, cfg.Output)
+			return outputCreateRoleResult(cmd, name, readOnly, statementTimeout, from, cfg.Output)
 		},
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&roleName, "name", "", "Role name to create (required)")
+	cmd.Flags().StringVar(&name, "name", "", "Role name to create (required)")
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Enable permanent read-only enforcement via tsdb_admin.read_only_role")
-	cmd.Flags().StringSliceVar(&fromRoles, "from", []string{}, "Roles to inherit grants from (e.g., --from app_role --from readonly_role or --from app_role,readonly_role)")
+	cmd.Flags().StringSliceVar(&from, "from", []string{}, "Roles to inherit grants from (e.g., --from app_role --from readonly_role or --from app_role,readonly_role)")
 	cmd.Flags().DurationVar(&statementTimeout, "statement-timeout", 0, "Set statement timeout for the role (e.g., 30s, 5m)")
-	cmd.Flags().StringVar(&passwordFlag, "password", "", "Password for the role. If not provided, checks TIGER_NEW_PASSWORD environment variable, otherwise auto-generates a secure random password.")
+	cmd.Flags().StringVar(&password, "password", "", "Password for the role. If not provided, checks TIGER_NEW_PASSWORD environment variable, otherwise auto-generates a secure random password.")
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "output format (json, yaml, table)")
 	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
 
@@ -174,8 +174,8 @@ PostgreSQL Configuration Parameters That May Be Set:
 }
 
 // buildCreateRoleSQL generates the CREATE ROLE SQL statement with LOGIN, PASSWORD, and optional IN ROLE clause
-func buildCreateRoleSQL(roleName string, quotedPassword string, fromRoles []string) string {
-	sanitizedRoleName := pgx.Identifier{roleName}.Sanitize()
+func buildCreateRoleSQL(name string, quotedPassword string, fromRoles []string) string {
+	sanitizedRoleName := pgx.Identifier{name}.Sanitize()
 	createSQL := fmt.Sprintf("CREATE ROLE %s WITH LOGIN PASSWORD %s", sanitizedRoleName, quotedPassword)
 
 	// Add IN ROLE clause if fromRoles is specified
@@ -192,20 +192,20 @@ func buildCreateRoleSQL(roleName string, quotedPassword string, fromRoles []stri
 }
 
 // buildReadOnlyAlterSQL generates the ALTER ROLE SQL statement for read-only enforcement
-func buildReadOnlyAlterSQL(roleName string) string {
-	sanitizedRoleName := pgx.Identifier{roleName}.Sanitize()
+func buildReadOnlyAlterSQL(name string) string {
+	sanitizedRoleName := pgx.Identifier{name}.Sanitize()
 	return fmt.Sprintf("ALTER ROLE %s SET tsdb_admin.read_only_role = true", sanitizedRoleName)
 }
 
 // buildStatementTimeoutAlterSQL generates the ALTER ROLE SQL statement for statement timeout configuration
-func buildStatementTimeoutAlterSQL(roleName string, timeout time.Duration) string {
-	sanitizedRoleName := pgx.Identifier{roleName}.Sanitize()
+func buildStatementTimeoutAlterSQL(name string, timeout time.Duration) string {
+	sanitizedRoleName := pgx.Identifier{name}.Sanitize()
 	timeoutMs := timeout.Milliseconds()
 	return fmt.Sprintf("ALTER ROLE %s SET statement_timeout = %d", sanitizedRoleName, timeoutMs)
 }
 
 // createRoleWithOptions creates a new PostgreSQL role with all specified options in a single transaction
-func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, roleName, rolePassword string, readOnly bool, statementTimeout time.Duration, fromRoles []string) error {
+func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, name, rolePassword string, readOnly bool, statementTimeout time.Duration, fromRoles []string) error {
 	// Begin transaction for atomic operation
 	tx, err := conn.Begin(ctx)
 	if err != nil {
@@ -240,13 +240,13 @@ func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, roleName, rolePa
 		// Use timescale_functions.create_bare_readonly_role to create the role
 		// This function creates a read-only role that can inherit tsdbadmin privileges
 		if _, err := tx.Exec(ctx, "SELECT timescale_functions.create_bare_readonly_role($1, $2)",
-			roleName, rolePassword); err != nil {
+			name, rolePassword); err != nil {
 			return fmt.Errorf("failed to create role with create_bare_readonly_role: %w", err)
 		}
 
 		// Grant tsdbadmin privileges using the special function
 		if _, err := tx.Exec(ctx, "SELECT timescale_functions.grant_tsdbadmin_to_role($1)",
-			roleName); err != nil {
+			name); err != nil {
 			return fmt.Errorf("failed to grant tsdbadmin privileges: %w", err)
 		}
 
@@ -255,7 +255,7 @@ func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, roleName, rolePa
 		for _, role := range otherRoles {
 			grantSQL := fmt.Sprintf("GRANT %s TO %s",
 				pgx.Identifier{role}.Sanitize(),
-				pgx.Identifier{roleName}.Sanitize())
+				pgx.Identifier{name}.Sanitize())
 			if _, err := tx.Exec(ctx, grantSQL); err != nil {
 				return fmt.Errorf("failed to grant role %s: %w", role, err)
 			}
@@ -269,14 +269,14 @@ func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, roleName, rolePa
 		// Wrap password in single quotes for SQL literal
 		quotedPassword := "'" + rolePassword + "'"
 		// IN ROLE clause handles all role grants, so no need for separate GRANT statements
-		createSQL := buildCreateRoleSQL(roleName, quotedPassword, fromRoles)
+		createSQL := buildCreateRoleSQL(name, quotedPassword, fromRoles)
 		if _, err := tx.Exec(ctx, createSQL); err != nil {
 			return fmt.Errorf("failed to create role: %w", err)
 		}
 
 		// Configure read-only mode if requested
 		if readOnly {
-			alterSQL := buildReadOnlyAlterSQL(roleName)
+			alterSQL := buildReadOnlyAlterSQL(name)
 			if _, err := tx.Exec(ctx, alterSQL); err != nil {
 				return fmt.Errorf("failed to configure read-only mode: %w", err)
 			}
@@ -285,7 +285,7 @@ func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, roleName, rolePa
 
 	// Set statement timeout if requested
 	if statementTimeout > 0 {
-		alterSQL := buildStatementTimeoutAlterSQL(roleName, statementTimeout)
+		alterSQL := buildStatementTimeoutAlterSQL(name, statementTimeout)
 		if _, err := tx.Exec(ctx, alterSQL); err != nil {
 			return fmt.Errorf("failed to set statement timeout: %w", err)
 		}
@@ -300,15 +300,15 @@ func createRoleWithOptions(ctx context.Context, conn *pgx.Conn, roleName, rolePa
 }
 
 // getPasswordForRole determines the password based on flags and environment
-func getPasswordForRole(passwordFlag string) (string, error) {
+func getPasswordForRole(password string) (string, error) {
 	// Priority order:
 	// 1. Explicit password value from --password flag
 	// 2. TIGER_NEW_PASSWORD environment variable
 	// 3. Auto-generate secure random password
 
-	if passwordFlag != "" {
+	if password != "" {
 		// Explicit password provided via --password flag
-		return passwordFlag, nil
+		return password, nil
 	}
 
 	// Check environment variable
@@ -329,9 +329,9 @@ type CreateRoleResult struct {
 }
 
 // outputCreateRoleResult formats and outputs the create role result
-func outputCreateRoleResult(cmd *cobra.Command, roleName string, readOnly bool, statementTimeout time.Duration, fromRoles []string, format string) error {
+func outputCreateRoleResult(cmd *cobra.Command, name string, readOnly bool, statementTimeout time.Duration, fromRoles []string, format string) error {
 	result := CreateRoleResult{
-		RoleName: roleName,
+		RoleName: name,
 		ReadOnly: readOnly,
 	}
 
@@ -351,7 +351,7 @@ func outputCreateRoleResult(cmd *cobra.Command, roleName string, readOnly bool, 
 	case "yaml":
 		return util.SerializeToYAML(outputWriter, result)
 	default: // table format
-		cmd.Printf("✓ Role '%s' created successfully\n", roleName)
+		cmd.Printf("✓ Role '%s' created successfully\n", name)
 		if readOnly {
 			cmd.Printf("  Read-only enforcement: enabled (permanent, role-based)\n")
 		}

--- a/internal/cmd/db_create_role.go
+++ b/internal/cmd/db_create_role.go
@@ -166,7 +166,7 @@ PostgreSQL Configuration Parameters That May Be Set:
 	cmd.Flags().DurationVar(&statementTimeout, "statement-timeout", 0, "Set statement timeout for the role (e.g., 30s, 5m)")
 	cmd.Flags().StringVar(&password, "password", "", "Password for the role. If not provided, checks TIGER_NEW_PASSWORD environment variable, otherwise auto-generates a secure random password.")
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	cmd.MarkFlagRequired("name")
 

--- a/internal/cmd/db_query.go
+++ b/internal/cmd/db_query.go
@@ -49,10 +49,8 @@ Use --read-only to open the session in Tiger Cloud's immutable read-only mode
 (writes and DDL are rejected by the server). The global read_only config option
 (or TIGER_READ_ONLY) also forces this behavior: read_only=all makes every session
 read-only, and read_only=prod makes sessions against services tagged PROD
-read-only while leaving DEV services writable.
-
-Examples:
-  # Select data from a table
+read-only while leaving DEV services writable.`,
+		Example: `  # Select data from a table
   tiger db query svc-12345 -c "SELECT * FROM users LIMIT 5"
 
   # Query the default service

--- a/internal/cmd/db_query.go
+++ b/internal/cmd/db_query.go
@@ -144,7 +144,8 @@ read-only while leaving DEV services writable.`,
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Query timeout duration (e.g., 30s, 5m). Use 0 for no timeout")
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (table, json, yaml)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "file", fileCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 	cmd.MarkFlagsMutuallyExclusive("command", "file")
 
 	return cmd

--- a/internal/cmd/db_save_password.go
+++ b/internal/cmd/db_save_password.go
@@ -11,8 +11,8 @@ import (
 )
 
 func buildDbSavePasswordCmd(app *common.App) *cobra.Command {
-	var dbSavePasswordRole string
-	var dbSavePasswordValue string
+	var role string
+	var password string
 
 	cmd := &cobra.Command{
 		Use:   "save-password [service-id]",
@@ -73,7 +73,7 @@ The password will be saved according to your --password-storage setting
 
 			if cmd.Flags().Changed("password") {
 				// --password flag was provided
-				passwordToSave = dbSavePasswordValue
+				passwordToSave = password
 				if passwordToSave == "" {
 					return fmt.Errorf("password cannot be empty when provided via --password flag")
 				}
@@ -99,7 +99,7 @@ The password will be saved according to your --password-storage setting
 
 			// Save password using configured storage
 			storage := common.GetPasswordStorage(cfg)
-			if err := storage.Save(service, passwordToSave, dbSavePasswordRole); err != nil {
+			if err := storage.Save(service, passwordToSave, role); err != nil {
 				return fmt.Errorf("failed to save password: %w", err)
 			}
 
@@ -108,14 +108,14 @@ The password will be saved according to your --password-storage setting
 					service.ServiceID)
 			}
 			cmd.PrintErrf("Password saved successfully for service %s (role: %s)\n",
-				service.ServiceID, dbSavePasswordRole)
+				service.ServiceID, role)
 			return nil
 		},
 	}
 
 	// Add flags for db save-password command
-	cmd.Flags().StringVarP(&dbSavePasswordValue, "password", "p", "", "Password to save")
-	cmd.Flags().StringVar(&dbSavePasswordRole, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password to save")
+	cmd.Flags().StringVar(&role, "role", "tsdbadmin", "Database role/username")
 
 	return cmd
 }

--- a/internal/cmd/db_save_password.go
+++ b/internal/cmd/db_save_password.go
@@ -26,10 +26,8 @@ from your configuration. The password can be provided via:
 3. Interactive prompt (if neither provided)
 
 The password will be saved according to your --password-storage setting
-(keyring, pgpass, or none).
-
-Examples:
-  # Save password with explicit value (highest precedence)
+(keyring, pgpass, or none).`,
+		Example: `  # Save password with explicit value (highest precedence)
   tiger db save-password svc-12345 --password=your-password
 
   # Using environment variable

--- a/internal/cmd/db_schema.go
+++ b/internal/cmd/db_schema.go
@@ -29,10 +29,8 @@ connection is opened in Tiger Cloud's immutable read-only mode.
 
 By default only user-facing schemas and objects are shown. View and routine
 definitions and object comments are omitted unless requested, since they can be
-large and may embed implementation details.
-
-Examples:
-  # Show the schema of the default service
+large and may embed implementation details.`,
+		Example: `  # Show the schema of the default service
   tiger db schema
 
   # Show the schema of a specific service

--- a/internal/cmd/db_schema.go
+++ b/internal/cmd/db_schema.go
@@ -7,12 +7,12 @@ import (
 )
 
 func buildDbSchemaCmd(app *common.App) *cobra.Command {
-	var dbSchemaSchema string
-	var dbSchemaInternal bool
-	var dbSchemaDefinitions bool
-	var dbSchemaComments bool
-	var dbSchemaRole string
-	var dbSchemaPooled bool
+	var schema string
+	var internal bool
+	var definitions bool
+	var comments bool
+	var role string
+	var pooled bool
 
 	cmd := &cobra.Command{
 		Use:   "schema [service-id]",
@@ -63,29 +63,29 @@ large and may embed implementation details.`,
 				return err
 			}
 
-			warnReplicaPooler(cmd, target, dbSchemaPooled)
+			warnReplicaPooler(cmd, target, pooled)
 
-			schema, err := common.FetchServiceSchema(cmd.Context(), cfg, target, dbSchemaRole, dbSchemaPooled, common.SchemaOptions{
-				Schema:             dbSchemaSchema,
-				IncludeInternal:    dbSchemaInternal,
-				IncludeDefinitions: dbSchemaDefinitions,
-				IncludeComments:    dbSchemaComments,
+			result, err := common.FetchServiceSchema(cmd.Context(), cfg, target, role, pooled, common.SchemaOptions{
+				Schema:             schema,
+				IncludeInternal:    internal,
+				IncludeDefinitions: definitions,
+				IncludeComments:    comments,
 			})
 			if err != nil {
 				return handleDatabaseError(err, target)
 			}
 
-			cmd.Print(common.FormatSchema(schema))
+			cmd.Print(common.FormatSchema(result))
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&dbSchemaSchema, "schema", "", "Restrict output to a single schema")
-	cmd.Flags().BoolVar(&dbSchemaInternal, "internal", false, "Include system schemas (pg_*, information_schema, TimescaleDB internals) and extension-owned objects")
-	cmd.Flags().BoolVar(&dbSchemaDefinitions, "definitions", false, "Include full object definitions (view SELECTs, function/procedure bodies)")
-	cmd.Flags().BoolVar(&dbSchemaComments, "comments", false, "Include object comments (COMMENT ON text)")
-	cmd.Flags().StringVar(&dbSchemaRole, "role", "tsdbadmin", "Database role/username")
-	cmd.Flags().BoolVar(&dbSchemaPooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&schema, "schema", "", "Restrict output to a single schema")
+	cmd.Flags().BoolVar(&internal, "internal", false, "Include system schemas (pg_*, information_schema, TimescaleDB internals) and extension-owned objects")
+	cmd.Flags().BoolVar(&definitions, "definitions", false, "Include full object definitions (view SELECTs, function/procedure bodies)")
+	cmd.Flags().BoolVar(&comments, "comments", false, "Include object comments (COMMENT ON text)")
+	cmd.Flags().StringVar(&role, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().BoolVar(&pooled, "pooled", false, "Use connection pooling")
 
 	return cmd
 }

--- a/internal/cmd/db_test_connection.go
+++ b/internal/cmd/db_test_connection.go
@@ -35,10 +35,8 @@ Return Codes:
   0: Server is accepting connections normally
   1: Server is rejecting connections (e.g., during startup)
   2: No response to connection attempt (server unreachable)
-  3: No attempt made (e.g., invalid parameters)
-
-Examples:
-  # Test connection to default service
+  3: No attempt made (e.g., invalid parameters)`,
+		Example: `  # Test connection to default service
   tiger db test-connection
 
   # Test connection to specific service

--- a/internal/cmd/db_test_connection.go
+++ b/internal/cmd/db_test_connection.go
@@ -15,9 +15,9 @@ import (
 )
 
 func buildDbTestConnectionCmd(app *common.App) *cobra.Command {
-	var dbTestConnectionTimeout time.Duration
-	var dbTestConnectionPooled bool
-	var dbTestConnectionRole string
+	var timeout time.Duration
+	var pooled bool
+	var role string
 
 	cmd := &cobra.Command{
 		Use:     "test-connection [service-id]",
@@ -69,12 +69,12 @@ Return Codes:
 				return common.ExitWithCode(common.ExitInvalidParameters, err)
 			}
 
-			warnReplicaPooler(cmd, target, dbTestConnectionPooled)
+			warnReplicaPooler(cmd, target, pooled)
 
 			// Build connection string for testing with password (if available)
 			details, err := target.Details(cfg, common.ConnectionDetailsOptions{
-				Pooled:       dbTestConnectionPooled,
-				Role:         dbTestConnectionRole,
+				Pooled:       pooled,
+				Role:         role,
 				WithPassword: true,
 			})
 			if err != nil {
@@ -82,19 +82,19 @@ Return Codes:
 			}
 
 			// Validate timeout (Cobra handles parsing automatically)
-			if dbTestConnectionTimeout < 0 {
-				return common.ExitWithCode(common.ExitInvalidParameters, fmt.Errorf("timeout must be positive or zero, got %v", dbTestConnectionTimeout))
+			if timeout < 0 {
+				return common.ExitWithCode(common.ExitInvalidParameters, fmt.Errorf("timeout must be positive or zero, got %v", timeout))
 			}
 
 			// Test the connection
-			return testDatabaseConnection(cmd.Context(), details.String(), dbTestConnectionTimeout, cmd)
+			return testDatabaseConnection(cmd.Context(), details.String(), timeout, cmd)
 		},
 	}
 
 	// Add flags for db test-connection command
-	cmd.Flags().DurationVarP(&dbTestConnectionTimeout, "timeout", "t", 3*time.Second, "Timeout duration (e.g., 30s, 5m, 1h). Use 0 for no timeout")
-	cmd.Flags().BoolVar(&dbTestConnectionPooled, "pooled", false, "Use connection pooling")
-	cmd.Flags().StringVar(&dbTestConnectionRole, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 3*time.Second, "Timeout duration (e.g., 30s, 5m, 1h). Use 0 for no timeout")
+	cmd.Flags().BoolVar(&pooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&role, "role", "tsdbadmin", "Database role/username")
 
 	return cmd
 }

--- a/internal/cmd/mcp_get.go
+++ b/internal/cmd/mcp_get.go
@@ -22,10 +22,8 @@ func buildMCPGetCmd(app *common.App) *cobra.Command {
 		Use:     "get <name>",
 		Aliases: []string{"describe", "show"},
 		Short:   "Get detailed information about a specific MCP capability",
-		Long: `Get detailed information about a specific MCP tool, prompt, resource, or resource template.
-
-Examples:
-  # Get details about a tool
+		Long:    `Get detailed information about a specific MCP tool, prompt, resource, or resource template.`,
+		Example: `  # Get details about a tool
   tiger mcp get service_create
 
   # Get details about a prompt

--- a/internal/cmd/mcp_get.go
+++ b/internal/cmd/mcp_get.go
@@ -91,7 +91,7 @@ func buildMCPGetCmd(app *common.App) *cobra.Command {
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/mcp_install.go
+++ b/internal/cmd/mcp_install.go
@@ -88,7 +88,7 @@ If no client is specified, you'll be prompted to select one interactively.`, gen
 	// Add flags
 	cmd.Flags().BoolVar(&noBackup, "no-backup", false, "Skip creating backup of existing configuration (default: create backup)")
 	cmd.Flags().StringVar(&configPath, "config-path", "", "Custom path to configuration file (overrides default locations)")
-	registerFlagCompletion(cmd, "config-path", fileCompletion("json", "toml"))
+	registerFlagCompletion(cmd, "config-path", fileCompletion())
 
 	return cmd
 }

--- a/internal/cmd/mcp_install.go
+++ b/internal/cmd/mcp_install.go
@@ -44,10 +44,8 @@ The command will:
 - Merge with existing MCP server configurations (doesn't overwrite other servers)
 - Validate the configuration after installation
 
-If no client is specified, you'll be prompted to select one interactively.
-
-Examples:
-  # Interactive client selection
+If no client is specified, you'll be prompted to select one interactively.`, generateSupportedEditorsHelp()),
+		Example: `  # Interactive client selection
   tiger mcp install
 
   # Install for Claude Code (User scope - available in all projects)
@@ -60,7 +58,7 @@ Examples:
   tiger mcp install claude-code --no-backup
 
   # Use custom configuration file path
-  tiger mcp install claude-code --config-path ~/custom/config.json`, generateSupportedEditorsHelp()),
+  tiger mcp install claude-code --config-path ~/custom/config.json`,
 		Args:         cobra.MaximumNArgs(1),
 		ValidArgs:    getValidEditorNames(),
 		SilenceUsage: true,

--- a/internal/cmd/mcp_install.go
+++ b/internal/cmd/mcp_install.go
@@ -88,6 +88,7 @@ If no client is specified, you'll be prompted to select one interactively.`, gen
 	// Add flags
 	cmd.Flags().BoolVar(&noBackup, "no-backup", false, "Skip creating backup of existing configuration (default: create backup)")
 	cmd.Flags().StringVar(&configPath, "config-path", "", "Custom path to configuration file (overrides default locations)")
+	registerFlagCompletion(cmd, "config-path", fileCompletion("json", "toml"))
 
 	return cmd
 }

--- a/internal/cmd/mcp_list.go
+++ b/internal/cmd/mcp_list.go
@@ -21,10 +21,8 @@ func buildMCPListCmd(app *common.App) *cobra.Command {
 		Short:   "List available MCP tools, prompts, and resources",
 		Long: `List all MCP tools, prompts, and resources exposed via the Tiger MCP server.
 
-The output can be formatted as a table, JSON, or YAML.
-
-Examples:
-  # List all capabilities in table format (default)
+The output can be formatted as a table, JSON, or YAML.`,
+		Example: `  # List all capabilities in table format (default)
   tiger mcp list
 
   # List as JSON

--- a/internal/cmd/mcp_list.go
+++ b/internal/cmd/mcp_list.go
@@ -30,9 +30,8 @@ The output can be formatted as a table, JSON, or YAML.`,
 
   # List as YAML
   tiger mcp list -o yaml`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := app.GetConfig()
 
@@ -68,7 +67,7 @@ The output can be formatted as a table, JSON, or YAML.`,
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/mcp_start.go
+++ b/internal/cmd/mcp_start.go
@@ -19,10 +19,8 @@ func buildMCPStartCmd(app *common.App) *cobra.Command {
 		Long: `Start the Tiger Model Context Protocol (MCP) server for AI assistant integration.
 
 The MCP server provides programmatic access to Tiger Cloud platform resources
-through Claude and other AI assistants. By default, it uses stdio transport.
-
-Examples:
-  # Start with stdio transport (default)
+through Claude and other AI assistants. By default, it uses stdio transport.`,
+		Example: `  # Start with stdio transport (default)
   tiger mcp start
 
   # Start with stdio transport (explicit)

--- a/internal/cmd/mcp_start.go
+++ b/internal/cmd/mcp_start.go
@@ -28,9 +28,8 @@ through Claude and other AI assistants. By default, it uses stdio transport.`,
 
   # Start with HTTP transport
   tiger mcp start http`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Default behavior when no subcommand is specified - use stdio
 			return startStdioServer(cmd, app)

--- a/internal/cmd/mcp_start_http.go
+++ b/internal/cmd/mcp_start_http.go
@@ -24,10 +24,8 @@ func buildMCPHTTPCmd(app *common.App) *cobra.Command {
 		Short: "Start MCP server with HTTP transport",
 		Long: `Start the MCP server using HTTP transport.
 
-The server will automatically find an available port if the specified port is busy.
-
-Examples:
-  # Start HTTP server on default port 8080
+The server will automatically find an available port if the specified port is busy.`,
+		Example: `  # Start HTTP server on default port 8080
   tiger mcp start http
 
   # Start HTTP server on custom port

--- a/internal/cmd/mcp_start_http.go
+++ b/internal/cmd/mcp_start_http.go
@@ -36,10 +36,9 @@ The server will automatically find an available port if the specified port is bu
 
   # Start server and bind to specific interface
   tiger mcp start http --host 192.168.1.100 --port 9000`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
-		SilenceErrors:     true, // HTTP server uses slog for all output, including errors
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true, // HTTP server uses slog for all output, including errors
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return startHTTPServer(cmd, app, host, port)
 		},

--- a/internal/cmd/mcp_start_http.go
+++ b/internal/cmd/mcp_start_http.go
@@ -16,8 +16,8 @@ import (
 
 // buildMCPHTTPCmd creates the http subcommand with port/host flags
 func buildMCPHTTPCmd(app *common.App) *cobra.Command {
-	var httpPort int
-	var httpHost string
+	var port int
+	var host string
 
 	cmd := &cobra.Command{
 		Use:   "http",
@@ -41,13 +41,13 @@ The server will automatically find an available port if the specified port is bu
 		SilenceUsage:      true,
 		SilenceErrors:     true, // HTTP server uses slog for all output, including errors
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return startHTTPServer(cmd, app, httpHost, httpPort)
+			return startHTTPServer(cmd, app, host, port)
 		},
 	}
 
 	// Add HTTP-specific flags
-	cmd.Flags().IntVar(&httpPort, "port", 8080, "Port to run HTTP server on")
-	cmd.Flags().StringVar(&httpHost, "host", "localhost", "Host to bind to")
+	cmd.Flags().IntVar(&port, "port", 8080, "Port to run HTTP server on")
+	cmd.Flags().StringVar(&host, "host", "localhost", "Host to bind to")
 
 	return cmd
 }

--- a/internal/cmd/mcp_start_stdio.go
+++ b/internal/cmd/mcp_start_stdio.go
@@ -14,9 +14,8 @@ func buildMCPStdioCmd(app *common.App) *cobra.Command {
 		Long:  `Start the MCP server using standard input/output transport.`,
 		Example: `  # Start with stdio transport
   tiger mcp start stdio`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return startStdioServer(cmd, app)
 		},

--- a/internal/cmd/mcp_start_stdio.go
+++ b/internal/cmd/mcp_start_stdio.go
@@ -11,10 +11,8 @@ func buildMCPStdioCmd(app *common.App) *cobra.Command {
 	return &cobra.Command{
 		Use:   "stdio",
 		Short: "Start MCP server with stdio transport",
-		Long: `Start the MCP server using standard input/output transport.
-
-Examples:
-  # Start with stdio transport
+		Long:  `Start the MCP server using standard input/output transport.`,
+		Example: `  # Start with stdio transport
   tiger mcp start stdio`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,

--- a/internal/cmd/project_list.go
+++ b/internal/cmd/project_list.go
@@ -34,9 +34,8 @@ func buildProjectListCmd(app *common.App) *cobra.Command {
 
 The active project — the one subsequent commands operate on — is marked in the
 output. Use 'tiger project use' to switch to another one.`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {

--- a/internal/cmd/project_list.go
+++ b/internal/cmd/project_list.go
@@ -61,7 +61,7 @@ output. Use 'tiger project use' to switch to another one.`,
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/project_use.go
+++ b/internal/cmd/project_use.go
@@ -22,10 +22,8 @@ is scoped to a single project. To use an API key for another project, run 'tiger
 with that project's keys instead.
 
 The default service (config key service_id) belongs to the project it was set in, so it is
-cleared when you switch away.
-
-Example:
-  tiger project use my-project-id`,
+cleared when you switch away.`,
+		Example:           `  tiger project use my-project-id`,
 		Args:              cobra.ExactArgs(1),
 		SilenceUsage:      true,
 		ValidArgsFunction: projectIDCompletion(app),

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -61,6 +61,13 @@ tiger auth login
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
+	// Complete nothing where no completion is registered, rather than falling
+	// back to filenames. Cobra checks this on the command and its parents, so
+	// setting it here covers every flag and argument in the tree. A flag that
+	// does want paths registers a completion for itself (fileCompletion,
+	// dirCompletion).
+	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveNoFileComp)
+
 	// Match flag names case-insensitively (e.g. `--Output` works the same as
 	// `--output`). Propagates to all subcommands added after this point.
 	cmd.SetGlobalNormalizationFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
@@ -76,7 +83,8 @@ tiger auth login
 	cmd.PersistentFlags().String("password-storage", config.DefaultPasswordStorage, "password storage method (keyring, pgpass, none)")
 	cmd.PersistentFlags().String("service-id", "", "service ID")
 	skipUpdateCheck := cmd.PersistentFlags().Bool("skip-update-check", false, "skip checking for updates on startup")
-	cmd.RegisterFlagCompletionFunc("password-storage", passwordStorageCompletion)
+	registerFlagCompletion(cmd, "password-storage", passwordStorageCompletion)
+	registerFlagCompletion(cmd, "config-dir", dirCompletion)
 
 	// Add all subcommands
 	cmd.AddCommand(buildVersionCmd(app))

--- a/internal/cmd/service_backups.go
+++ b/internal/cmd/service_backups.go
@@ -29,10 +29,8 @@ Backups run automatically on a schedule; there is no command to create or delete
 one. To restore data, create a recovery fork with tiger service fork.
 
 The service ID can be provided as an argument or will use the default service
-from your configuration.
-
-Examples:
-  # List backups for the default service
+from your configuration.`,
+		Example: `  # List backups for the default service
   tiger service backup
 
   # List backups for a specific service

--- a/internal/cmd/service_backups.go
+++ b/internal/cmd/service_backups.go
@@ -76,7 +76,7 @@ from your configuration.`,
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -16,17 +16,17 @@ import (
 
 // serviceCreateCmd represents the create command under service
 func buildServiceCreateCmd(app *common.App) *cobra.Command {
-	var createServiceName string
-	var createAddons []string
-	var createRegionCode string
-	var createCpuMillis string
-	var createMemoryGBs string
-	var createReplicaCount int
-	var createNoWait bool
-	var createWaitTimeout time.Duration
-	var createNoSetDefault bool
-	var createWithPassword bool
-	var createEnvironment string
+	var name string
+	var addons []string
+	var region string
+	var cpu string
+	var memory string
+	var replicas int
+	var noWait bool
+	var waitTimeout time.Duration
+	var noSetDefault bool
+	var withPassword bool
+	var environment string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -38,7 +38,13 @@ The default type of service created depends on your plan:
 - Paid plans: Creates a service with 0.5 CPU / 2 GB memory and the 'time-series' add-on
 
 By default, the newly created service will be set as your default service for future
-commands. Use --no-set-default to prevent this behavior.`,
+commands. Use --no-set-default to prevent this behavior.
+
+Allowed CPU/Memory Configurations:
+  shared / shared       |  0.5 CPU (500m) / 2GB    |  1 CPU (1000m) / 4GB     |  2 CPU (2000m) / 8GB
+  4 CPU (4000m) / 16GB  |  8 CPU (8000m) / 32GB    |  16 CPU (16000m) / 64GB  |  32 CPU (32000m) / 128GB
+
+Note: You can specify both CPU and memory together, or specify only one (the other will be automatically configured).`,
 		Example: `  # Create a TimescaleDB service with all defaults (0.5 CPU, 2GB, us-east-1, auto-generated name)
   tiger service create
 
@@ -70,46 +76,40 @@ commands. Use --no-set-default to prevent this behavior.`,
   tiger service create --name quick-db --no-wait
 
   # Create service with custom wait timeout
-  tiger service create --name patient-db --wait-timeout 1h
-
-Allowed CPU/Memory Configurations:
-  shared / shared       |  0.5 CPU (500m) / 2GB    |  1 CPU (1000m) / 4GB     |  2 CPU (2000m) / 8GB
-  4 CPU (4000m) / 16GB  |  8 CPU (8000m) / 32GB    |  16 CPU (16000m) / 64GB  |  32 CPU (32000m) / 128GB
-
-Note: You can specify both CPU and memory together, or specify only one (the other will be automatically configured).`,
+  tiger service create --name patient-db --wait-timeout 1h`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Auto-generate service name if not provided
-			if createServiceName == "" {
-				createServiceName = common.GenerateServiceName()
+			if name == "" {
+				name = common.GenerateServiceName()
 			}
 
 			// Validate addons and resources
-			addons, err := common.ValidateAddons(createAddons)
+			validAddons, err := common.ValidateAddons(addons)
 			if err != nil {
 				return err
 			}
-			if createReplicaCount < 0 {
+			if replicas < 0 {
 				return fmt.Errorf("replica count must be non-negative (--replicas)")
 			}
 
 			// Validate and normalize environment tag (case-insensitive)
-			createEnvironment = strings.ToUpper(createEnvironment)
-			if !slices.Contains(validEnvironmentTags, createEnvironment) {
-				return fmt.Errorf("environment must be one of: %s (got '%s')", strings.Join(validEnvironmentTags, ", "), createEnvironment)
+			environment = strings.ToUpper(environment)
+			if !slices.Contains(validEnvironmentTags, environment) {
+				return fmt.Errorf("environment must be one of: %s (got '%s')", strings.Join(validEnvironmentTags, ", "), environment)
 			}
 
 			// Validate and normalize CPU/Memory configuration
-			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(createCpuMillis, createMemoryGBs)
+			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(cpu, memory)
 			if err != nil {
 				return err
 			}
 
 			// Validate wait timeout (Cobra handles parsing automatically)
-			if createWaitTimeout <= 0 {
-				return fmt.Errorf("wait timeout must be positive, got %v", createWaitTimeout)
+			if waitTimeout <= 0 {
+				return fmt.Errorf("wait timeout must be positive, got %v", waitTimeout)
 			}
 
 			cfg, client, projectID, err := app.GetAll()
@@ -119,31 +119,31 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 
 			// Gate on the requested tag: under prod mode, creating DEV is
 			// allowed and creating PROD is not.
-			environmentTag := api.EnvironmentTag(createEnvironment)
+			environmentTag := api.EnvironmentTag(environment)
 			if err := common.CheckReadOnly(cfg, environmentTag); err != nil {
 				return err
 			}
 
 			// Prepare service creation request
 			serviceCreateReq := api.ServiceCreate{
-				Name:           createServiceName,
-				Addons:         util.ConvertStringSlicePtr[api.ServiceCreateAddons](addons),
-				ReplicaCount:   &createReplicaCount,
+				Name:           name,
+				Addons:         util.ConvertStringSlicePtr[api.ServiceCreateAddons](validAddons),
+				ReplicaCount:   &replicas,
 				CPUMillis:      cpuMemoryCfg.CPUMillisString(),
 				MemoryGbs:      cpuMemoryCfg.MemoryGBsString(),
 				EnvironmentTag: &environmentTag,
 			}
 
-			if createRegionCode != "" {
-				serviceCreateReq.RegionCode = &createRegionCode
+			if region != "" {
+				serviceCreateReq.RegionCode = &region
 			}
 
 			// Make API call to create service
 			// All status messages go to stderr
 			if cmd.Flags().Changed("name") {
-				cmd.PrintErrf("🚀 Creating service '%s'...\n", createServiceName)
+				cmd.PrintErrf("🚀 Creating service '%s'...\n", name)
 			} else {
-				cmd.PrintErrf("🚀 Creating service '%s' (auto-generated name)...\n", createServiceName)
+				cmd.PrintErrf("🚀 Creating service '%s' (auto-generated name)...\n", name)
 			}
 			resp, err := client.CreateServiceWithResponse(cmd.Context(), projectID, serviceCreateReq)
 			if err != nil {
@@ -169,7 +169,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			passwordSaved := handlePasswordSaving(cmd, cfg, service, util.Deref(service.InitialPassword))
 
 			// Set as default service unless --no-set-default is specified
-			if !createNoSetDefault {
+			if !noSetDefault {
 				if err := setDefaultService(cmd, cfg, serviceID); err != nil {
 					// Log warning but don't fail the command
 					cmd.PrintErrf("⚠️  Warning: Failed to set service as default: %v\n", err)
@@ -178,11 +178,11 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 
 			// Handle wait behavior
 			var waitErr error
-			if createNoWait {
+			if noWait {
 				cmd.PrintErrf("⏳ Service is being created. Use 'tiger service list' to check status.\n")
 			} else {
 				// Wait for service to be ready
-				cmd.PrintErrf("⏳ Waiting for service to be ready (wait timeout: %v)...\n", createWaitTimeout)
+				cmd.PrintErrf("⏳ Waiting for service to be ready (wait timeout: %v)...\n", waitTimeout)
 				if waitErr = common.WaitForService(cmd.Context(), common.WaitForServiceArgs{
 					Client:    client,
 					ProjectID: projectID,
@@ -193,17 +193,17 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 					},
 					Input:      cmd.InOrStdin(),
 					Output:     cmd.ErrOrStderr(),
-					Timeout:    createWaitTimeout,
+					Timeout:    waitTimeout,
 					TimeoutMsg: "service may still be provisioning",
 				}); waitErr != nil {
 					cmd.PrintErrf("❌ Error: %s\n", waitErr)
 				} else {
 					cmd.PrintErrf("🎉 Service is ready and running!\n")
-					printConnectMessage(cmd, passwordSaved, createNoSetDefault, serviceID)
+					printConnectMessage(cmd, passwordSaved, noSetDefault, serviceID)
 				}
 			}
 
-			if err := outputService(cmd, cfg, service, cfg.Output, createWithPassword, false); err != nil {
+			if err := outputService(cmd, cfg, service, cfg.Output, withPassword, false); err != nil {
 				cmd.PrintErrf("⚠️  Warning: Failed to output service details: %v\n", err)
 			}
 
@@ -214,17 +214,17 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&createServiceName, "name", "", "Service name (auto-generated if not provided)")
-	cmd.Flags().StringSliceVar(&createAddons, "addons", nil, fmt.Sprintf("Addons to enable (%s, or 'none' for PostgreSQL-only)", strings.Join(common.ValidAddons(), ", ")))
-	cmd.Flags().StringVar(&createRegionCode, "region", "", "Region code")
-	cmd.Flags().StringVar(&createCpuMillis, "cpu", "", "CPU allocation in millicores or 'shared'")
-	cmd.Flags().StringVar(&createMemoryGBs, "memory", "", "Memory allocation in gigabytes or 'shared'")
-	cmd.Flags().IntVar(&createReplicaCount, "replicas", 0, "Number of high-availability replicas")
-	cmd.Flags().StringVar(&createEnvironment, "environment", "DEV", "Environment tag (DEV or PROD)")
-	cmd.Flags().BoolVar(&createNoWait, "no-wait", false, "Don't wait for operation to complete")
-	cmd.Flags().DurationVar(&createWaitTimeout, "wait-timeout", 30*time.Minute, "Wait timeout duration (e.g., 30m, 1h30m, 90s)")
-	cmd.Flags().BoolVar(&createNoSetDefault, "no-set-default", false, "Don't set this service as the default service")
-	cmd.Flags().BoolVar(&createWithPassword, "with-password", false, "Include password in output")
+	cmd.Flags().StringVar(&name, "name", "", "Service name (auto-generated if not provided)")
+	cmd.Flags().StringSliceVar(&addons, "addons", nil, fmt.Sprintf("Addons to enable (%s, or 'none' for PostgreSQL-only)", strings.Join(common.ValidAddons(), ", ")))
+	cmd.Flags().StringVar(&region, "region", "", "Region code")
+	cmd.Flags().StringVar(&cpu, "cpu", "", "CPU allocation in millicores or 'shared'")
+	cmd.Flags().StringVar(&memory, "memory", "", "Memory allocation in gigabytes or 'shared'")
+	cmd.Flags().IntVar(&replicas, "replicas", 0, "Number of high-availability replicas")
+	cmd.Flags().StringVar(&environment, "environment", "DEV", "Environment tag (DEV or PROD)")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for operation to complete")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "Wait timeout duration (e.g., 30m, 1h30m, 90s)")
+	cmd.Flags().BoolVar(&noSetDefault, "no-set-default", false, "Don't set this service as the default service")
+	cmd.Flags().BoolVar(&withPassword, "with-password", false, "Include password in output")
 	cmd.Flags().VarP(new(outputWithEnvFlag), "output", "o", "Output format (json, yaml, env, table)")
 
 	cmd.RegisterFlagCompletionFunc("addons", addonsCompletion)

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -77,9 +77,8 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 
   # Create service with custom wait timeout
   tiger service create --name patient-db --wait-timeout 1h`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Auto-generate service name if not provided
 			if name == "" {
@@ -227,11 +226,11 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 	cmd.Flags().BoolVar(&withPassword, "with-password", false, "Include password in output")
 	cmd.Flags().VarP(new(outputWithEnvFlag), "output", "o", "Output format (json, yaml, env, table)")
 
-	cmd.RegisterFlagCompletionFunc("addons", addonsCompletion)
-	cmd.RegisterFlagCompletionFunc("environment", environmentCompletion)
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion("env"))
-	cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(common.GetAllowedCPUMemoryConfigs()))
-	cmd.RegisterFlagCompletionFunc("memory", memoryCompletion(common.GetAllowedCPUMemoryConfigs()))
+	registerFlagCompletion(cmd, "addons", addonsCompletion)
+	registerFlagCompletion(cmd, "environment", environmentCompletion)
+	registerFlagCompletion(cmd, "output", outputCompletion("env"))
+	registerFlagCompletion(cmd, "cpu", cpuCompletion(common.GetAllowedCPUMemoryConfigs()))
+	registerFlagCompletion(cmd, "memory", memoryCompletion(common.GetAllowedCPUMemoryConfigs()))
 
 	return cmd
 }

--- a/internal/cmd/service_create.go
+++ b/internal/cmd/service_create.go
@@ -38,10 +38,8 @@ The default type of service created depends on your plan:
 - Paid plans: Creates a service with 0.5 CPU / 2 GB memory and the 'time-series' add-on
 
 By default, the newly created service will be set as your default service for future
-commands. Use --no-set-default to prevent this behavior.
-
-Examples:
-  # Create a TimescaleDB service with all defaults (0.5 CPU, 2GB, us-east-1, auto-generated name)
+commands. Use --no-set-default to prevent this behavior.`,
+		Example: `  # Create a TimescaleDB service with all defaults (0.5 CPU, 2GB, us-east-1, auto-generated name)
   tiger service create
 
   # Create a free TimescaleDB service

--- a/internal/cmd/service_delete.go
+++ b/internal/cmd/service_delete.go
@@ -14,9 +14,9 @@ import (
 
 // buildServiceDeleteCmd creates the delete subcommand
 func buildServiceDeleteCmd(app *common.App) *cobra.Command {
-	var deleteNoWait bool
-	var deleteWaitTimeout time.Duration
-	var deleteConfirm bool
+	var noWait bool
+	var waitTimeout time.Duration
+	var confirm bool
 
 	cmd := &cobra.Command{
 		Use:     "delete [service-id]",
@@ -61,7 +61,7 @@ Note for AI agents: Always confirm with the user before performing this destruct
 			}
 
 			// Prompt for confirmation unless --confirm is used
-			if !deleteConfirm {
+			if !confirm {
 				if !util.IsTerminal(cmd.InOrStdin()) || !util.IsTerminal(cmd.ErrOrStderr()) {
 					return fmt.Errorf("TTY not detected - cannot prompt for confirmation. Use --confirm to skip the prompt")
 				}
@@ -95,7 +95,7 @@ Note for AI agents: Always confirm with the user before performing this destruct
 			cmd.PrintErrf("🗑️  Delete request accepted for service '%s'.\n", serviceID)
 
 			// If not waiting, return early
-			if deleteNoWait {
+			if noWait {
 				cmd.PrintErrln("💡 Use 'tiger service list' to check deletion status.")
 				return nil
 			}
@@ -110,7 +110,7 @@ Note for AI agents: Always confirm with the user before performing this destruct
 				},
 				Input:      cmd.InOrStdin(),
 				Output:     cmd.ErrOrStderr(),
-				Timeout:    deleteWaitTimeout,
+				Timeout:    waitTimeout,
 				TimeoutMsg: "service may still be deleting",
 			}); err != nil {
 				// Return error for sake of exit code, but log ourselves for sake of icon
@@ -124,9 +124,9 @@ Note for AI agents: Always confirm with the user before performing this destruct
 		},
 	}
 
-	cmd.Flags().BoolVar(&deleteNoWait, "no-wait", false, "Don't wait for deletion to complete, return immediately")
-	cmd.Flags().DurationVar(&deleteWaitTimeout, "wait-timeout", 30*time.Minute, "Wait timeout duration (e.g., 30m, 1h30m, 90s)")
-	cmd.Flags().BoolVar(&deleteConfirm, "confirm", false, "Skip confirmation prompt (AI agents must confirm with user first)")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for deletion to complete, return immediately")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "Wait timeout duration (e.g., 30m, 1h30m, 90s)")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Skip confirmation prompt (AI agents must confirm with user first)")
 
 	return cmd
 }

--- a/internal/cmd/service_delete.go
+++ b/internal/cmd/service_delete.go
@@ -27,10 +27,8 @@ func buildServiceDeleteCmd(app *common.App) *cobra.Command {
 This operation is irreversible. By default, you will be prompted to type the service ID
 to confirm deletion, unless you use the --confirm flag.
 
-Note for AI agents: Always confirm with the user before performing this destructive operation.
-
-Examples:
-  # Delete a service (with confirmation prompt)
+Note for AI agents: Always confirm with the user before performing this destructive operation.`,
+		Example: `  # Delete a service (with confirmation prompt)
   tiger service delete svc-12345
 
   # Delete service without confirmation prompt

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -16,17 +16,17 @@ import (
 
 // buildServiceForkCmd creates the fork subcommand
 func buildServiceForkCmd(app *common.App) *cobra.Command {
-	var forkServiceName string
-	var forkNoWait bool
-	var forkNoSetDefault bool
-	var forkWaitTimeout time.Duration
-	var forkNow bool
-	var forkLastSnapshot bool
-	var forkToTimestamp time.Time
-	var forkCPU string
-	var forkMemory string
-	var forkWithPassword bool
-	var forkEnvironment string
+	var name string
+	var noWait bool
+	var noSetDefault bool
+	var waitTimeout time.Duration
+	var now bool
+	var lastSnapshot bool
+	var toTimestamp time.Time
+	var cpu string
+	var memory string
+	var withPassword bool
+	var environment string
 
 	cmd := &cobra.Command{
 		Use:   "fork [service-id]",
@@ -73,10 +73,10 @@ You can override any of these defaults with the corresponding flags.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate timing flags first - exactly one must be specified
 			timingFlagsSet := 0
-			if forkNow {
+			if now {
 				timingFlagsSet++
 			}
-			if forkLastSnapshot {
+			if lastSnapshot {
 				timingFlagsSet++
 			}
 			toTimestampSet := cmd.Flags().Changed("to-timestamp")
@@ -92,9 +92,9 @@ You can override any of these defaults with the corresponding flags.`,
 			}
 
 			// Validate and normalize environment tag (case-insensitive)
-			forkEnvironment = strings.ToUpper(forkEnvironment)
-			if !slices.Contains(validEnvironmentTags, forkEnvironment) {
-				return fmt.Errorf("environment must be one of: %s (got '%s')", strings.Join(validEnvironmentTags, ", "), forkEnvironment)
+			environment = strings.ToUpper(environment)
+			if !slices.Contains(validEnvironmentTags, environment) {
+				return fmt.Errorf("environment must be one of: %s (got '%s')", strings.Join(validEnvironmentTags, ", "), environment)
 			}
 
 			cfg, client, projectID, err := app.GetAll()
@@ -104,7 +104,7 @@ You can override any of these defaults with the corresponding flags.`,
 
 			// Gate on the fork's own tag: under prod mode, forking a PROD source
 			// into a DEV fork is allowed — it reads production without changing it.
-			environmentTag := api.EnvironmentTag(forkEnvironment)
+			environmentTag := api.EnvironmentTag(environment)
 			if err := common.CheckReadOnly(cfg, environmentTag); err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ You can override any of these defaults with the corresponding flags.`,
 			}
 
 			// Use provided custom values, validate against allowed combinations
-			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(forkCPU, forkMemory)
+			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(cpu, memory)
 			if err != nil {
 				return err
 			}
@@ -125,13 +125,13 @@ You can override any of these defaults with the corresponding flags.`,
 			var forkStrategy api.ForkStrategy
 			var targetTime *time.Time
 
-			if forkNow {
+			if now {
 				forkStrategy = api.ForkStrategyNOW
-			} else if forkLastSnapshot {
+			} else if lastSnapshot {
 				forkStrategy = api.ForkStrategyLASTSNAPSHOT
 			} else if toTimestampSet {
 				forkStrategy = api.ForkStrategyPITR
-				targetTime = new(forkToTimestamp)
+				targetTime = new(toTimestamp)
 			}
 
 			// Display what we're about to do
@@ -145,7 +145,7 @@ You can override any of these defaults with the corresponding flags.`,
 				strategyDesc = fmt.Sprintf("point-in-time: %s", targetTime.Format(time.RFC3339))
 			}
 			// Prepare output message for name
-			displayName := forkServiceName
+			displayName := name
 			if !cmd.Flags().Changed("name") {
 				displayName = "(auto-generated)"
 			}
@@ -161,8 +161,8 @@ You can override any of these defaults with the corresponding flags.`,
 			}
 
 			// Only set optional fields if flags were provided
-			if forkServiceName != "" {
-				forkReq.Name = &forkServiceName
+			if name != "" {
+				forkReq.Name = &name
 			}
 
 			// Make API call to fork service
@@ -189,7 +189,7 @@ You can override any of these defaults with the corresponding flags.`,
 			passwordSaved := handlePasswordSaving(cmd, cfg, forkedService, util.Deref(forkedService.InitialPassword))
 
 			// Set as default service unless --no-set-default is used
-			if !forkNoSetDefault {
+			if !noSetDefault {
 				if err := setDefaultService(cmd, cfg, forkedServiceID); err != nil {
 					// Log warning but don't fail the command
 					cmd.PrintErrf("⚠️  Warning: Failed to set service as default: %v\n", err)
@@ -198,11 +198,11 @@ You can override any of these defaults with the corresponding flags.`,
 
 			// Handle wait behavior
 			var waitErr error
-			if forkNoWait {
+			if noWait {
 				cmd.PrintErrf("⏳ Service is being forked. Use 'tiger service list' to check status.\n")
 			} else {
 				// Wait for service to be ready
-				cmd.PrintErrf("⏳ Waiting for fork to complete (timeout: %v)...\n", forkWaitTimeout)
+				cmd.PrintErrf("⏳ Waiting for fork to complete (timeout: %v)...\n", waitTimeout)
 				if waitErr = common.WaitForService(cmd.Context(), common.WaitForServiceArgs{
 					Client:    client,
 					ProjectID: projectID,
@@ -213,17 +213,17 @@ You can override any of these defaults with the corresponding flags.`,
 					},
 					Input:      cmd.InOrStdin(),
 					Output:     cmd.ErrOrStderr(),
-					Timeout:    forkWaitTimeout,
+					Timeout:    waitTimeout,
 					TimeoutMsg: "service may still be provisioning",
 				}); waitErr != nil {
 					cmd.PrintErrf("❌ Error: %s\n", waitErr)
 				} else {
 					cmd.PrintErrf("🎉 Service fork completed successfully!\n")
-					printConnectMessage(cmd, passwordSaved, forkNoSetDefault, forkedServiceID)
+					printConnectMessage(cmd, passwordSaved, noSetDefault, forkedServiceID)
 				}
 			}
 
-			if err := outputService(cmd, cfg, forkedService, cfg.Output, forkWithPassword, false); err != nil {
+			if err := outputService(cmd, cfg, forkedService, cfg.Output, withPassword, false); err != nil {
 				cmd.PrintErrf("⚠️  Warning: Failed to output service details: %v\n", err)
 			}
 
@@ -234,21 +234,21 @@ You can override any of these defaults with the corresponding flags.`,
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&forkServiceName, "name", "", "Name for the forked service (defaults to '{source-name}-fork')")
-	cmd.Flags().BoolVar(&forkNoWait, "no-wait", false, "Don't wait for fork operation to complete")
-	cmd.Flags().BoolVar(&forkNoSetDefault, "no-set-default", false, "Don't set this service as the default service")
-	cmd.Flags().DurationVar(&forkWaitTimeout, "wait-timeout", 30*time.Minute, "Wait timeout duration (e.g., 30m, 1h30m, 90s)")
+	cmd.Flags().StringVar(&name, "name", "", "Name for the forked service (defaults to '{source-name}-fork')")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for fork operation to complete")
+	cmd.Flags().BoolVar(&noSetDefault, "no-set-default", false, "Don't set this service as the default service")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "Wait timeout duration (e.g., 30m, 1h30m, 90s)")
 
 	// Timing strategy flags
-	cmd.Flags().BoolVar(&forkNow, "now", false, "Fork at the current database state (creates new snapshot or uses WAL replay)")
-	cmd.Flags().BoolVar(&forkLastSnapshot, "last-snapshot", false, "Fork at the last existing snapshot (faster)")
-	cmd.Flags().TimeVar(&forkToTimestamp, "to-timestamp", time.Time{}, []string{time.RFC3339}, "Fork at a specific point in time (RFC3339 format, e.g., 2025-01-15T10:30:00Z)")
+	cmd.Flags().BoolVar(&now, "now", false, "Fork at the current database state (creates new snapshot or uses WAL replay)")
+	cmd.Flags().BoolVar(&lastSnapshot, "last-snapshot", false, "Fork at the last existing snapshot (faster)")
+	cmd.Flags().TimeVar(&toTimestamp, "to-timestamp", time.Time{}, []string{time.RFC3339}, "Fork at a specific point in time (RFC3339 format, e.g., 2025-01-15T10:30:00Z)")
 
 	// Resource customization flags
-	cmd.Flags().StringVar(&forkCPU, "cpu", "", "CPU allocation in millicores (inherits from source if not specified)")
-	cmd.Flags().StringVar(&forkMemory, "memory", "", "Memory allocation in gigabytes (inherits from source if not specified)")
-	cmd.Flags().StringVar(&forkEnvironment, "environment", "DEV", "Environment tag (DEV or PROD)")
-	cmd.Flags().BoolVar(&forkWithPassword, "with-password", false, "Include password in output")
+	cmd.Flags().StringVar(&cpu, "cpu", "", "CPU allocation in millicores (inherits from source if not specified)")
+	cmd.Flags().StringVar(&memory, "memory", "", "Memory allocation in gigabytes (inherits from source if not specified)")
+	cmd.Flags().StringVar(&environment, "environment", "DEV", "Environment tag (DEV or PROD)")
+	cmd.Flags().BoolVar(&withPassword, "with-password", false, "Include password in output")
 	cmd.Flags().VarP(new(outputWithEnvFlag), "output", "o", "Output format (json, yaml, env, table)")
 
 	cmd.RegisterFlagCompletionFunc("environment", environmentCompletion)

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -43,10 +43,8 @@ By default:
 - CPU and memory will be inherited from the source service
 - The forked service will be set as your default service
 
-You can override any of these defaults with the corresponding flags.
-
-Examples:
-  # Fork a service at the current state
+You can override any of these defaults with the corresponding flags.`,
+		Example: `  # Fork a service at the current state
   tiger service fork svc-12345 --now
 
   # Fork a service at the last snapshot

--- a/internal/cmd/service_fork.go
+++ b/internal/cmd/service_fork.go
@@ -251,10 +251,10 @@ You can override any of these defaults with the corresponding flags.`,
 	cmd.Flags().BoolVar(&withPassword, "with-password", false, "Include password in output")
 	cmd.Flags().VarP(new(outputWithEnvFlag), "output", "o", "Output format (json, yaml, env, table)")
 
-	cmd.RegisterFlagCompletionFunc("environment", environmentCompletion)
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion("env"))
-	cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(common.GetAllowedCPUMemoryConfigs()))
-	cmd.RegisterFlagCompletionFunc("memory", memoryCompletion(common.GetAllowedCPUMemoryConfigs()))
+	registerFlagCompletion(cmd, "environment", environmentCompletion)
+	registerFlagCompletion(cmd, "output", outputCompletion("env"))
+	registerFlagCompletion(cmd, "cpu", cpuCompletion(common.GetAllowedCPUMemoryConfigs()))
+	registerFlagCompletion(cmd, "memory", memoryCompletion(common.GetAllowedCPUMemoryConfigs()))
 
 	return cmd
 }

--- a/internal/cmd/service_get.go
+++ b/internal/cmd/service_get.go
@@ -71,7 +71,7 @@ the service including configuration, status, endpoints, and resource usage.`,
 
 	cmd.Flags().BoolVar(&withPassword, "with-password", false, "Include password in output")
 	cmd.Flags().VarP(new(outputWithEnvFlag), "output", "o", "Output format (json, yaml, env, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion("env"))
+	registerFlagCompletion(cmd, "output", outputCompletion("env"))
 
 	return cmd
 }

--- a/internal/cmd/service_get.go
+++ b/internal/cmd/service_get.go
@@ -21,10 +21,8 @@ func buildServiceGetCmd(app *common.App) *cobra.Command {
 
 The service ID can be provided as an argument or will use the default service
 from your configuration. This command displays comprehensive information about
-the service including configuration, status, endpoints, and resource usage.
-
-Examples:
-  # Get default service details
+the service including configuration, status, endpoints, and resource usage.`,
+		Example: `  # Get default service details
   tiger service get
 
   # Get specific service details

--- a/internal/cmd/service_list.go
+++ b/internal/cmd/service_list.go
@@ -19,13 +19,12 @@ import (
 func buildServiceListCmd(app *common.App) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:               "list",
-		Aliases:           []string{"ls"},
-		Short:             "List all services",
-		Long:              `List all database services in the current project.`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Use:          "list",
+		Aliases:      []string{"ls"},
+		Short:        "List all services",
+		Long:         `List all database services in the current project.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, client, projectID, err := app.GetAll()
 			if err != nil {
@@ -60,7 +59,7 @@ func buildServiceListCmd(app *common.App) *cobra.Command {
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/service_logs.go
+++ b/internal/cmd/service_logs.go
@@ -130,7 +130,7 @@ from your configuration.`,
 	cmd.Flags().TimeVar(&until, "until", time.Time{}, []string{time.RFC3339}, "Fetch logs before this timestamp (RFC3339 format, e.g., 2024-01-15T10:00:00Z)")
 	cmd.Flags().IntVar(&node, "node", 0, "Specific service node to fetch logs from (for services with HA replicas, 0 is valid)")
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (text, json, yaml)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 
 	return cmd
 }

--- a/internal/cmd/service_logs.go
+++ b/internal/cmd/service_logs.go
@@ -28,10 +28,8 @@ Fetches and displays logs from the specified service. By default, shows the last
 100 log entries. Supports filtering by time range.
 
 The service ID can be provided as an argument or will use the default service
-from your configuration.
-
-Examples:
-  # View last 100 logs for default service (default behavior)
+from your configuration.`,
+		Example: `  # View last 100 logs for default service (default behavior)
   tiger service logs
 
   # View logs for specific service

--- a/internal/cmd/service_metrics_available_series.go
+++ b/internal/cmd/service_metrics_available_series.go
@@ -62,6 +62,6 @@ func buildServiceMetricsAvailableSeriesCmd(app *common.App) *cobra.Command {
 	}
 
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
+	registerFlagCompletion(cmd, "output", outputCompletion())
 	return cmd
 }

--- a/internal/cmd/service_metrics_series.go
+++ b/internal/cmd/service_metrics_series.go
@@ -119,9 +119,9 @@ full list of raw data points.`,
 	cmd.Flags().IntVar(&bucketSeconds, "bucket-seconds", 0, "Aggregation bucket size in seconds (optional; server auto-selects based on the time window when omitted, minimum 60s)")
 	cmd.Flags().StringVar(&fn, "fn", "", "Aggregation function applied per bucket. One of: RATE, INCREASE, SUM, AVG, MIN, MAX, COUNT, P50, P90, P99, LAST. Rejected on the timescale_cloud_* resource/qps/connections/jobs metrics; omit to let the server pick the default")
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion())
-	cmd.RegisterFlagCompletionFunc("role", metricsSeriesRoleCompletion)
-	cmd.RegisterFlagCompletionFunc("fn", metricsSeriesFnCompletion)
+	registerFlagCompletion(cmd, "output", outputCompletion())
+	registerFlagCompletion(cmd, "role", metricsSeriesRoleCompletion)
+	registerFlagCompletion(cmd, "fn", metricsSeriesFnCompletion)
 
 	cmd.MarkFlagRequired("metric")
 	cmd.MarkFlagRequired("from")

--- a/internal/cmd/service_metrics_series.go
+++ b/internal/cmd/service_metrics_series.go
@@ -33,10 +33,8 @@ func buildServiceMetricsSeriesCmd(app *common.App) *cobra.Command {
 Use 'tiger service metrics available-series' to discover valid metric names.
 
 Each labeled series (e.g. one per replica) is returned independently with its
-full list of raw data points.
-
-Examples:
-  # Fetch CPU usage for the last hour
+full list of raw data points.`,
+		Example: `  # Fetch CPU usage for the last hour
   tiger service metrics series --metric timescale_cloud_system_cpu_usage_millicores \
     --from 2026-05-13T00:00:00Z --to 2026-05-13T01:00:00Z
 

--- a/internal/cmd/service_metrics_series.go
+++ b/internal/cmd/service_metrics_series.go
@@ -21,7 +21,7 @@ func buildServiceMetricsSeriesCmd(app *common.App) *cobra.Command {
 	var from string
 	var to string
 	var role string
-	var filters []string
+	var filter []string
 	var bucketSeconds int
 	var fn string
 
@@ -62,7 +62,7 @@ full list of raw data points.`,
 				return fmt.Errorf("--to must be RFC3339 (e.g., 2026-05-13T01:00:00Z): %w", err)
 			}
 
-			labelFilters, err := parseMetricFilters(role, filters)
+			labelFilters, err := parseMetricFilters(role, filter)
 			if err != nil {
 				return err
 			}
@@ -115,7 +115,7 @@ full list of raw data points.`,
 	cmd.Flags().StringVar(&from, "from", "", "Start of the time window (RFC3339)")
 	cmd.Flags().StringVar(&to, "to", "", "End of the time window (RFC3339)")
 	cmd.Flags().StringVar(&role, "role", "", "Filter to a specific instance role (PRIMARY or REPLICA)")
-	cmd.Flags().StringSliceVar(&filters, "filter", nil, "Arbitrary label filter as name=value (repeatable)")
+	cmd.Flags().StringSliceVar(&filter, "filter", nil, "Arbitrary label filter as name=value (repeatable)")
 	cmd.Flags().IntVar(&bucketSeconds, "bucket-seconds", 0, "Aggregation bucket size in seconds (optional; server auto-selects based on the time window when omitted, minimum 60s)")
 	cmd.Flags().StringVar(&fn, "fn", "", "Aggregation function applied per bucket. One of: RATE, INCREASE, SUM, AVG, MIN, MAX, COUNT, P50, P90, P99, LAST. Rejected on the timescale_cloud_* resource/qps/connections/jobs metrics; omit to let the server pick the default")
 	cmd.Flags().VarP(new(outputFlag), "output", "o", "Output format (json, yaml, table)")

--- a/internal/cmd/service_resize.go
+++ b/internal/cmd/service_resize.go
@@ -29,10 +29,8 @@ allocated to your database service.
 
 The service may be temporarily unavailable during the resize operation. Note
 that changing resources will affect your billing - increasing resources will
-increase costs.
-
-Examples:
-  # Resize default service to 2 CPU cores and 8GB memory
+increase costs.`,
+		Example: `  # Resize default service to 2 CPU cores and 8GB memory
   tiger service resize --cpu 2000 --memory 8
 
   # Resize specific service to 4 CPU cores and 16GB memory

--- a/internal/cmd/service_resize.go
+++ b/internal/cmd/service_resize.go
@@ -13,10 +13,10 @@ import (
 
 // buildServiceResizeCmd creates the resize subcommand
 func buildServiceResizeCmd(app *common.App) *cobra.Command {
-	var resizeCPU string
-	var resizeMemory string
-	var resizeNoWait bool
-	var resizeWaitTimeout time.Duration
+	var cpu string
+	var memory string
+	var noWait bool
+	var waitTimeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "resize [service-id]",
@@ -29,7 +29,13 @@ allocated to your database service.
 
 The service may be temporarily unavailable during the resize operation. Note
 that changing resources will affect your billing - increasing resources will
-increase costs.`,
+increase costs.
+
+Allowed CPU/Memory Configurations:
+  0.5 CPU (500m) / 2GB  |  1 CPU (1000m) / 4GB     |  2 CPU (2000m) / 8GB     |  4 CPU (4000m) / 16GB
+  8 CPU (8000m) / 32GB  |  16 CPU (16000m) / 64GB  |  32 CPU (32000m) / 128GB
+
+Note: You can specify both CPU and memory together, or specify only one (the other will be automatically configured).`,
 		Example: `  # Resize default service to 2 CPU cores and 8GB memory
   tiger service resize --cpu 2000 --memory 8
 
@@ -46,13 +52,7 @@ increase costs.`,
   tiger service resize --cpu 2000 --memory 8 --no-wait
 
   # Resize with custom wait timeout
-  tiger service resize --cpu 2000 --memory 8 --wait-timeout 45m
-
-Allowed CPU/Memory Configurations:
-  0.5 CPU (500m) / 2GB  |  1 CPU (1000m) / 4GB     |  2 CPU (2000m) / 8GB     |  4 CPU (4000m) / 16GB
-  8 CPU (8000m) / 32GB  |  16 CPU (16000m) / 64GB  |  32 CPU (32000m) / 128GB
-
-Note: You can specify both CPU and memory together, or specify only one (the other will be automatically configured).`,
+  tiger service resize --cpu 2000 --memory 8 --wait-timeout 45m`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
 		SilenceUsage:      true,
@@ -69,7 +69,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			}
 
 			// Validate and normalize CPU/Memory configuration
-			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(resizeCPU, resizeMemory)
+			cpuMemoryCfg, err := common.ValidateAndNormalizeCPUMemory(cpu, memory)
 			if err != nil {
 				return err
 			}
@@ -111,13 +111,13 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 			cmd.PrintErrf("✅ Resize request accepted for service '%s'!\n", serviceID)
 
 			// If not waiting, return early
-			if resizeNoWait {
+			if noWait {
 				cmd.PrintErrln("💡 Use 'tiger service get' to check service status.")
 				return nil
 			}
 
 			// Wait for resize to complete
-			cmd.PrintErrf("⏳ Waiting for resize to complete (timeout: %v)...\n", resizeWaitTimeout)
+			cmd.PrintErrf("⏳ Waiting for resize to complete (timeout: %v)...\n", waitTimeout)
 			if err := common.WaitForService(cmd.Context(), common.WaitForServiceArgs{
 				Client:    client,
 				ProjectID: projectID,
@@ -128,7 +128,7 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 				},
 				Input:      cmd.InOrStdin(),
 				Output:     cmd.ErrOrStderr(),
-				Timeout:    resizeWaitTimeout,
+				Timeout:    waitTimeout,
 				TimeoutMsg: "service may still be resizing",
 			}); err != nil {
 				// Return error for sake of exit code, but silence since we already output it
@@ -143,10 +143,10 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&resizeCPU, "cpu", "", "CPU allocation in millicores")
-	cmd.Flags().StringVar(&resizeMemory, "memory", "", "Memory allocation in gigabytes")
-	cmd.Flags().BoolVar(&resizeNoWait, "no-wait", false, "Don't wait for resize operation to complete")
-	cmd.Flags().DurationVar(&resizeWaitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
+	cmd.Flags().StringVar(&cpu, "cpu", "", "CPU allocation in millicores")
+	cmd.Flags().StringVar(&memory, "memory", "", "Memory allocation in gigabytes")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for resize operation to complete")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
 
 	cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(common.GetAllowedResizeCPUMemoryConfigs()))
 	cmd.RegisterFlagCompletionFunc("memory", memoryCompletion(common.GetAllowedResizeCPUMemoryConfigs()))

--- a/internal/cmd/service_resize.go
+++ b/internal/cmd/service_resize.go
@@ -148,8 +148,8 @@ Note: You can specify both CPU and memory together, or specify only one (the oth
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for resize operation to complete")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
 
-	cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(common.GetAllowedResizeCPUMemoryConfigs()))
-	cmd.RegisterFlagCompletionFunc("memory", memoryCompletion(common.GetAllowedResizeCPUMemoryConfigs()))
+	registerFlagCompletion(cmd, "cpu", cpuCompletion(common.GetAllowedResizeCPUMemoryConfigs()))
+	registerFlagCompletion(cmd, "memory", memoryCompletion(common.GetAllowedResizeCPUMemoryConfigs()))
 
 	return cmd
 }

--- a/internal/cmd/service_start.go
+++ b/internal/cmd/service_start.go
@@ -13,8 +13,8 @@ import (
 
 // buildServiceStartCmd creates the start subcommand
 func buildServiceStartCmd(app *common.App) *cobra.Command {
-	var startNoWait bool
-	var startWaitTimeout time.Duration
+	var noWait bool
+	var waitTimeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:     "start [service-id]",
@@ -73,13 +73,13 @@ This operation starts a service that is currently in an inactive/stopped state. 
 			cmd.PrintErrf("▶️  Start request accepted for service '%s'.\n", serviceID)
 
 			// If not waiting, return early
-			if startNoWait {
+			if noWait {
 				cmd.PrintErrln("💡 Use 'tiger service get' to check service status.")
 				return nil
 			}
 
 			// Wait for service to become ready
-			cmd.PrintErrf("⏳ Waiting for service to start (wait timeout: %v)...\n", startWaitTimeout)
+			cmd.PrintErrf("⏳ Waiting for service to start (wait timeout: %v)...\n", waitTimeout)
 			if err := common.WaitForService(cmd.Context(), common.WaitForServiceArgs{
 				Client:    client,
 				ProjectID: projectID,
@@ -90,7 +90,7 @@ This operation starts a service that is currently in an inactive/stopped state. 
 				},
 				Input:      cmd.InOrStdin(),
 				Output:     cmd.ErrOrStderr(),
-				Timeout:    startWaitTimeout,
+				Timeout:    waitTimeout,
 				TimeoutMsg: "service may still be starting",
 			}); err != nil {
 				// Return error for sake of exit code, but log ourselves for sake of icon
@@ -105,8 +105,8 @@ This operation starts a service that is currently in an inactive/stopped state. 
 	}
 
 	// Add flags
-	cmd.Flags().BoolVar(&startNoWait, "no-wait", false, "Don't wait for the operation to complete")
-	cmd.Flags().DurationVar(&startWaitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for the operation to complete")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
 
 	return cmd
 }

--- a/internal/cmd/service_start.go
+++ b/internal/cmd/service_start.go
@@ -22,10 +22,8 @@ func buildServiceStartCmd(app *common.App) *cobra.Command {
 		Short:   "Start a stopped database service",
 		Long: `Start a stopped database service.
 
-This operation starts a service that is currently in an inactive/stopped state. The service will transition to an active state and become available for connections.
-
-Examples:
-  # Start a service (waits for completion by default)
+This operation starts a service that is currently in an inactive/stopped state. The service will transition to an active state and become available for connections.`,
+		Example: `  # Start a service (waits for completion by default)
   tiger service start svc-12345
 
   # Start service without waiting for completion

--- a/internal/cmd/service_stop.go
+++ b/internal/cmd/service_stop.go
@@ -13,8 +13,8 @@ import (
 
 // buildServiceStopCmd creates the stop subcommand
 func buildServiceStopCmd(app *common.App) *cobra.Command {
-	var stopNoWait bool
-	var stopWaitTimeout time.Duration
+	var noWait bool
+	var waitTimeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:     "stop [service-id]",
@@ -73,13 +73,13 @@ This operation stops a service that is currently active/running. The service wil
 			cmd.PrintErrf("⏹️  Stop request accepted for service '%s'.\n", serviceID)
 
 			// If not waiting, return early
-			if stopNoWait {
+			if noWait {
 				cmd.PrintErrln("💡 Use 'tiger service get' to check service status.")
 				return nil
 			}
 
 			// Wait for service to become paused
-			cmd.PrintErrf("⏳ Waiting for service to stop (timeout: %v)...\n", stopWaitTimeout)
+			cmd.PrintErrf("⏳ Waiting for service to stop (timeout: %v)...\n", waitTimeout)
 			if err := common.WaitForService(cmd.Context(), common.WaitForServiceArgs{
 				Client:    client,
 				ProjectID: projectID,
@@ -90,7 +90,7 @@ This operation stops a service that is currently active/running. The service wil
 				},
 				Input:      cmd.InOrStdin(),
 				Output:     cmd.ErrOrStderr(),
-				Timeout:    stopWaitTimeout,
+				Timeout:    waitTimeout,
 				TimeoutMsg: "service may still be stopping",
 			}); err != nil {
 				// Return error for sake of exit code, but log ourselves for sake of icon
@@ -105,8 +105,8 @@ This operation stops a service that is currently active/running. The service wil
 	}
 
 	// Add flags
-	cmd.Flags().BoolVar(&stopNoWait, "no-wait", false, "Don't wait for the operation to complete")
-	cmd.Flags().DurationVar(&stopWaitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for the operation to complete")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for operation to complete")
 
 	return cmd
 }

--- a/internal/cmd/service_stop.go
+++ b/internal/cmd/service_stop.go
@@ -22,10 +22,8 @@ func buildServiceStopCmd(app *common.App) *cobra.Command {
 		Short:   "Stop a running database service",
 		Long: `Stop a running database service.
 
-This operation stops a service that is currently active/running. The service will transition to an inactive state and will no longer accept connections.
-
-Examples:
-  # Stop a service (waits for completion by default)
+This operation stops a service that is currently active/running. The service will transition to an inactive state and will no longer accept connections.`,
+		Example: `  # Stop a service (waits for completion by default)
   tiger service stop svc-12345
 
   # Stop service without waiting for completion

--- a/internal/cmd/service_update_password.go
+++ b/internal/cmd/service_update_password.go
@@ -13,7 +13,7 @@ import (
 
 // buildServiceUpdatePasswordCmd creates a new update-password command
 func buildServiceUpdatePasswordCmd(app *common.App) *cobra.Command {
-	var updatePasswordValue string
+	var newPassword string
 	var autoGenerate bool
 
 	cmd := &cobra.Command{
@@ -70,7 +70,7 @@ so update the password on the primary instead.`,
 			}
 
 			// The password comes from the flag, falling back to the env var
-			password := updatePasswordValue
+			password := newPassword
 			if password == "" {
 				password = os.Getenv("TIGER_NEW_PASSWORD")
 			}
@@ -132,7 +132,7 @@ so update the password on the primary instead.`,
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&updatePasswordValue, "new-password", "", "New password for the tsdbadmin user (can also be set via TIGER_NEW_PASSWORD env var)")
+	cmd.Flags().StringVar(&newPassword, "new-password", "", "New password for the tsdbadmin user (can also be set via TIGER_NEW_PASSWORD env var)")
 	cmd.Flags().BoolVar(&autoGenerate, "auto-generate", false, "Auto-generate a secure password")
 	cmd.MarkFlagsMutuallyExclusive("new-password", "auto-generate")
 	return cmd

--- a/internal/cmd/service_update_password.go
+++ b/internal/cmd/service_update_password.go
@@ -26,10 +26,8 @@ from your configuration. This command updates the master password for the
 'tsdbadmin' user used to authenticate to the database service.
 
 A read replica ID is rejected — read replicas share the primary's credentials,
-so update the password on the primary instead.
-
-Examples:
-  # Update password for default service, interactively prompts
+so update the password on the primary instead.`,
+		Example: `  # Update password for default service, interactively prompts
   tiger service update-password
 
   # Update password for default service

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -64,9 +64,8 @@ func buildUpgradeCmd(app *common.App) *cobra.Command {
 		Long: `Download and install the latest published version of the Tiger CLI, replacing the currently running binary.
 
 If Tiger CLI was installed via a package manager (Homebrew, apt, yum/dnf), the upgrade will be refused with a suggestion to use that package manager instead.`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpgrade(cmd, app, requestedVersion, force)
 		},

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -24,7 +24,7 @@ type VersionOutput struct {
 }
 
 func buildVersionCmd(app *common.App) *cobra.Command {
-	var checkVersion bool
+	var check bool
 
 	cmd := &cobra.Command{
 		Use:               "version",
@@ -45,7 +45,7 @@ func buildVersionCmd(app *common.App) *cobra.Command {
 			}
 
 			updateAvailable := false
-			if checkVersion {
+			if check {
 				result, err := version.CheckForUpdate(cmd.Context(), cfg)
 				if err != nil {
 					// A failed check shouldn't fail the version command; warn and
@@ -85,7 +85,7 @@ func buildVersionCmd(app *common.App) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&checkVersion, "check", false, "Force checking for updates (regardless of last check time)")
+	cmd.Flags().BoolVar(&check, "check", false, "Force checking for updates (regardless of last check time)")
 	cmd.Flags().VarP(new(outputWithBareFlag), "output", "o", "Output format (table, json, yaml, bare)")
 	cmd.RegisterFlagCompletionFunc("output", outputCompletion("bare"))
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -27,12 +27,11 @@ func buildVersionCmd(app *common.App) *cobra.Command {
 	var check bool
 
 	cmd := &cobra.Command{
-		Use:               "version",
-		Short:             "Show version information",
-		Long:              `Display version, build time, and git commit information for the Tiger CLI`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		SilenceUsage:      true,
+		Use:          "version",
+		Short:        "Show version information",
+		Long:         `Display version, build time, and git commit information for the Tiger CLI`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := app.GetConfig()
 
@@ -87,7 +86,7 @@ func buildVersionCmd(app *common.App) *cobra.Command {
 
 	cmd.Flags().BoolVar(&check, "check", false, "Force checking for updates (regardless of last check time)")
 	cmd.Flags().VarP(new(outputWithBareFlag), "output", "o", "Output format (table, json, yaml, bare)")
-	cmd.RegisterFlagCompletionFunc("output", outputCompletion("bare"))
+	registerFlagCompletion(cmd, "output", outputCompletion("bare"))
 
 	return cmd
 }


### PR DESCRIPTION
Three small refactors:

- Move the examples that were embedded at the end of each command's `Long` description into cobra's `Example` field, so cobra renders them itself under `Examples:` in the help output.
- Drop the command-name prefix from flag variables (`createNoSetDefault` → `noSetDefault`, `dbSchemaPooled` → `pooled`), so each variable just matches its flag name. The prefixes were redundant — the variables are already scoped to a single command's builder function.
- Make flags complete nothing by default instead of falling back to filenames. Most flags don't take a path, so cobra's default of suggesting files was wrong almost everywhere — one setting on the root command flips it for the whole tree, and the three flags that do take a path (`--config-dir`, `--config-path`, `db query --file`) now ask for path completion explicitly. The redundant `cobra.NoFileCompletions` argument completions go away with it, and flag completions register through a helper that panics instead of discarding cobra's registration error.

Stacked on #206.
