### PR TITLE
Remove hand-added Details field and enforce clean go generate in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Mod
         run: go mod tidy --diff
 
+      - name: Generate
+        run: |
+          go generate ./...
+          git diff --exit-code || { echo "::error::generated files are out of date; run 'go generate ./...' and commit the result (never edit generated files by hand)"; exit 1; }
+
       - name: Build
         run: go build ./...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Use the official product names in all user-facing text (documentation, code comm
 - **`pkg/`** - Public Go packages. Contains `mcpinstall`, an API for installing MCP server configurations into AI coding assistants and editors, exposed as thin aliases over the `mcp install` logic in `internal/cmd`. Changes to install behavior are part of this package's public surface.
 - **`docs/`** - Documentation. `development.md` is the development guide (building from source, testing, contributing).
 - **`scripts/`** - Build and installation scripts (`install.sh`, `install.ps1`, completions generation) and the integration test runner (`test-integration.sh`).
-- **`openapi.yaml`** - OpenAPI spec for the Tiger Cloud API, from which the API client is generated.
+- **`openapi.yaml`** - OpenAPI spec for the Tiger Cloud API, from which the API client is generated. It is a verbatim copy synced from the API's own spec and is never edited here (see [Code Generation](#code-generation)).
 - **`.github/`** - GitHub Actions CI/CD workflows for testing (`test.yml`) and releases (`release.yml`).
 - **`.goreleaser.yaml`** - GoReleaser configuration for building and publishing releases.
 - **`Dockerfile`** - The container image published to `ghcr.io/timescale/tiger-cli`, which defaults to running `tiger mcp start`.
@@ -41,7 +41,7 @@ Use the official product names in all user-facing text (documentation, code comm
 ```bash
 go install ./...   # build and install the tiger binary
 go test ./...      # run all tests (integration tests skip without credentials)
-go generate ./...  # regenerate the API client and mocks after editing openapi.yaml
+go generate ./...  # regenerate the API client and mocks after syncing openapi.yaml
 ```
 
 You can also run without installing via `go run ./cmd/tiger --help`.
@@ -52,7 +52,7 @@ Integration tests run via `./scripts/test-integration.sh [-v] [-run Pattern] [an
 
 ## Code Generation
 
-The API client and mocks in `internal/api/` are generated from `openapi.yaml`. Never edit `client.go`, `types.go`, or `mocks/mock_client.go` by hand — edit the spec and run `go generate ./...` to regenerate everything. If the mock is stale, `go vet` will report that it no longer implements the client interface.
+The API client and mocks in `internal/api/` are generated from `openapi.yaml`, which is itself a verbatim copy of the Tiger Cloud API's own spec — the single source of truth. Nothing in this chain is edited by hand in this repo: not `client.go`, `types.go`, or `mocks/mock_client.go`, and not `openapi.yaml` either. If the CLI needs something the spec lacks, or the API returns something the spec doesn't describe, the change lands in the upstream spec first; then sync `openapi.yaml` from it and run `go generate ./...` to regenerate everything (CI enforces this — see [CI](#ci)). If the mock is stale, `go vet` will report that it no longer implements the client interface.
 
 Generation is configured by `internal/api/types.yaml` and `internal/api/client.yaml` rather than command-line flags. Both set `name-normalizer: ToCamelCaseWithInitialisms` (generated names capitalize initialisms the Go way: `ServiceID`, not `ServiceId`) and `always-prefix-enum-values: true` (enum constants are prefixed with their type: `api.DeployStatusREADY`, so values from different enums can't collide). Keep the two configs in sync with each other — changing either option renames identifiers across the whole codebase.
 
@@ -250,7 +250,7 @@ This file is pulled into every agent session, so unnecessary detail bloats conte
 
 ## CI
 
-`test.yml` runs the test suite on pull requests and pushes to `main`. CI needs no keyring setup — `TestMain` swaps in the in-memory mock.
+`test.yml` runs the test suite on pull requests and pushes to `main`. CI needs no keyring setup — `TestMain` swaps in the in-memory mock. It also runs `go generate ./...` and fails on any resulting diff, so hand edits to generated files or a stale regeneration after a spec change don't merge.
 
 ## Releases
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -182,6 +182,13 @@ Generation is configured by `internal/api/types.yaml` and
 conventions (`ServiceID`, `CPUMillis`) and prefix enum constants with their type
 name (`api.DeployStatusREADY`).
 
+`openapi.yaml` is a verbatim copy of the Tiger Cloud API's own spec, which is
+the source of truth. Don't edit it here, and don't edit the generated files
+either. To pick up an API change, sync `openapi.yaml` from the upstream spec and
+regenerate. If the CLI needs something the spec doesn't describe, the change has
+to land in the upstream spec first. CI runs `go generate ./...` and fails if the
+result differs from what's committed.
+
 ## Development Best Practices
 
 1. **Always use go fmt** after making file changes and before committing

--- a/internal/api/client_util.go
+++ b/internal/api/client_util.go
@@ -129,18 +129,8 @@ func (e *Error) Error() string {
 	if e == nil {
 		return "unknown error"
 	}
-	msg := ""
-	if e.Message != nil {
-		msg = *e.Message
-	}
-	if e.Details != nil && *e.Details != "" {
-		if msg != "" {
-			return msg + ": " + *e.Details
-		}
-		return *e.Details
-	}
-	if msg != "" {
-		return msg
+	if e.Message != nil && *e.Message != "" {
+		return *e.Message
 	}
 	return "unknown error"
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -281,9 +281,6 @@ type Error struct {
 	// Code A machine-readable error code.
 	Code *string `json:"code,omitempty"`
 
-	// Details additional context, sent by the API but not yet in its spec. Hand-added, not regenerated from openapi.yaml.
-	Details *string `json:"details,omitempty"`
-
 	// Message A human-readable error message.
 	Message *string `json:"message,omitempty"`
 }


### PR DESCRIPTION
Remove the hand-added `details` field from the generated `Error` type, and add a CI check so it can't happen again.

#158 added `details` to the `Error` schema in our `openapi.yaml` (see [here](https://github.com/timescale/tiger-cli/pull/158/changes#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39R1476-R1482)) so 401 responses could surface the reason for the auth failure. The upstream Tiger Cloud API spec is the source of truth, though, and it never gained the field, so re-syncing the spec in #192 removed it. That PR restored the field in the generated Go code by hand, which broke `go generate ./...`, because regenerating now drops the field and breaks the code that depends on it (namely, [this](https://github.com/timescale/tiger-cli/blob/af6b9dd370fc1bdd71d61b1b27530342c81d259d/internal/api/client_util.go#L136-L141)).

This PR regenerates `types.go` from the spec and returns the `Error()` method to its pre-#158 shape. The only user-visible change is that 401 errors lose the trailing reason (for example "missing Authorization header") and show just the API's generic "Invalid or missing authentication credentials". The API only populates `details` on 401s.

Whether to restore that reason is a follow-up decision for the team: either add `details` to the upstream spec, or fold the reason into `message`, after which a spec sync would pick it up with no hand edits (my personal preference).

Additionally, CI now runs `go generate ./...` and fails on any resulting diff, so a hand edit to generated code (or a stale regeneration after a spec sync) can't merge. CLAUDE.md and the development guide now spell out that nothing in this chain is edited in this repo: not the generated files, and not `openapi.yaml` either, which is always a verbatim copy of the upstream spec.


