### PR TITLE
Change the primary name of several commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Every command gets its own file in `internal/cmd/`, named to match the command i
 
 Place a helper by who calls it, working down this list until one matches:
 
-1. **One command** → that command's file, even when the helper is large. `db_connect.go` holds the entire `db connect`/`psql` flow (read-replica selection, password recovery, the psql handoff) and `auth_login.go` the entire OAuth flow — a long file whose contents all serve one command is easier to follow than several short files with scattered entry points.
+1. **One command** → that command's file, even when the helper is large. `db_psql.go` holds the entire `db psql` flow (read-replica selection, password recovery, the psql handoff) and `auth_login.go` the entire OAuth flow — a long file whose contents all serve one command is easier to follow than several short files with scattered entry points.
 2. **Several commands in one group** → the group file (`service.go`, `db.go`).
 3. **Across groups** → a package-level `<topic>_helper.go` file. The `_helper.go` suffix is reserved for this, so every other file in `internal/cmd` is named after a command.
 4. **A genuine standalone utility** — small and isolated, with no notion of a command → `internal/util`. Anything shaped around the CLI stays in `cmd` even if its signature looks generic.
@@ -89,7 +89,7 @@ Exception: all shell completion functions — both `ValidArgsFunction` completio
 
 Configuration is layered, with precedence **flags > `TIGER_*` env vars > config file (`~/.config/tiger/config.yaml`) > defaults**. The complete list of options lives in `internal/config/config.go`, and the global flags in `internal/cmd/root.go` (the two don't correspond one-to-one).
 
-- **There is no global config.** `config.Load` builds a fresh viper instance per call; nothing reads the global viper instance. Commands and MCP handlers read configuration through the App — `app.GetAll()`, `app.GetConfig()`, or `app.GetClient()` — and never call `config.Load` themselves. The only places that load directly are `config.LoadForOutput` (for `tiger config show`) and tests.
+- **There is no global config.** `config.Load` builds a fresh viper instance per call; nothing reads the global viper instance. Commands and MCP handlers read configuration through the App — `app.GetAll()`, `app.GetConfig()`, or `app.GetClient()` — and never call `config.Load` themselves. The only places that load directly are `config.LoadForOutput` (for `tiger config list`) and tests.
 - **Pass what you read down the call chain.** Hand the `*config.Config` (plus client and project ID where needed) to the functions that need them rather than reloading. Don't pass the App into `internal/common` helpers — they take the specific values they use, which keeps them usable from both CLI and MCP.
 - **The App owns flag precedence.** `config.Load` binds the flags listed in `flagBindings` (`internal/config/config.go`) against the flag set it's given, so a flag bound for one command never leaks into another, and a command that doesn't define a flag simply skips it.
 - **Flags that override config values** must be added to `flagBindings` and declared *without* a bound variable (`cmd.Flags().String(...)`, or `Var(new(outputFlag), ...)` for validating flag types), so the only way to read the value is through the config. A variable in scope is an invitation to read the raw flag instead, silently bypassing the env var and config file. Flags that aren't config values stay plain local variables; one that only needs an env-var fallback can read the env var directly (see `--new-password` in `service_update_password.go`).
@@ -101,7 +101,7 @@ Configuration is layered, with precedence **flags > `TIGER_*` env vars > config 
 
 `TIGER_EXPERIMENTAL` gates commands and MCP tools that aren't ready to be public yet, for whatever reason — including, but not limited to, anything backed by a gateway endpoint marked `x-tigerdata-preview: true` in `openapi.yaml` (those request/response shapes are still in flux, so a surface built on one must always be gated).
 
-It's an env var **only**: deliberately not a config key, not a flag, and hidden from `tiger config show`. `buildRootCmd` reads it once into `app.Experimental`, and the CLI guards its `AddCommand` calls with it while the MCP server guards its `addTool` calls, so when the env var is off the gated commands and tools don't exist at all — no help entry, no completion, not advertised to MCP clients (restart the MCP server after toggling). **Never mention `TIGER_EXPERIMENTAL` in user-facing docs, command help, or error messages.** When a feature graduates, delete the gates on both sides.
+It's an env var **only**: deliberately not a config key, not a flag, and hidden from `tiger config list`. `buildRootCmd` reads it once into `app.Experimental`, and the CLI guards its `AddCommand` calls with it while the MCP server guards its `addTool` calls, so when the env var is off the gated commands and tools don't exist at all — no help entry, no completion, not advertised to MCP clients (restart the MCP server after toggling). **Never mention `TIGER_EXPERIMENTAL` in user-facing docs, command help, or error messages.** When a feature graduates, delete the gates on both sides.
 
 ## Command Patterns
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ FROM ${BINARY_SOURCE} AS binary_source
 # Create final alpine image
 FROM alpine:3.23 AS final
 
-# Install psql for sake of `tiger db connect`
+# Install psql for sake of `tiger db psql`
 RUN apk add --update --no-cache postgresql-client
 
 # Create non-root user/group

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ tiger service list
 tiger service create --name my-database
 
 # Get connection string
-tiger db connection-string
+tiger db uri
 
 # Connect to your database
-tiger db connect
+tiger db psql
 
 # Run a query without psql
 tiger db query -c "SELECT now()"
@@ -117,15 +117,15 @@ Tiger CLI provides the following commands:
   - `update-password` - Update service master password
   - `logs` - View service logs (alias: `log`)
 - `tiger db` - Database operations
-  - `connect` - Connect to a database with psql (in an interactive terminal, if the service has read replicas, offers to connect to one of them; use `--no-replica-prompt` to skip) (alias: `psql`)
+  - `psql` - Connect to a database with psql (in an interactive terminal, if the service has read replicas, offers to connect to one of them; use `--no-replica-prompt` to skip) (alias: `connect`)
   - `query` - Execute a SQL query against a database and display the results, without needing psql (alias: `sql`)
-  - `connection-string` - Get connection string for a service (alias: `uri`)
-  - `test-connection` - Test database connectivity (aliases: `test`, `ping`)
+  - `uri` - Get connection URI for a service (alias: `connection-string`)
+  - `ping` - Test database connectivity (aliases: `test`, `test-connection`)
   - `schema` - Display database schema information (tables, views, indexes, functions, TimescaleDB hypertables, and more)
   - `save-password` - Save a database password to configured password storage (keyring, pgpass, or none)
   - `create role` - Create a new database role, with optional read-only enforcement, inherited grants (`--from`), and statement timeout (alias: `create user`)
 - `tiger config` - Configuration management (alias: `cfg`)
-  - `show` - Show current configuration (aliases: `list`, `ls`)
+  - `list` - List current configuration (aliases: `ls`, `show`)
   - `set` - Set configuration value
   - `unset` - Remove configuration value (aliases: `rm`, `delete`)
   - `reset` - Reset configuration to defaults (alias: `clear`)
@@ -234,8 +234,8 @@ tiger config set docs_mcp false
 The CLI stores configuration in `~/.config/tiger/config.yaml` by default, and supports hierarchical configuration through environment variables and command-line flags.
 
 ```bash
-# Show current configuration
-tiger config show
+# List current configuration
+tiger config list
 
 # Set configuration values
 tiger config set output json
@@ -259,7 +259,7 @@ All configuration options can be set via `tiger config set <key> <value>`:
 - `password_storage` - Password storage method: `keyring`, `pgpass`, or `none` (default: `keyring`)
 - `read_only` - Which services this CLI may change: `all`, `prod`, or `off` (default: `off`, which protects nothing). An interactive `tiger auth login` offers a menu of the three modes, and records your choice either way, so it only asks until you answer once. `true` and `on` are accepted as aliases for `all`, and `false` for `off`, so existing config files and `TIGER_READ_ONLY=true` behave as before.
 
-  Changing a protected service is refused, and so is creating one: `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` and `tiger db create role` return an error. Connection strings for it open the session in Tiger Cloud's immutable read-only mode, so the server rejects writes and DDL — that covers `tiger db connect`, `tiger db query`, `tiger db connection-string`, the `db_query` MCP tool, and the connection strings embedded in `tiger service` output and the equivalent MCP tools.
+  Changing a protected service is refused, and so is creating one: `tiger service create`/`fork`/`start`/`stop`/`resize`/`update-password`/`delete` and `tiger db create role` return an error. Connection strings for it open the session in Tiger Cloud's immutable read-only mode, so the server rejects writes and DDL — that covers `tiger db psql`, `tiger db query`, `tiger db uri`, the `db_query` MCP tool, and the connection strings embedded in `tiger service` output and the equivalent MCP tools.
 
   - `all` protects every service, and the MCP write tools aren't registered at all, so they don't appear in `tools/list` and can't be called.
   - `prod` protects only services tagged `PROD`, leaving `DEV` services writable. `tiger service create`/`fork` are gated on the `--environment` they request, so creating a `DEV` service is allowed and a `PROD` one is not — otherwise you could create a service this same mode then refuses to delete. Forking a `PROD` service into a `DEV` fork is allowed, since that reads production without changing it. The MCP write tools stay registered — they still work on `DEV` services — and refuse per call instead. Reading a service's tag costs one extra API call for `tiger service start`/`stop`/`resize`/`delete`, and the operation is refused if that lookup fails. A read replica is judged on its own tag, so a replica of a `PROD` primary is protected only if that replica set is itself tagged `PROD`.

--- a/internal/cmd/completion_helper_test.go
+++ b/internal/cmd/completion_helper_test.go
@@ -100,7 +100,7 @@ func TestCompletion(t *testing.T) {
 		},
 		{
 			// Config keys come straight from the registry, so this list is the
-			// same one `tiger config show` renders (see TestConfigShowCoversEveryKey).
+			// same one `tiger config list` renders (see TestConfigListCoversEveryKey).
 			name:       "config set completes keys",
 			args:       []string{"__complete", "config", "set", ""},
 			wantStdout: "analytics\napi_url\ncolor\nconsole_url\ndocs_mcp\ndocs_mcp_url\ngateway_url\nmcp_max_rows\noutput\npassword_storage\nread_only\nreleases_url\nservice_id\nversion_check\n" + noFileComp,

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -14,7 +14,7 @@ func buildConfigCmd(app *common.App) *cobra.Command {
 		Long:    `Manage CLI configuration settings stored in ~/.config/tiger/config.yaml`,
 	}
 
-	cmd.AddCommand(buildConfigShowCmd(app))
+	cmd.AddCommand(buildConfigListCmd(app))
 	cmd.AddCommand(buildConfigSetCmd(app))
 	cmd.AddCommand(buildConfigUnsetCmd(app))
 	cmd.AddCommand(buildConfigResetCmd(app))

--- a/internal/cmd/config_list.go
+++ b/internal/cmd/config_list.go
@@ -12,15 +12,15 @@ import (
 	"github.com/timescale/tiger-cli/internal/util"
 )
 
-func buildConfigShowCmd(app *common.App) *cobra.Command {
+func buildConfigListCmd(app *common.App) *cobra.Command {
 	var noDefaults bool
 	var withEnv bool
 
 	cmd := &cobra.Command{
-		Use:               "show",
-		Aliases:           []string{"list", "ls"},
-		Short:             "Show current configuration",
-		Long:              `Display the current CLI configuration settings`,
+		Use:               "list",
+		Aliases:           []string{"ls", "show"},
+		Short:             "List current configuration",
+		Long:              `List the current CLI configuration settings`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		SilenceUsage:      true,
@@ -28,7 +28,7 @@ func buildConfigShowCmd(app *common.App) *cobra.Command {
 			cfg := app.GetConfig()
 
 			// Values are re-read free of env and CLI flags (unless --with-env
-			// is given), so `config show -o json` reports the configured
+			// is given), so `config list -o json` reports the configured
 			// `output` value rather than the flag's.
 			cfgOut, err := config.LoadForOutput(cfg.ConfigDir, withEnv, noDefaults)
 			if err != nil {

--- a/internal/cmd/config_list_test.go
+++ b/internal/cmd/config_list_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
-// Full `config show` output for an all-defaults config, per format. Cases
+// Full `config list` output for an all-defaults config, per format. Cases
 // whose output differs use their own literals.
 const (
-	configShowDefaultsTable = `┌──────────────────┬───────────────────────────────────────────────────────────────┐
+	configListDefaultsTable = `┌──────────────────┬───────────────────────────────────────────────────────────────┐
 │     PROPERTY     │                             VALUE                             │
 ├──────────────────┼───────────────────────────────────────────────────────────────┤
 │ analytics        │ true                                                          │
@@ -35,7 +35,7 @@ const (
 └──────────────────┴───────────────────────────────────────────────────────────────┘
 `
 
-	configShowDefaultsJSON = `{
+	configListDefaultsJSON = `{
   "analytics": true,
   "api_url": "https://console.cloud.tigerdata.com/public/api/v1",
   "color": true,
@@ -53,7 +53,7 @@ const (
 }
 `
 
-	configShowDefaultsYAML = `analytics: true
+	configListDefaultsYAML = `analytics: true
 api_url: https://console.cloud.tigerdata.com/public/api/v1
 color: true
 console_url: https://console.cloud.tigerdata.com
@@ -70,7 +70,7 @@ version_check: true
 `
 )
 
-func TestConfigShowCmd(t *testing.T) {
+func TestConfigListCmd(t *testing.T) {
 	// A second config dir, pointed at by TIGER_CONFIG_DIR in one case to prove
 	// the --config-dir flag takes precedence over the env var.
 	envDir := t.TempDir()
@@ -79,17 +79,17 @@ func TestConfigShowCmd(t *testing.T) {
 	runCmdTests(t, []cmdTest{
 		{
 			name:    "unexpected argument",
-			args:    []string{"config", "show", "extra"},
-			wantErr: `unknown command "extra" for "tiger config show"`,
+			args:    []string{"config", "list", "extra"},
+			wantErr: `unknown command "extra" for "tiger config list"`,
 		},
 		{
 			name:       "table output defaults",
-			args:       []string{"config", "show"},
-			wantStdout: configShowDefaultsTable,
+			args:       []string{"config", "list"},
+			wantStdout: configListDefaultsTable,
 		},
 		{
 			name: "table output with configured values",
-			args: []string{"config", "show"},
+			args: []string{"config", "list"},
 			opts: []runOption{withConfig(map[string]any{
 				"api_url":          "https://test.api.com/v1",
 				"service_id":       "test-service",
@@ -118,7 +118,7 @@ func TestConfigShowCmd(t *testing.T) {
 		},
 		{
 			name: "json output from config file",
-			args: []string{"config", "show"},
+			args: []string{"config", "list"},
 			opts: []runOption{withConfig(map[string]any{
 				"output":    "json",
 				"api_url":   "https://json.api.com/v1",
@@ -144,21 +144,21 @@ func TestConfigShowCmd(t *testing.T) {
 		},
 		{
 			name:       "output flag changes format but not reported value",
-			args:       []string{"config", "show", "-o", "json"},
-			wantStdout: configShowDefaultsJSON,
+			args:       []string{"config", "list", "-o", "json"},
+			wantStdout: configListDefaultsJSON,
 		},
 		{
 			name: "output env var changes format but not reported value",
-			args: []string{"config", "show"},
+			args: []string{"config", "list"},
 			opts: []runOption{
 				withConfig(map[string]any{"output": "table"}),
 				withEnv("TIGER_OUTPUT", "json"),
 			},
-			wantStdout: configShowDefaultsJSON,
+			wantStdout: configListDefaultsJSON,
 		},
 		{
 			name: "yaml output from config file",
-			args: []string{"config", "show"},
+			args: []string{"config", "list"},
 			opts: []runOption{withConfig(map[string]any{
 				"output":  "yaml",
 				"api_url": "https://yaml.api.com/v1",
@@ -181,12 +181,12 @@ version_check: true
 		},
 		{
 			name:       "yaml output via flag",
-			args:       []string{"config", "show", "-o", "yaml"},
-			wantStdout: configShowDefaultsYAML,
+			args:       []string{"config", "list", "-o", "yaml"},
+			wantStdout: configListDefaultsYAML,
 		},
 		{
 			name: "no-defaults shows only configured values",
-			args: []string{"config", "show", "--no-defaults"},
+			args: []string{"config", "list", "--no-defaults"},
 			opts: []runOption{withConfig(map[string]any{
 				"service_id": "test-service",
 				"analytics":  false,
@@ -201,7 +201,7 @@ version_check: true
 		},
 		{
 			name: "with-env applies env overrides",
-			args: []string{"config", "show", "--with-env"},
+			args: []string{"config", "list", "--with-env"},
 			opts: []runOption{withEnv("TIGER_SERVICE_ID", "env-service")},
 			wantStdout: `┌──────────────────┬───────────────────────────────────────────────────────────────┐
 │     PROPERTY     │                             VALUE                             │
@@ -225,13 +225,13 @@ version_check: true
 		},
 		{
 			name:       "env override ignored without with-env",
-			args:       []string{"config", "show"},
+			args:       []string{"config", "list"},
 			opts:       []runOption{withEnv("TIGER_SERVICE_ID", "env-service")},
-			wantStdout: configShowDefaultsTable,
+			wantStdout: configListDefaultsTable,
 		},
 		{
 			name: "config-dir flag overrides TIGER_CONFIG_DIR env var",
-			args: []string{"config", "show"},
+			args: []string{"config", "list"},
 			opts: []runOption{
 				withConfig(map[string]any{"api_url": "https://flag-test.api.com/v1"}),
 				withEnv("TIGER_CONFIG_DIR", envDir),
@@ -261,7 +261,7 @@ version_check: true
 			// version_check_interval duration; 0 (checks disabled) must carry
 			// over to version_check=false rather than the default true.
 			name: "legacy version_check_interval 0 disables version_check",
-			args: []string{"config", "show"},
+			args: []string{"config", "list"},
 			opts: []runOption{withConfig(map[string]any{"version_check_interval": 0})},
 			wantStdout: `┌──────────────────┬───────────────────────────────────────────────────────────────┐
 │     PROPERTY     │                             VALUE                             │
@@ -284,25 +284,25 @@ version_check: true
 `,
 		},
 		{
-			name:       "list alias",
-			args:       []string{"config", "list"},
-			wantStdout: configShowDefaultsTable,
+			name:       "show alias",
+			args:       []string{"config", "show"},
+			wantStdout: configListDefaultsTable,
 		},
 		{
 			name:       "ls alias",
 			args:       []string{"config", "ls"},
-			wantStdout: configShowDefaultsTable,
+			wantStdout: configListDefaultsTable,
 		},
 	})
 }
 
-// Every config key must be visible in every `config show` format. The table is
+// Every config key must be visible in every `config list` format. The table is
 // rendered by a hand-written if-chain in outputTable and the other two by
 // ConfigOutput's json/yaml tags, so a newly added key can silently fail to
 // show up in one of them. The literal expectations above would still pass —
 // they only assert the keys that were there when they were written — so assert
 // the full key set against the registry instead.
-func TestConfigShowCoversEveryKey(t *testing.T) {
+func TestConfigListCoversEveryKey(t *testing.T) {
 	want := config.ValidConfigOptions()
 	slices.Sort(want)
 
@@ -310,12 +310,12 @@ func TestConfigShowCoversEveryKey(t *testing.T) {
 		t.Helper()
 		slices.Sort(got)
 		if !slices.Equal(want, got) {
-			t.Errorf("`config show` keys = %v, want %v", got, want)
+			t.Errorf("`config list` keys = %v, want %v", got, want)
 		}
 	}
 
 	t.Run("table", func(t *testing.T) {
-		result := runCommand(t, []string{"config", "show"}, nil)
+		result := runCommand(t, []string{"config", "list"}, nil)
 		var got []string
 		for line := range strings.SplitSeq(result.stdout, "\n") {
 			cells := strings.Split(line, "\u2502")
@@ -331,7 +331,7 @@ func TestConfigShowCoversEveryKey(t *testing.T) {
 	})
 
 	t.Run("json", func(t *testing.T) {
-		result := runCommand(t, []string{"config", "show", "-o", "json"}, nil)
+		result := runCommand(t, []string{"config", "list", "-o", "json"}, nil)
 		var values map[string]any
 		if err := json.Unmarshal([]byte(result.stdout), &values); err != nil {
 			t.Fatalf("failed to parse json output: %v", err)
@@ -340,7 +340,7 @@ func TestConfigShowCoversEveryKey(t *testing.T) {
 	})
 
 	t.Run("yaml", func(t *testing.T) {
-		result := runCommand(t, []string{"config", "show", "-o", "yaml"}, nil)
+		result := runCommand(t, []string{"config", "list", "-o", "yaml"}, nil)
 		var values map[string]any
 		if err := yaml.Unmarshal([]byte(result.stdout), &values); err != nil {
 			t.Fatalf("failed to parse yaml output: %v", err)

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -17,9 +17,9 @@ func buildDbCmd(app *common.App) *cobra.Command {
 		Long:  `Database-specific operations including connection management, testing, and configuration.`,
 	}
 
-	cmd.AddCommand(buildDbConnectionStringCmd(app))
-	cmd.AddCommand(buildDbConnectCmd(app))
-	cmd.AddCommand(buildDbTestConnectionCmd(app))
+	cmd.AddCommand(buildDbURICmd(app))
+	cmd.AddCommand(buildDbPsqlCmd(app))
+	cmd.AddCommand(buildDbPingCmd(app))
 	cmd.AddCommand(buildDbSavePasswordCmd(app))
 	cmd.AddCommand(buildDbCreateCmd(app))
 	cmd.AddCommand(buildDbSchemaCmd(app))

--- a/internal/cmd/db_ping.go
+++ b/internal/cmd/db_ping.go
@@ -14,14 +14,14 @@ import (
 	"github.com/timescale/tiger-cli/internal/common"
 )
 
-func buildDbTestConnectionCmd(app *common.App) *cobra.Command {
-	var dbTestConnectionTimeout time.Duration
-	var dbTestConnectionPooled bool
-	var dbTestConnectionRole string
+func buildDbPingCmd(app *common.App) *cobra.Command {
+	var dbPingTimeout time.Duration
+	var dbPingPooled bool
+	var dbPingRole string
 
 	cmd := &cobra.Command{
-		Use:     "test-connection [service-id]",
-		Aliases: []string{"test", "ping"},
+		Use:     "ping [service-id]",
+		Aliases: []string{"test", "test-connection"},
 		Short:   "Test database connectivity",
 		Long: `Test database connectivity to a service.
 
@@ -39,19 +39,19 @@ Return Codes:
 
 Examples:
   # Test connection to default service
-  tiger db test-connection
+  tiger db ping
 
   # Test connection to specific service
-  tiger db test-connection svc-12345
+  tiger db ping svc-12345
 
   # Test connection with custom timeout (10 seconds)
-  tiger db test-connection svc-12345 --timeout 10s
+  tiger db ping svc-12345 --timeout 10s
 
   # Test connection with longer timeout (5 minutes)
-  tiger db test-connection svc-12345 --timeout 5m
+  tiger db ping svc-12345 --timeout 5m
 
   # Test connection with no timeout (wait indefinitely)
-  tiger db test-connection svc-12345 --timeout 0`,
+  tiger db ping svc-12345 --timeout 0`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
 		SilenceUsage:      true,
@@ -71,12 +71,12 @@ Examples:
 				return common.ExitWithCode(common.ExitInvalidParameters, err)
 			}
 
-			warnReplicaPooler(cmd, target, dbTestConnectionPooled)
+			warnReplicaPooler(cmd, target, dbPingPooled)
 
 			// Build connection string for testing with password (if available)
 			details, err := target.Details(cfg, common.ConnectionDetailsOptions{
-				Pooled:       dbTestConnectionPooled,
-				Role:         dbTestConnectionRole,
+				Pooled:       dbPingPooled,
+				Role:         dbPingRole,
 				WithPassword: true,
 			})
 			if err != nil {
@@ -84,19 +84,19 @@ Examples:
 			}
 
 			// Validate timeout (Cobra handles parsing automatically)
-			if dbTestConnectionTimeout < 0 {
-				return common.ExitWithCode(common.ExitInvalidParameters, fmt.Errorf("timeout must be positive or zero, got %v", dbTestConnectionTimeout))
+			if dbPingTimeout < 0 {
+				return common.ExitWithCode(common.ExitInvalidParameters, fmt.Errorf("timeout must be positive or zero, got %v", dbPingTimeout))
 			}
 
 			// Test the connection
-			return testDatabaseConnection(cmd.Context(), details.String(), dbTestConnectionTimeout, cmd)
+			return testDatabaseConnection(cmd.Context(), details.String(), dbPingTimeout, cmd)
 		},
 	}
 
-	// Add flags for db test-connection command
-	cmd.Flags().DurationVarP(&dbTestConnectionTimeout, "timeout", "t", 3*time.Second, "Timeout duration (e.g., 30s, 5m, 1h). Use 0 for no timeout")
-	cmd.Flags().BoolVar(&dbTestConnectionPooled, "pooled", false, "Use connection pooling")
-	cmd.Flags().StringVar(&dbTestConnectionRole, "role", "tsdbadmin", "Database role/username")
+	// Add flags for db ping command
+	cmd.Flags().DurationVarP(&dbPingTimeout, "timeout", "t", 3*time.Second, "Timeout duration (e.g., 30s, 5m, 1h). Use 0 for no timeout")
+	cmd.Flags().BoolVar(&dbPingPooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&dbPingRole, "role", "tsdbadmin", "Database role/username")
 
 	return cmd
 }

--- a/internal/cmd/db_ping_test.go
+++ b/internal/cmd/db_ping_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/timescale/tiger-cli/internal/common"
 )
 
-func TestDbTestConnectionCmd(t *testing.T) {
+func TestDbPingCmd(t *testing.T) {
 	setupGet := func(m *mocks.MockClientWithResponsesInterface) {
 		expectGetService(m, "svc-12345", sampleService())
 	}
@@ -25,25 +25,30 @@ func TestDbTestConnectionCmd(t *testing.T) {
 	runCmdTests(t, []cmdTest{
 		{
 			name:    "not logged in",
-			args:    []string{"db", "test-connection", "svc-12345"},
+			args:    []string{"db", "ping", "svc-12345"},
 			opts:    []runOption{withNotLoggedIn()},
 			wantErr: notLoggedInMsg,
 			checks:  []checkFunc{checkExitCode(common.ExitInvalidParameters)},
 		},
 		{
 			name:    "missing service id",
-			args:    []string{"db", "test-connection"},
+			args:    []string{"db", "ping"},
 			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
 			checks:  []checkFunc{checkExitCode(common.ExitInvalidParameters)},
 		},
 		{
-			name:    "missing service id via ping alias",
-			args:    []string{"db", "ping"},
+			name:    "missing service id via test alias",
+			args:    []string{"db", "test"},
+			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
+		},
+		{
+			name:    "missing service id via test-connection alias",
+			args:    []string{"db", "test-connection"},
 			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
 		},
 		{
 			name: "default service id from config",
-			args: []string{"db", "test-connection"},
+			args: []string{"db", "ping"},
 			opts: []runOption{withConfig(map[string]any{"service_id": "svc-12345"})},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
@@ -54,12 +59,12 @@ func TestDbTestConnectionCmd(t *testing.T) {
 		},
 		{
 			name:    "invalid timeout duration",
-			args:    []string{"db", "test-connection", "svc-12345", "--timeout", "invalid"},
+			args:    []string{"db", "ping", "svc-12345", "--timeout", "invalid"},
 			wantErr: "invalid argument \"invalid\" for \"-t, --timeout\" flag: time: invalid duration \"invalid\"",
 		},
 		{
 			name: "network error",
-			args: []string{"db", "test-connection", "svc-12345"},
+			args: []string{"db", "ping", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(nil, errors.New("connection refused"))
@@ -69,7 +74,7 @@ func TestDbTestConnectionCmd(t *testing.T) {
 		},
 		{
 			name: "API error",
-			args: []string{"db", "test-connection", "svc-12345"},
+			args: []string{"db", "ping", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(&api.GetServiceResponse{
@@ -82,7 +87,7 @@ func TestDbTestConnectionCmd(t *testing.T) {
 		},
 		{
 			name: "nil response body",
-			args: []string{"db", "test-connection", "svc-12345"},
+			args: []string{"db", "ping", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(&api.GetServiceResponse{
@@ -95,14 +100,14 @@ func TestDbTestConnectionCmd(t *testing.T) {
 		},
 		{
 			name:    "pooled without pooler",
-			args:    []string{"db", "test-connection", "svc-12345", "--pooled"},
+			args:    []string{"db", "ping", "svc-12345", "--pooled"},
 			setup:   setupGet,
 			wantErr: "connection pooler not available for this service",
 			checks:  []checkFunc{checkExitCode(common.ExitInvalidParameters)},
 		},
 		{
 			name:    "negative timeout",
-			args:    []string{"db", "test-connection", "svc-12345", "--timeout=-5s"},
+			args:    []string{"db", "ping", "svc-12345", "--timeout=-5s"},
 			setup:   setupGet,
 			wantErr: "timeout must be positive or zero, got -5s",
 			checks:  []checkFunc{checkExitCode(common.ExitInvalidParameters)},
@@ -111,7 +116,7 @@ func TestDbTestConnectionCmd(t *testing.T) {
 			// The dial is refused instantly; pgx's error text is
 			// environment-dependent, hence the non-exact matches.
 			name: "unreachable server",
-			args: []string{"db", "test-connection", "svc-12345"},
+			args: []string{"db", "ping", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(func(s *api.Service) {
 					s.Endpoint = &api.Endpoint{Host: new("127.0.0.1"), Port: new(1)}
@@ -130,7 +135,7 @@ func TestDbTestConnectionCmd(t *testing.T) {
 			// until the --timeout deadline fires; pgx's error text is
 			// environment-dependent.
 			name: "connection timeout",
-			args: []string{"db", "test-connection", "svc-12345", "--timeout", "250ms"},
+			args: []string{"db", "ping", "svc-12345", "--timeout", "250ms"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(func(s *api.Service) {
 					s.Endpoint = &api.Endpoint{Host: new("192.0.2.1"), Port: new(5432)}

--- a/internal/cmd/db_psql.go
+++ b/internal/cmd/db_psql.go
@@ -62,9 +62,6 @@ Examples:
   # Connect to default service
   tiger db psql
 
-  # The connect alias works the same way
-  tiger db connect
-
   # Connect directly to a read replica by its ID
   tiger db psql rep1234567
 

--- a/internal/cmd/db_psql.go
+++ b/internal/cmd/db_psql.go
@@ -20,16 +20,16 @@ import (
 	"github.com/timescale/tiger-cli/internal/util"
 )
 
-func buildDbConnectCmd(app *common.App) *cobra.Command {
-	var dbConnectPooled bool
-	var dbConnectRole string
-	var dbConnectReadOnly bool
-	var dbConnectNoReplicaPrompt bool
+func buildDbPsqlCmd(app *common.App) *cobra.Command {
+	var dbPsqlPooled bool
+	var dbPsqlRole string
+	var dbPsqlReadOnly bool
+	var dbPsqlNoReplicaPrompt bool
 
 	cmd := &cobra.Command{
-		Use:     "connect [service-id]",
-		Aliases: []string{"psql"},
-		Short:   "Connect to a database",
+		Use:     "psql [service-id]",
+		Aliases: []string{"connect"},
+		Short:   "Connect to a database with psql",
 		Long: `Connect to a database service using psql client.
 
 The service ID can be provided as an argument or will use the default service
@@ -60,32 +60,31 @@ skipping the prompt. Read replicas share the primary's credentials.
 
 Examples:
   # Connect to default service
-  tiger db connect
   tiger db psql
 
+  # The connect alias works the same way
+  tiger db connect
+
   # Connect directly to a read replica by its ID
-  tiger db connect rep1234567
+  tiger db psql rep1234567
 
   # Connect without the read replica prompt
-  tiger db connect svc-12345 --no-replica-prompt
+  tiger db psql svc-12345 --no-replica-prompt
 
   # Connect to specific service
-  tiger db connect svc-12345
   tiger db psql svc-12345
 
   # Connect using connection pooler
-  tiger db connect svc-12345 --pooled
   tiger db psql svc-12345 --pooled
 
   # Connect with custom role/username
-  tiger db connect svc-12345 --role readonly
   tiger db psql svc-12345 --role readonly
 
   # Connect in read-only mode (writes and DDL are rejected by the server)
-  tiger db connect svc-12345 --read-only
+  tiger db psql svc-12345 --read-only
 
   # Pass additional flags to psql (use -- to separate)
-  tiger db connect svc-12345 -- --single-transaction --quiet
+  tiger db psql svc-12345 -- --single-transaction --quiet
   tiger db psql svc-12345 -- -c "SELECT version();" --no-psqlrc`,
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: serviceIDCompletion(app),
@@ -116,14 +115,14 @@ Examples:
 			}
 
 			opts := common.ConnectionDetailsOptions{
-				Pooled:   dbConnectPooled,
-				Role:     dbConnectRole,
-				ReadOnly: dbConnectReadOnly,
+				Pooled:   dbPsqlPooled,
+				Role:     dbPsqlRole,
+				ReadOnly: dbPsqlReadOnly,
 			}
 
 			// Connects straight to a replica named by ID, or offers the interactive
 			// replica menu for a primary. Returns nil details if the user cancels.
-			details, err := selectConnection(cmd.Context(), cmd, cfg, client, projectID, target, opts, dbConnectNoReplicaPrompt)
+			details, err := selectConnection(cmd.Context(), cmd, cfg, client, projectID, target, opts, dbPsqlNoReplicaPrompt)
 			if err != nil {
 				return err
 			}
@@ -137,11 +136,11 @@ Examples:
 		},
 	}
 
-	// Add flags for db connect command (works for both connect and psql)
-	cmd.Flags().BoolVar(&dbConnectPooled, "pooled", false, "Use connection pooling")
-	cmd.Flags().StringVar(&dbConnectRole, "role", "tsdbadmin", "Database role/username")
-	cmd.Flags().BoolVar(&dbConnectReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
-	cmd.Flags().BoolVar(&dbConnectNoReplicaPrompt, "no-replica-prompt", false, "Don't prompt to connect to a read replica")
+	// Add flags for db psql command
+	cmd.Flags().BoolVar(&dbPsqlPooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&dbPsqlRole, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().BoolVar(&dbPsqlReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
+	cmd.Flags().BoolVar(&dbPsqlNoReplicaPrompt, "no-replica-prompt", false, "Don't prompt to connect to a read replica")
 
 	return cmd
 }
@@ -169,7 +168,7 @@ func separateServiceAndPsqlArgs(cmd ArgsLenAtDashProvider, args []string) ([]str
 	return serviceArgs, psqlFlags
 }
 
-// selectConnection returns the connection details for `tiger db connect`. A
+// selectConnection returns the connection details for `tiger db psql`. A
 // replica target connects straight through; a primary in an interactive
 // terminal is offered a menu to pick the primary or one of its replicas (nil
 // details means the user cancelled).

--- a/internal/cmd/db_psql_test.go
+++ b/internal/cmd/db_psql_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/timescale/tiger-cli/internal/config"
 )
 
-func TestDbConnectCmd(t *testing.T) {
+func TestDbPsqlCmd(t *testing.T) {
 	// A stub psql on PATH lets cases get past the LookPath check; every case
 	// that does so still fails before psql would actually run.
 	psqlDir := t.TempDir()
@@ -34,29 +34,29 @@ func TestDbConnectCmd(t *testing.T) {
 	runCmdTests(t, []cmdTest{
 		{
 			name:    "not logged in",
-			args:    []string{"db", "connect", "svc-12345"},
+			args:    []string{"db", "psql", "svc-12345"},
 			opts:    []runOption{withNotLoggedIn()},
 			wantErr: notLoggedInMsg,
 			checks:  []checkFunc{checkExitCode(common.ExitAuthenticationError)},
 		},
 		{
 			name:    "service ID required",
-			args:    []string{"db", "connect"},
-			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
-		},
-		{
-			name:    "psql alias",
 			args:    []string{"db", "psql"},
 			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
 		},
 		{
+			name:    "connect alias",
+			args:    []string{"db", "connect"},
+			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
+		},
+		{
 			name:    "args after -- are not the service ID",
-			args:    []string{"db", "connect", "--", "--single-transaction"},
+			args:    []string{"db", "psql", "--", "--single-transaction"},
 			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
 		},
 		{
 			name: "default service ID from config with psql flags after --",
-			args: []string{"db", "connect", "--", "-c", "SELECT 1;"},
+			args: []string{"db", "psql", "--", "-c", "SELECT 1;"},
 			opts: []runOption{withConfig(map[string]any{"service_id": "svc-12345"})},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
@@ -66,7 +66,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "service ID before -- separator",
-			args: []string{"db", "connect", "svc-12345", "--", "-c", "SELECT 1;"},
+			args: []string{"db", "psql", "svc-12345", "--", "-c", "SELECT 1;"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(nil, errors.New("connection refused"))
@@ -75,7 +75,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "API error fetching service",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(&api.GetServiceResponse{
@@ -88,7 +88,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "nil response body",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(&api.GetServiceResponse{
@@ -100,7 +100,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "parent fetch fails for read replica",
-			args: []string{"db", "connect", "rep-67890"},
+			args: []string{"db", "psql", "rep-67890"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "rep-67890", sampleReplica())
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
@@ -110,7 +110,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "psql not found",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			opts: []runOption{withEnv("PATH", "/nonexistent")},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService())
@@ -121,7 +121,7 @@ func TestDbConnectCmd(t *testing.T) {
 			// No GetReplicaSets expectation: a non-TTY stdin/stderr must skip
 			// the replica prompt entirely.
 			name: "non-TTY skips replica prompt",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			opts: []runOption{withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(noEndpoint))
@@ -130,7 +130,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "--no-replica-prompt skips replica prompt on a TTY",
-			args: []string{"db", "connect", "svc-12345", "--no-replica-prompt"},
+			args: []string{"db", "psql", "svc-12345", "--no-replica-prompt"},
 			opts: []runOption{withIsTerminal(true), withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(noEndpoint))
@@ -139,7 +139,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "replica target skips replica prompt",
-			args: []string{"db", "connect", "rep-67890"},
+			args: []string{"db", "psql", "rep-67890"},
 			opts: []runOption{withIsTerminal(true), withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "rep-67890", sampleReplica(noEndpoint))
@@ -149,7 +149,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "replica listing failure warns and continues",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			opts: []runOption{withIsTerminal(true), withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(noEndpoint))
@@ -161,7 +161,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "no replicas skips prompt on a TTY",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			opts: []runOption{withIsTerminal(true), withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(noEndpoint))
@@ -175,7 +175,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "no connectable replicas skips prompt",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			opts: []runOption{withIsTerminal(true), withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(noEndpoint))
@@ -201,7 +201,7 @@ func TestDbConnectCmd(t *testing.T) {
 		},
 		{
 			name: "--pooled without pooler",
-			args: []string{"db", "connect", "svc-12345", "--pooled"},
+			args: []string{"db", "psql", "svc-12345", "--pooled"},
 			opts: []runOption{withEnv("PATH", psqlDir)},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService())
@@ -215,7 +215,7 @@ func TestDbConnectCmd(t *testing.T) {
 			// password is stored, so the lookup warning comes first; the pgx
 			// error text is environment-dependent, hence the non-exact matches.
 			name: "non-auth connection error surfaces directly",
-			args: []string{"db", "connect", "svc-12345"},
+			args: []string{"db", "psql", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(func(s *api.Service) {
 					s.Endpoint = &api.Endpoint{Host: new("127.0.0.1"), Port: new(1)}

--- a/internal/cmd/db_query.go
+++ b/internal/cmd/db_query.go
@@ -29,7 +29,7 @@ func buildDbQueryCmd(app *common.App) *cobra.Command {
 		Short:   "Execute a SQL query on a database",
 		Long: `Execute a SQL query against a database service and display the results.
 
-Unlike 'tiger db connect', this runs the query directly and does not require a
+Unlike 'tiger db psql', this runs the query directly and does not require a
 local psql installation.
 
 The service ID can be provided as an argument or will use the default service

--- a/internal/cmd/db_save_password.go
+++ b/internal/cmd/db_save_password.go
@@ -60,7 +60,7 @@ Examples:
 
 			// Resolve the target so a read replica id stores the password against
 			// its parent primary: replicas share the primary's credentials, and
-			// connect/test-connection look the password up against the primary.
+			// psql/ping look the password up against the primary.
 			target, err := common.ResolveConnectionTargetByID(cmd.Context(), client, projectID, serviceID)
 			if err != nil {
 				return err

--- a/internal/cmd/db_uri.go
+++ b/internal/cmd/db_uri.go
@@ -8,17 +8,17 @@ import (
 	"github.com/timescale/tiger-cli/internal/common"
 )
 
-func buildDbConnectionStringCmd(app *common.App) *cobra.Command {
-	var dbConnectionStringPooled bool
-	var dbConnectionStringRole string
-	var dbConnectionStringWithPassword bool
-	var dbConnectionStringReadOnly bool
+func buildDbURICmd(app *common.App) *cobra.Command {
+	var dbURIPooled bool
+	var dbURIRole string
+	var dbURIWithPassword bool
+	var dbURIReadOnly bool
 
 	cmd := &cobra.Command{
-		Use:     "connection-string [service-id]",
-		Aliases: []string{"uri"},
-		Short:   "Get connection string for a service",
-		Long: `Get a PostgreSQL connection string for connecting to a database service.
+		Use:     "uri [service-id]",
+		Aliases: []string{"connection-string"},
+		Short:   "Get connection URI for a service",
+		Long: `Get a PostgreSQL connection URI for connecting to a database service.
 
 The service ID can be provided as an argument or will use the default service
 from your configuration. The connection string includes all necessary parameters
@@ -38,22 +38,22 @@ services writable.
 
 Examples:
   # Get connection string for default service
-  tiger db connection-string
+  tiger db uri
 
   # Get connection string for specific service
-  tiger db connection-string svc-12345
+  tiger db uri svc-12345
 
   # Get pooled connection string (uses connection pooler if available)
-  tiger db connection-string svc-12345 --pooled
+  tiger db uri svc-12345 --pooled
 
   # Get connection string with custom role/username
-  tiger db connection-string svc-12345 --role readonly
+  tiger db uri svc-12345 --role readonly
 
   # Get a read-only connection string
-  tiger db connection-string svc-12345 --read-only
+  tiger db uri svc-12345 --read-only
 
   # Get connection string with password included (less secure)
-  tiger db connection-string svc-12345 --with-password`,
+  tiger db uri svc-12345 --with-password`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: serviceIDCompletion(app),
 		SilenceUsage:      true,
@@ -73,19 +73,19 @@ Examples:
 				return err
 			}
 
-			warnReplicaPooler(cmd, target, dbConnectionStringPooled)
+			warnReplicaPooler(cmd, target, dbURIPooled)
 
 			details, err := target.Details(cfg, common.ConnectionDetailsOptions{
-				Pooled:       dbConnectionStringPooled,
-				Role:         dbConnectionStringRole,
-				WithPassword: dbConnectionStringWithPassword,
-				ReadOnly:     dbConnectionStringReadOnly || common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(target.ConnectionService)) != nil,
+				Pooled:       dbURIPooled,
+				Role:         dbURIRole,
+				WithPassword: dbURIWithPassword,
+				ReadOnly:     dbURIReadOnly || common.CheckReadOnly(cfg, common.ServiceEnvironmentTag(target.ConnectionService)) != nil,
 			})
 			if err != nil {
 				return err
 			}
 
-			if dbConnectionStringWithPassword && details.Password == "" {
+			if dbURIWithPassword && details.Password == "" {
 				return fmt.Errorf("password not available to include in connection string")
 			}
 
@@ -94,11 +94,11 @@ Examples:
 		},
 	}
 
-	// Add flags for db connection-string command
-	cmd.Flags().BoolVar(&dbConnectionStringPooled, "pooled", false, "Use connection pooling")
-	cmd.Flags().StringVar(&dbConnectionStringRole, "role", "tsdbadmin", "Database role/username")
-	cmd.Flags().BoolVar(&dbConnectionStringWithPassword, "with-password", false, "Include password in connection string (less secure)")
-	cmd.Flags().BoolVar(&dbConnectionStringReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
+	// Add flags for db uri command
+	cmd.Flags().BoolVar(&dbURIPooled, "pooled", false, "Use connection pooling")
+	cmd.Flags().StringVar(&dbURIRole, "role", "tsdbadmin", "Database role/username")
+	cmd.Flags().BoolVar(&dbURIWithPassword, "with-password", false, "Include password in connection string (less secure)")
+	cmd.Flags().BoolVar(&dbURIReadOnly, "read-only", false, "Open the connection in Tiger Cloud's immutable read-only mode")
 
 	return cmd
 }

--- a/internal/cmd/db_uri_test.go
+++ b/internal/cmd/db_uri_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/timescale/tiger-cli/internal/common"
 )
 
-func TestDbConnectionStringCmd(t *testing.T) {
+func TestDbURICmd(t *testing.T) {
 	const (
 		directURI   = "postgresql://tsdbadmin@svc-12345.project.tsdb.cloud.timescale.com:5432/tsdb?sslmode=require\n"
 		readOnlyURI = "postgresql://tsdbadmin@svc-12345.project.tsdb.cloud.timescale.com:5432/tsdb?sslmode=require&options=-c%20tsdb_admin.read_only_connection%3Dtrue\n"
@@ -36,19 +36,19 @@ func TestDbConnectionStringCmd(t *testing.T) {
 	runCmdTests(t, []cmdTest{
 		{
 			name:    "not logged in",
-			args:    []string{"db", "connection-string", "svc-12345"},
+			args:    []string{"db", "uri", "svc-12345"},
 			opts:    []runOption{withNotLoggedIn()},
 			wantErr: notLoggedInMsg,
 			checks:  []checkFunc{checkExitCode(common.ExitAuthenticationError)},
 		},
 		{
 			name:    "missing service id",
-			args:    []string{"db", "connection-string"},
+			args:    []string{"db", "uri"},
 			wantErr: "service ID is required. Provide it as an argument or set a default with 'tiger config set service_id <service-id>'",
 		},
 		{
 			name: "network error",
-			args: []string{"db", "connection-string", "svc-12345"},
+			args: []string{"db", "uri", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(nil, errors.New("connection refused"))
@@ -57,7 +57,7 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		},
 		{
 			name: "API error",
-			args: []string{"db", "connection-string", "svc-12345"},
+			args: []string{"db", "uri", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(&api.GetServiceResponse{
@@ -70,7 +70,7 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		},
 		{
 			name: "nil response body",
-			args: []string{"db", "connection-string", "svc-12345"},
+			args: []string{"db", "uri", "svc-12345"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
 					Return(&api.GetServiceResponse{
@@ -82,32 +82,32 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		},
 		{
 			name:       "positional service id",
-			args:       []string{"db", "connection-string", "svc-12345"},
-			setup:      setupGet,
-			wantStdout: directURI,
-		},
-		{
-			name:       "default service id from config",
-			args:       []string{"db", "connection-string"},
-			setup:      setupGet,
-			opts:       []runOption{withConfig(map[string]any{"service_id": "svc-12345"})},
-			wantStdout: directURI,
-		},
-		{
-			name:       "uri alias",
 			args:       []string{"db", "uri", "svc-12345"},
 			setup:      setupGet,
 			wantStdout: directURI,
 		},
 		{
+			name:       "default service id from config",
+			args:       []string{"db", "uri"},
+			setup:      setupGet,
+			opts:       []runOption{withConfig(map[string]any{"service_id": "svc-12345"})},
+			wantStdout: directURI,
+		},
+		{
+			name:       "connection-string alias",
+			args:       []string{"db", "connection-string", "svc-12345"},
+			setup:      setupGet,
+			wantStdout: directURI,
+		},
+		{
 			name:       "custom role",
-			args:       []string{"db", "connection-string", "svc-12345", "--role", "readonly"},
+			args:       []string{"db", "uri", "svc-12345", "--role", "readonly"},
 			setup:      setupGet,
 			wantStdout: "postgresql://readonly@svc-12345.project.tsdb.cloud.timescale.com:5432/tsdb?sslmode=require\n",
 		},
 		{
 			name: "pooled with pooler available",
-			args: []string{"db", "connection-string", "svc-12345", "--pooled"},
+			args: []string{"db", "uri", "svc-12345", "--pooled"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "svc-12345", sampleService(withPooler))
 			},
@@ -115,73 +115,73 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		},
 		{
 			name:    "pooled without pooler",
-			args:    []string{"db", "connection-string", "svc-12345", "--pooled"},
+			args:    []string{"db", "uri", "svc-12345", "--pooled"},
 			setup:   setupGet,
 			wantErr: "connection pooler not available for this service",
 		},
 		{
 			name:    "with-password without stored password",
-			args:    []string{"db", "connection-string", "svc-12345", "--with-password"},
+			args:    []string{"db", "uri", "svc-12345", "--with-password"},
 			setup:   setupGet,
 			wantErr: "password not available to include in connection string",
 		},
 		{
 			name:       "read-only flag",
-			args:       []string{"db", "connection-string", "svc-12345", "--read-only"},
+			args:       []string{"db", "uri", "svc-12345", "--read-only"},
 			setup:      setupGet,
 			wantStdout: readOnlyURI,
 		},
 		{
 			name:       "read-only from config all",
-			args:       []string{"db", "connection-string", "svc-12345"},
+			args:       []string{"db", "uri", "svc-12345"},
 			setup:      setupGet,
 			opts:       []runOption{withConfig(map[string]any{"read_only": "all"})},
 			wantStdout: readOnlyURI,
 		},
 		{
 			name:       "read-only flag and config all",
-			args:       []string{"db", "connection-string", "svc-12345", "--read-only"},
+			args:       []string{"db", "uri", "svc-12345", "--read-only"},
 			setup:      setupGet,
 			opts:       []runOption{withConfig(map[string]any{"read_only": "all"})},
 			wantStdout: readOnlyURI,
 		},
 		{
 			name:       "config prod, PROD service",
-			args:       []string{"db", "connection-string", "svc-12345"},
+			args:       []string{"db", "uri", "svc-12345"},
 			setup:      expectTaggedService("PROD"),
 			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
 			wantStdout: readOnlyURI,
 		},
 		{
 			name:       "config prod, DEV service",
-			args:       []string{"db", "connection-string", "svc-12345"},
+			args:       []string{"db", "uri", "svc-12345"},
 			setup:      expectTaggedService("DEV"),
 			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
 			wantStdout: directURI,
 		},
 		{
 			name:       "config prod, untagged service",
-			args:       []string{"db", "connection-string", "svc-12345"},
+			args:       []string{"db", "uri", "svc-12345"},
 			setup:      setupGet,
 			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
 			wantStdout: directURI,
 		},
 		{
 			name:       "flag on beats config prod",
-			args:       []string{"db", "connection-string", "svc-12345", "--read-only"},
+			args:       []string{"db", "uri", "svc-12345", "--read-only"},
 			setup:      expectTaggedService("DEV"),
 			opts:       []runOption{withConfig(map[string]any{"read_only": "prod"})},
 			wantStdout: readOnlyURI,
 		},
 		{
 			name:       "replica target uses replica endpoint",
-			args:       []string{"db", "connection-string", "rep-67890"},
+			args:       []string{"db", "uri", "rep-67890"},
 			setup:      setupGetReplica,
 			wantStdout: replicaURI,
 		},
 		{
 			name: "replica pooled with pooler uses replica pooler",
-			args: []string{"db", "connection-string", "rep-67890", "--pooled"},
+			args: []string{"db", "uri", "rep-67890", "--pooled"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "rep-67890", sampleReplica(func(s *api.Service) {
 					s.ConnectionPooler = &api.ConnectionPooler{
@@ -197,14 +197,14 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		},
 		{
 			name:       "replica pooled without pooler falls back with warning",
-			args:       []string{"db", "connection-string", "rep-67890", "--pooled"},
+			args:       []string{"db", "uri", "rep-67890", "--pooled"},
 			setup:      setupGetReplica,
 			wantStdout: replicaURI,
 			wantStderr: "⚠️  Warning: read replica \"replica-service\" has no connection pooler; connecting directly instead\n",
 		},
 		{
 			name: "replica parent fetch error",
-			args: []string{"db", "connection-string", "rep-67890"},
+			args: []string{"db", "uri", "rep-67890"},
 			setup: func(m *mocks.MockClientWithResponsesInterface) {
 				expectGetService(m, "rep-67890", sampleReplica())
 				m.EXPECT().GetServiceWithResponse(validCtx, testProjectID, "svc-12345").
@@ -214,14 +214,14 @@ func TestDbConnectionStringCmd(t *testing.T) {
 		},
 		{
 			name:       "with-password includes stored password",
-			args:       []string{"db", "connection-string", "svc-12345", "--with-password"},
+			args:       []string{"db", "uri", "svc-12345", "--with-password"},
 			setup:      setupGet,
 			opts:       []runOption{withStoredPassword(sampleService(), "secret-pw")},
 			wantStdout: "postgresql://tsdbadmin:secret-pw@svc-12345.project.tsdb.cloud.timescale.com:5432/tsdb?sslmode=require\n",
 		},
 		{
 			name:       "replica uses primary credentials",
-			args:       []string{"db", "connection-string", "rep-67890", "--with-password"},
+			args:       []string{"db", "uri", "rep-67890", "--with-password"},
 			setup:      setupGetReplica,
 			opts:       []runOption{withStoredPassword(sampleService(), "primary-pw")},
 			wantStdout: "postgresql://tsdbadmin:primary-pw@rep-67890.project.tsdb.cloud.timescale.com:5432/tsdb?sslmode=require\n",

--- a/internal/cmd/integration_test.go
+++ b/internal/cmd/integration_test.go
@@ -1600,13 +1600,13 @@ func TestServiceNotFoundIntegration(t *testing.T) {
 			expectedExitCode: common.ExitServiceNotFound,
 		},
 		{
-			name:             "db connection-string",
-			args:             []string{"db", "connection-string", nonExistentServiceID},
+			name:             "db uri",
+			args:             []string{"db", "uri", nonExistentServiceID},
 			expectedExitCode: common.ExitServiceNotFound,
 		},
 		{
-			name:             "db test-connection",
-			args:             []string{"db", "test-connection", nonExistentServiceID},
+			name:             "db ping",
+			args:             []string{"db", "ping", nonExistentServiceID},
 			expectedExitCode: common.ExitInvalidParameters,
 			reason:           "maintains compatibility with PostgreSQL tooling conventions",
 		},
@@ -1792,18 +1792,18 @@ func TestAuthenticationErrorsIntegration(t *testing.T) {
 		args []string
 	}{
 		{
-			name: "db connection-string",
-			args: []string{"db", "connection-string", "non-existent-service"},
+			name: "db uri",
+			args: []string{"db", "uri", "non-existent-service"},
 		},
 		{
-			name: "db connect",
-			args: []string{"db", "connect", "non-existent-service"},
+			name: "db psql",
+			args: []string{"db", "psql", "non-existent-service"},
 		},
-		// Note: db test-connection follows pg_isready conventions, so it uses exit code 3 (common.ExitInvalidParameters)
+		// Note: db ping follows pg_isready conventions, so it uses exit code 3 (common.ExitInvalidParameters)
 		// for authentication issues, not common.ExitAuthenticationError like other commands
 		{
-			name: "db test-connection",
-			args: []string{"db", "test-connection", "non-existent-service"},
+			name: "db ping",
+			args: []string{"db", "ping", "non-existent-service"},
 		},
 	}
 
@@ -1852,8 +1852,8 @@ func TestAuthenticationErrorsIntegration(t *testing.T) {
 				expectedExitCode := common.ExitAuthenticationError
 				expectedDescription := "authentication error"
 
-				// db test-connection follows pg_isready conventions and uses exit code 3
-				if tc.name == "db test-connection" {
+				// db ping follows pg_isready conventions and uses exit code 3
+				if tc.name == "db ping" {
 					expectedExitCode = common.ExitInvalidParameters
 					expectedDescription = "invalid parameters (pg_isready convention)"
 				}

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -249,10 +249,10 @@ func printConnectMessage(cmd *cobra.Command, passwordSaved, noSetDefault bool, s
 		return
 	} else if noSetDefault {
 		// If the service wasn't set as the default, include the serviceID in the command
-		cmd.PrintErrf("🔌 Run 'tiger db connect %s' to connect to your new service\n", serviceID)
+		cmd.PrintErrf("🔌 Run 'tiger db psql %s' to connect to your new service\n", serviceID)
 	} else {
 		// If the service was set as the default, no need to include the serviceID in the command
-		cmd.PrintErrf("🔌 Run 'tiger db connect' to connect to your new service\n")
+		cmd.PrintErrf("🔌 Run 'tiger db psql' to connect to your new service\n")
 	}
 }
 

--- a/internal/cmd/service_create_test.go
+++ b/internal/cmd/service_create_test.go
@@ -179,7 +179,7 @@ func TestServiceCreateCmd(t *testing.T) {
 🎯 Set service 'svc-12345' as default service.
 ⏳ Waiting for service to be ready (wait timeout: 30m0s)...
 🎉 Service is ready and running!
-🔌 Run 'tiger db connect' to connect to your new service
+🔌 Run 'tiger db psql' to connect to your new service
 `,
 			checks: []checkFunc{checkStoredPassword("svc-12345", "init-pass-123")},
 		},
@@ -203,7 +203,7 @@ func TestServiceCreateCmd(t *testing.T) {
 🔐 Password saved to system keyring for automatic authentication
 ⏳ Waiting for service to be ready (wait timeout: 30m0s)...
 🎉 Service is ready and running!
-🔌 Run 'tiger db connect svc-12345' to connect to your new service
+🔌 Run 'tiger db psql svc-12345' to connect to your new service
 `,
 			checks: []checkFunc{checkDefaultService("")},
 		},

--- a/internal/cmd/service_fork_test.go
+++ b/internal/cmd/service_fork_test.go
@@ -166,7 +166,7 @@ PGUSER=tsdbadmin
 🎯 Set service 'svc-67890' as default service.
 ⏳ Waiting for fork to complete (timeout: 30m0s)...
 🎉 Service fork completed successfully!
-🔌 Run 'tiger db connect' to connect to your new service
+🔌 Run 'tiger db psql' to connect to your new service
 `,
 			checks: []checkFunc{
 				checkDefaultService("svc-67890"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,7 +145,7 @@ type Config struct {
 	flags     *pflag.FlagSet `mapstructure:"-"`
 }
 
-// ConfigOutput is the shape `tiger config show` renders. Every field is a
+// ConfigOutput is the shape `tiger config list` renders. Every field is a
 // pointer so unset values can be omitted when defaults are suppressed.
 type ConfigOutput struct {
 	Analytics       *bool         `mapstructure:"analytics" json:"analytics,omitempty"`
@@ -180,7 +180,7 @@ func Load(flags *pflag.FlagSet) (*Config, error) {
 }
 
 // LoadForOutput loads config values for display purposes using a fresh viper
-// instance, independent of CLI flags. This keeps `tiger config show -o json`
+// instance, independent of CLI flags. This keeps `tiger config list -o json`
 // from reporting the flag's format as the configured `output` value.
 func LoadForOutput(configDir string, withEnv bool, noDefaults bool) (*ConfigOutput, error) {
 	v := viper.New()

--- a/internal/config/config_keys_test.go
+++ b/internal/config/config_keys_test.go
@@ -30,8 +30,8 @@ func mapstructureKeys(t *testing.T, v any) []string {
 
 // A config key has to be spelled out in several places that Go can't tie
 // together: defaultValues, the Config struct, the ConfigOutput struct that
-// `tiger config show` renders, and validateValue's switch. Missing one is
-// silent — a key absent from ConfigOutput just never appears in `config show`,
+// `tiger config list` renders, and validateValue's switch. Missing one is
+// silent — a key absent from ConfigOutput just never appears in `config list`,
 // and one absent from validateValue can't be set at all — so assert the lists
 // agree rather than relying on whoever adds the next key to find all four.
 func TestConfigKeyRegistriesAgree(t *testing.T) {


### PR DESCRIPTION
This changes the primary name of four commands to make them clearer or shorter and easier to type. Every old name stays around as an alias, so existing scripts and muscle memory keep working. What changes is only the name that appears in `--help` output and in shell completions.

- `tiger db connect` becomes `tiger db psql`. The command is essentially a pass-through to psql and requires it to be installed, and now that `tiger db query` runs queries without psql, the name should make that dependency obvious.
- `tiger db test-connection` becomes `tiger db ping`, keeping `test` and `test-connection` as aliases. It's shorter to type, and avoiding hyphenated multi-word subcommands makes the CLI feel cleaner.
- `tiger db connection-string` becomes `tiger db uri`. Same reasoning, and it's no less clear: URI is the Postgres term for the kind of connection string we return.
- `tiger config show` becomes `tiger config list`, keeping `show` and `ls` as aliases. Elsewhere `show` is an alias for `get` and returns a single item, so using it for the full list of settings was inconsistent. `list` reserves `show` for single-item commands and matches `git config list`.

Files, functions, and tests are renamed to match the new primary names, and the README and CLAUDE.md are updated accordingly.

These changes were originally proposed in [this Slack thread](https://iobeam.slack.com/archives/C099S47CSRX/p1786657856053839?thread_ts=1786654004.137259&cid=C099S47CSRX).