### PR TITLE
Add GitHub Copilot support to `tiger mcp install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ tiger mcp install
 # Or specify your client directly
 tiger mcp install claude-code    # Claude Code
 tiger mcp install codex          # Codex
+tiger mcp install copilot        # GitHub Copilot CLI
 tiger mcp install cursor         # Cursor IDE
 tiger mcp install gemini         # Gemini CLI
 tiger mcp install vscode         # VS Code

--- a/internal/cmd/mcp_install.go
+++ b/internal/cmd/mcp_install.go
@@ -106,6 +106,7 @@ const (
 	VSCode      MCPClient = "vscode"
 	Antigravity MCPClient = "antigravity"
 	KiroCLI     MCPClient = "kiro-cli"
+	Copilot     MCPClient = "copilot" // Both the IDE and the CLI
 )
 
 // MCPServerConfig represents the MCP server configuration
@@ -246,6 +247,17 @@ var supportedClients = []clientConfig{
 		},
 		buildInstallCommand: func(serverName, command string, args []string) ([]string, error) {
 			return []string{"kiro-cli", "mcp", "add", "--name", serverName, "--command", command, "--args", strings.Join(args, ",")}, nil
+		},
+	},
+	{
+		ClientType:  Copilot,
+		Name:        "GitHub Copilot CLI",
+		EditorNames: []string{"copilot", "copilot-cli"},
+		ConfigPaths: []string{
+			"~/.copilot/mcp-config.json",
+		},
+		buildInstallCommand: func(serverName, command string, args []string) ([]string, error) {
+			return append([]string{"copilot", "mcp", "add", serverName, "--", command}, args...), nil
 		},
 	},
 }
@@ -662,7 +674,7 @@ func createConfigBackup(configPath string) (string, error) {
 
 	// Get original file mode, fallback to 0600 if unavailable
 	origInfo, err := os.Stat(configPath)
-	var mode fs.FileMode = 0600
+	var mode fs.FileMode = 0o600
 	if err == nil {
 		mode = origInfo.Mode().Perm()
 	}
@@ -685,7 +697,7 @@ func createConfigBackup(configPath string) (string, error) {
 func addMCPServerViaJSON(configPath, mcpServersPathPrefix, serverName, command string, args []string) error {
 	// Create configuration directory if it doesn't exist
 	configDir := filepath.Dir(configPath)
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create configuration directory %s: %w", configDir, err)
 	}
 
@@ -696,7 +708,7 @@ func addMCPServerViaJSON(configPath, mcpServersPathPrefix, serverName, command s
 	}
 
 	// Get original file mode to preserve it, fallback to 0600 for new files
-	var fileMode fs.FileMode = 0600
+	var fileMode fs.FileMode = 0o600
 	if info, err := os.Stat(configPath); err == nil {
 		fileMode = info.Mode().Perm()
 	}

--- a/internal/cmd/mcp_install_test.go
+++ b/internal/cmd/mcp_install_test.go
@@ -155,7 +155,7 @@ func TestMCPInstallCmd(t *testing.T) {
 		{
 			name:    "unsupported client",
 			args:    []string{"mcp", "install", "bogus"},
-			wantErr: "unsupported client: bogus. Supported clients: claude-code, cursor, windsurf, codex, gemini, gemini-cli, vscode, code, vs-code, antigravity, agy, kiro-cli",
+			wantErr: "unsupported client: bogus. Supported clients: claude-code, cursor, windsurf, codex, gemini, gemini-cli, vscode, code, vs-code, antigravity, agy, kiro-cli, copilot, copilot-cli",
 		},
 		{
 			name:    "invalid existing config",
@@ -557,6 +557,7 @@ func TestAddMCPServerViaCLI(t *testing.T) {
 			Gemini:     {"gemini", "mcp", "add", "-s", "user", "tiger", "/path/to/tiger", "mcp", "start"},
 			VSCode:     {"code", "--add-mcp", `{"args":["mcp","start"],"command":"/path/to/tiger","name":"tiger"}`},
 			KiroCLI:    {"kiro-cli", "mcp", "add", "--name", "tiger", "--command", "/path/to/tiger", "--args", "mcp,start"},
+			Copilot:    {"copilot", "mcp", "add", "tiger", "--", "/path/to/tiger", "mcp", "start"},
 		}
 		for _, cfg := range supportedClients {
 			if cfg.buildInstallCommand == nil {


### PR DESCRIPTION
Adds `copilot` (alias `copilot-cli`) to the clients supported by `tiger mcp install`, so users of the GitHub Copilot CLI can set up the Tiger MCP server with one command. Per [GitHub's docs](https://docs.github.com/en/copilot/concepts/context/mcp#overview-of-model-context-protocol-mcp), the GitHub Copilot desktop app also picks up MCP servers configured through the Copilot CLI, so this covers both without a separate client.

The Copilot CLI has a non-interactive `copilot mcp add` command that writes to `~/.copilot/mcp-config.json`, so this follows the same CLI-based approach we use for Codex and Gemini: we shell out to the client's own command and only use the config path for backups. The README install examples and tests are updated to match.